### PR TITLE
Make error really useful

### DIFF
--- a/doc/common/error.md
+++ b/doc/common/error.md
@@ -1,0 +1,30 @@
+# NAME
+Error -- Represents an error.
+
+# LIBRARY
+MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+using namespace measurement_kit::common;
+
+Error err = GenericError(); // Assign to error class
+Error err = 17;             // Assign error code
+int code = (int) err;       // Convert error to int
+bool x = (error != 17);     // Implicit conversion here
+bool y = (error == 17);     // Also here
+```
+
+# DESCRIPTION
+
+In general MeasurementKit code reports errors using the `Error` class
+and uses exceptions only to report unrecoverable errors.
+
+It should be possible to pull all possible errors by including
+the `common.hpp` header of MeasurementKit.
+
+# HISTORY
+
+The `Error` class appeared in MeasurementKit 0.1.

--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -8,11 +8,29 @@
 namespace measurement_kit {
 namespace common {
 
-struct Error {
-    int error = 0;
+/// An error that occurred
+class Error {
+  public:
+    Error() : Error(0) {}                   ///< Default constructor (no error)
+    Error(int e) { error_ = e; }            ///< Constructor with error code
+    operator int() const { return error_; } ///< Cast to integer
 
-    Error(int e) { this->error = e; };
+    /// Equality operator
+    bool operator==(int n) const { return error_ == n; }
+
+    /// Unequality operator
+    bool operator!=(int n) const { return error_ != n; }
+
+  private:
+    int error_ = 0;
 };
 
-}}
+/// A generic error
+class GenericError : public Error {
+  public:
+    GenericError() : Error(1) {} ///< Default constructor
+};
+
+} // namespace common
+} // namespace measurement_kit
 #endif

--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -237,7 +237,7 @@ class Stream {
         //
         connection->on_error([&](Error error) {
             auto safe_eh = error_handler;
-            if (error.error == 0) {
+            if (error == 0) {
                 parser->eof();
             }
             // parser->eof() may cause this object to go out of
@@ -591,7 +591,7 @@ public:
         }
         stream = std::make_shared<Stream>(settings, logger);
         stream->on_error([this](Error err) {
-            if (err.error != 0) {
+            if (err != 0) {
                 emit_end(err, std::move(response));
             } else {
                 // When EOF is received, on_end() is called, therefore we

--- a/include/measurement_kit/ooni/http_test.hpp
+++ b/include/measurement_kit/ooni/http_test.hpp
@@ -49,14 +49,14 @@ public:
             // this.
             rr["method"] = settings.at("method");
 
-            if (error.error == 0) {
+            if (error == 0) {
                 rr["response"]["headers"] = std::map<std::string, std::string>(response.headers);
                 rr["response"]["body"] = response.body.read<char>();
                 rr["response"]["response_line"] = response.response_line;
                 rr["response"]["code"] = response.status_code;
             } else {
                 rr["failure"] = "unknown_failure measurement_kit_error";
-                rr["error_code"] = error.error;
+                rr["error_code"] = (int) error;
             }
 
             entry["requests"].push_back(rr);

--- a/src/ooni/tcp_test.cpp
+++ b/src/ooni/tcp_test.cpp
@@ -29,7 +29,7 @@ TCPTest::connect(Settings options, std::function<void()>&& cb)
     //
 
     connection->on_error([cb, this](Error e) {
-        entry["error_code"] = e.error;
+        entry["error_code"] = (int) e;
         entry["connection"] = "failed";
         cb();
     });

--- a/test/echo_client_evbuf.cpp
+++ b/test/echo_client_evbuf.cpp
@@ -28,7 +28,7 @@ main(void)
 	});
 
 	s.on_error([&](Error e) {
-		measurement_kit::info("echo - connection error %d", e.error);
+		measurement_kit::info("echo - connection error %d", (int) e);
 		s.close();
 	});
 

--- a/test/http/http.cpp
+++ b/test/http/http.cpp
@@ -282,7 +282,7 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
     });
     stream->set_timeout(1.0);
     stream->on_error([&](Error e) {
-        measurement_kit::debug("Connection error: %d", e.error);
+        measurement_kit::debug("Connection error: %d", (int) e);
         stream->close();
         measurement_kit::break_loop();
     });
@@ -328,7 +328,7 @@ TEST_CASE("HTTP stream receives connection errors") {
     });
     stream->set_timeout(1.0);
     stream->on_error([&](Error e) {
-        measurement_kit::debug("Connection error: %d", e.error);
+        measurement_kit::debug("Connection error: %d", (int) e);
         stream->close();
         measurement_kit::break_loop();
     });
@@ -366,8 +366,8 @@ TEST_CASE("HTTP Request works as expected") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        if (error.error != 0) {
-            std::cout << "Error: " << error.error << "\r\n";
+        if (error != 0) {
+            std::cout << "Error: " << (int) error << "\r\n";
             measurement_kit::break_loop();
             return;
         }
@@ -434,8 +434,8 @@ TEST_CASE("HTTP Request correctly receives errors") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        if (error.error) {
-            std::cout << "Error: " << error.error << "\r\n";
+        if (error != 0) {
+            std::cout << "Error: " << (int) error << "\r\n";
             measurement_kit::break_loop();
             return;
         }
@@ -463,8 +463,8 @@ TEST_CASE("HTTP Request works as expected over Tor") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        if (error.error != 0) {
-            std::cout << "Error: " << error.error << "\r\n";
+        if (error != 0) {
+            std::cout << "Error: " << (int) error << "\r\n";
             measurement_kit::break_loop();
             return;
         }
@@ -548,7 +548,7 @@ TEST_CASE("HTTP Client works as expected over Tor") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        std::cout << "Error: " << error.error << std::endl;
+        std::cout << "Error: " << (int) error << std::endl;
         std::cout << "Google:\r\n";
         std::cout << response.body.read<char>(128) << "\r\n";
         std::cout << "[snip]\r\n";
@@ -565,7 +565,7 @@ TEST_CASE("HTTP Client works as expected over Tor") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        std::cout << "Error: " << error.error << std::endl;
+        std::cout << "Error: " << (int) error << std::endl;
         std::cout << response.body.read<char>(128) << "\r\n";
         std::cout << "[snip]\r\n";
         if (++count >= 3) {
@@ -581,7 +581,7 @@ TEST_CASE("HTTP Client works as expected over Tor") {
     }, {
         {"Accept", "*/*"},
     }, "", [&](Error error, Response&& response) {
-        std::cout << "Error: " << error.error << std::endl;
+        std::cout << "Error: " << (int) error << std::endl;
         std::cout << response.body.read<char>(128) << "\r\n";
         std::cout << "[snip]\r\n";
         if (++count >= 3) {
@@ -604,7 +604,7 @@ TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
         {"Accept", "*/*"},
     }, "{\"test-helpers\": [\"dns\"]}",
                 [](Error error, Response&& response) {
-        std::cout << "Error: " << error.error << std::endl;
+        std::cout << "Error: " << (int) error << std::endl;
         std::cout << response.body.read<char>() << "\r\n";
         std::cout << "[snip]\r\n";
         measurement_kit::break_loop();
@@ -745,8 +745,8 @@ TEST_CASE("Make sure that settings are not modified") {
     }, "{\"test-helpers\": [\"dns\"]}",
                 [](Error error, Response&& response) {
         // XXX: assumes that Tor is not running on port 9999
-        REQUIRE(error.error != 0);
-        std::cout << "Error: " << error.error << std::endl;
+        REQUIRE(error != 0);
+        std::cout << "Error: " << (int) error << std::endl;
         std::cout << response.body.read<char>() << "\r\n";
         std::cout << "[snip]\r\n";
         measurement_kit::break_loop();


### PR DESCRIPTION
Let error encapsulate an integer error and start defining a generic-error class in error.hpp.

Also add manpage-like documentation.

This is part of the release engineering activities that I'm carrying out this weekend.

This pull request is simple-enough to qualify as hotfix. I will merge it shortly after travis-ci confirms that this is possible.