### PR TITLE
Use https address instead of ssh:// address for libevent submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/joyent/http-parser
 [submodule "src/ext/libevent"]
 	path = src/ext/libevent
-	url = git@github.com:bassosimone/libevent
+	url = https://github.com/bassosimone/libevent
 [submodule "src/ext/Catch"]
 	path = src/ext/Catch
 	url = https://github.com/philsquared/Catch


### PR DESCRIPTION
If you use the ssh:// address people that are not part of the collaborators for
that repo will not be able to do a submodule init, but will get a public key
permission denied error.
