### PR TITLE
Gitignore more stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ stamp-h1
 
 # Regression tests
 test/echo_client
+test/echo_client2
 test/echo_client_evbuf


### PR DESCRIPTION
This pull request adds more stuff to the .gitignore file. Basically, we now ignore all the artifacts generated by `autoreconf -i`, by `./configure` and by `make [check]`.
