### PR TITLE
log: make libight quiet by default

### DIFF
--- a/src/common/log.c
+++ b/src/common/log.c
@@ -14,6 +14,8 @@
 
 #include "common/log.h"
 
+static int IGHT_VERBOSE = 0;
+
 static void
 ight_warnv(const char *fmt, va_list ap)
 {
@@ -38,9 +40,18 @@ ight_warn(const char *fmt, ...)
 void
 ight_info(const char *fmt, ...)
 {
+	if (!IGHT_VERBOSE)
+		return;
+
 	va_list ap;
 
 	va_start(ap, fmt);
 	ight_warnv(fmt, ap);
 	va_end(ap);
+}
+
+void
+ight_set_verbose(int v)
+{
+	IGHT_VERBOSE = v;
 }

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -12,6 +12,8 @@ void ight_warn(const char *, ...)
 void ight_info(const char *, ...)
   __attribute__((format(printf, 1, 2)));
 
+void ight_set_verbose(int);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This pull request makes libight quiet by default and also adds a knob to log.c to allow one to make libight verbose. Tested on Lubuntu 14.04.
