### PR TITLE
Delayed call tests: one more test and minor improvements

### DIFF
--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -40,8 +40,7 @@ main(void)
 	// later) to ensure that move semantic works.
 	//
 	auto d2 = IghtDelayedCall(3.0, [](void) {
-		std::cout << "The wrong delayed call" << "\n";
-		ight_break_loop();
+		throw std::runtime_error("This should not happen");
 	});
 
 	//


### PR DESCRIPTION
Improve existing delayed call tests and add one more test, which checks that we can unschedule a pending callback just before such callback is due. This should clearly work, but it's better to guarantee it with a test, before starting to use massively the IghtDelayedCall API.
