### PR TITLE
Do not build traceroute on non Linux

### DIFF
--- a/include/ight/traceroute/interface.hpp
+++ b/include/ight/traceroute/interface.hpp
@@ -36,6 +36,9 @@
 
 /// Interface of traceroute module
 
+// Disable for non Linux until we figure out how to build on iOS
+#ifdef __linux__
+
 #include <ight/common/poller.hpp>
 
 #include <memory>
@@ -153,4 +156,5 @@ private:
 
 } // namespace traceroute
 } // namespace ight
+#endif
 #endif

--- a/src/traceroute/interface.cpp
+++ b/src/traceroute/interface.cpp
@@ -34,6 +34,9 @@
 
 /// Implementation of traceroute interface
 
+// Disable for non Linux until we figure out how to build on iOS
+#ifdef __linux__
+
 #include <ight/common/log.hpp>
 #include <ight/traceroute/interface.hpp>
 
@@ -90,3 +93,5 @@ ProberInterface::~ProberInterface() {}
 
 } // namespace traceroute
 } // namespace ight
+
+#endif


### PR DESCRIPTION
Fixes "Traceroute common doesn't compile on iOS (device)" issue (measurement-kit/measurement-kit-issues#9). [There are very few headers in the iOS SDK](http://stackoverflow.com/questions/29148341/xcode-fails-to-compile-for-real-ipad-but-works-for-simulator-missing-header-fil), since compiling only the generic interface of traceroute for iOS (or for MacOS for that matter) was not a priority, I took the fast route and just disabled compiling that part of code on any non-linux system.

Compiles on MacOS, compiles on iOS (arm) and I see no reason why it should not compile for other iOS architetures. Will merge right after travis-ci confirm that this builds on Linux as well.