### PR TITLE
Register test complete callback along with test

### DIFF
--- a/include/ight/common/async.hpp
+++ b/include/ight/common/async.hpp
@@ -34,8 +34,11 @@ class Async {
     /// Constructor with specified poller
     Async(SharedPointer<Poller> p);
 
-    /// Run the specified network test
-    void run_test(SharedPointer<NetTest> test);
+    /// Run the specified network test and call a callback when done
+    /// \param func Callback called when test is done
+    /// \warn The callback is called from a background thread
+    void run_test(SharedPointer<NetTest> test,
+      std::function<void(SharedPointer<NetTest>)> func);
 
     /// Break out of the loop
     void break_loop();
@@ -45,12 +48,6 @@ class Async {
 
     /// Returns true when no async jobs are running
     bool empty();
-
-    ///
-    /// Called when a test is completed
-    /// \warn This function is called from a background thread
-    ///
-    void on_complete(std::function<void(SharedPointer<NetTest>)>);
 
     ///
     /// Called when the tests queue is empty

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -42,7 +42,9 @@ static void run_http_invalid_request_line(Async &async) {
         (void) fprintf(stderr, "test #1: %s\n", s);
     });
     ight_debug("test created: %llu", test->identifier());
-    async.run_test(test);
+    async.run_test(test, [](SharedPointer<NetTest> test) {
+        ight_debug("test complete: %llu", test->identifier());
+    });
 }
 
 static void run_dns_injection(Async& async) {
@@ -56,7 +58,9 @@ static void run_dns_injection(Async& async) {
         (void) fprintf(stderr, "test #3: %s\n", s);
     });
     ight_debug("test created: %llu", test->identifier());
-    async.run_test(test);
+    async.run_test(test, [](SharedPointer<NetTest> test) {
+        ight_debug("test complete: %llu", test->identifier());
+    });
 }
 
 static void run_tcp_connect(Async& async) {
@@ -70,7 +74,9 @@ static void run_tcp_connect(Async& async) {
         (void) fprintf(stderr, "test #4: %s\n", s);
     });
     ight_debug("test created: %llu", test->identifier());
-    async.run_test(test);
+    async.run_test(test, [](SharedPointer<NetTest> test) {
+        ight_debug("test complete: %llu", test->identifier());
+    });
 }
 
 TEST_CASE("The async engine works as expected") {
@@ -80,9 +86,6 @@ TEST_CASE("The async engine works as expected") {
 
     // Note: the two following callbacks execute in a background thread
     volatile bool complete = false;
-    async.on_complete([](SharedPointer<NetTest> test) {
-        ight_debug("test complete: %llu", test->identifier());
-    });
     async.on_empty([&complete]() {
         ight_debug("all tests completed");
         complete = true;


### PR DESCRIPTION
This should solve the problem described in issue #139, even though the solution implemented here is different from the one suggested in issue's description (but that's irrelevant).

I've tested this on Linux, using valgrind to make sure that except for the leak reported in #138 there are no further memory errors.

Closes #139.