### PR TITLE
Release engineering of check-connectivity

### DIFF
--- a/doc/common/check_connectivity.md
+++ b/doc/common/check_connectivity.md
@@ -1,0 +1,56 @@
+# NAME
+CheckConnectivity -- Check whether there is connectivity
+
+# LIBRARY
+MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+using namespace measurement_kit::common;
+
+void do_something() {
+    if (CheckConnectivity::is_down()) {
+        fprintf(stderr, "The network is down\n");
+        return;
+    }
+    // do something ...
+}
+```
+
+# DESCRIPTION
+
+This class is implemented directly on top of evdns, to avoid depending
+from other modules, because it is often used in unit tests. In fact,
+we have tests that we want to skip when the network is down.
+
+To check whether the network is down, do:
+
+    if (CheckConnectivity::is_down()) {
+        return;
+    }
+
+This class reports that the network is up if the system-wide DNS
+resolver works and returns a valid IPv4 address for ebay.com. To
+reach the DNS resolver we use evdns, which we assume to be working.
+If evdns is broken, the DNS resolver is not reachable or ebay.com
+is no longer available, this class reports that the network is down
+even if it is not actually down. All these three conditions are
+quite unlikely, IMO, so this code should be robust enough.
+
+# BUGS
+
+The check on whether the network is down is performed only once
+when `is_down()` is called for the first time. Therefore, this class
+is not suitable to check whether the network is down in long running
+programs.
+
+Because it is designed for unit tests, this class uses its own event
+loop. This means that, the first time that `is_down()` is called,
+the current thread is blocked until the DNS response is received
+or until the evdns timeout expires.
+
+# HISTORY
+
+The `CheckConnectivity` class appeared in MeasurementKit 0.1.

--- a/include/measurement_kit/common/check_connectivity.hpp
+++ b/include/measurement_kit/common/check_connectivity.hpp
@@ -5,10 +5,6 @@
 #ifndef MEASUREMENT_KIT_COMMON_CHECK_CONNECTIVITY_HPP
 #define MEASUREMENT_KIT_COMMON_CHECK_CONNECTIVITY_HPP
 
-//
-// Helper class to check whether we have connectivity
-//
-
 #include <measurement_kit/common/constraints.hpp>
 
 // Forward declarations
@@ -18,66 +14,34 @@ struct evdns_base;
 namespace measurement_kit {
 namespace common {
 
-/*!
- * \brief Class used to check whether the network is up.
- *
- * This class is implemented directly on top of evdns, to avoid depending from
- * other modules, because it is often used in unit tests. In fact, we
- * have tests that we want to skip when the network is down.
- *
- * To check whether the network is down, do:
- *
- *     if (Network::is_down()) {
- *         return;
- *     }
- *
- * \remark This class reports that the network is up if the system-wide DNS
- * resolver works and returns a valid IPv4 address for ebay.com. To reach the
- * DNS resolver we use evdns, which we assume to be working. If evdns is broken,
- * the DNS resolver is not reachable or ebay.com is no longer available, this
- * class reports that the network is down even if it is not actually down. All
- * these three conditions are quite unlikely, IMO, so this code should be robust
- * enough.
- *
- * \remark The check on whether the network is down is performed only
- * once when is_down() is called for the first time. Therefore, this
- * class is not suitable to check whether the network is down in long
- * running programs.
- *
- * \warning Because it is designed for unit tests, this class uses its own
- * event loop. This means that, the first time that is_down() is called,
- * the current thread is blocked until the DNS response is received or until
- * the evdns timeout expires.
- */
-class Network : public NonCopyable, public NonMovable {
-    event_base *evbase = NULL;
-    evdns_base *dnsbase = NULL;
+/// Check whether the network is up
+class CheckConnectivity : public NonCopyable, public NonMovable {
+
+  public:
+    /// Returns whether the network is down.
+    /// \returns True if the network is down, false otherwise.
+    /// \throws std::bad_alloc if some allocation fails.
+    /// \throws std::runtime_error if evdns API fails.
+    static bool is_down() {
+        static CheckConnectivity singleton;
+        return !singleton.is_up;
+    }
+
+  private:
+    event_base *evbase = nullptr;
+    evdns_base *dnsbase = nullptr;
     bool is_up = false;
 
-    void cleanup(void);  // Idempotent cleanup function
+    void cleanup(); // Idempotent cleanup function
 
     static void dns_callback(int result, char type, int count, int ttl,
                              void *addresses, void *opaque);
 
-    Network(void);
+    CheckConnectivity();
 
-    ~Network(void) {
-        cleanup();
-    }
-
-public:
-
-    /*!
-     * \brief Returns whether the network is down.
-     * \returns True if the network is down, false otherwise.
-     * \throws std::bad_alloc if some allocation fails.
-     * \throws std::runtime_error if evdns API fails.
-     */
-    static bool is_down(void) {
-        static Network singleton;
-        return !singleton.is_up;
-    }
+    ~CheckConnectivity() { cleanup(); }
 };
 
-}}
+} // namespace common
+} // namespace measurement_kit
 #endif

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -14,30 +14,21 @@
 namespace measurement_kit {
 namespace common {
 
-void
-Network::cleanup(void)  // Idempotent cleanup function
+void CheckConnectivity::cleanup() // Idempotent cleanup function
 {
-    if (dnsbase != NULL) {
+    if (dnsbase != nullptr) {
         evdns_base_free(dnsbase, 0);
-        dnsbase = NULL;
+        dnsbase = nullptr;
     }
-    if (evbase != NULL) {
+    if (evbase != nullptr) {
         event_base_free(evbase);
-        evbase = NULL;
+        evbase = nullptr;
     }
 }
 
-void
-Network::dns_callback(int result, char type, int count, int ttl,
-                      void *addresses, void *opaque)
-{
-    auto that = static_cast<Network *>(opaque);
-
-    // Suppress "unused variable" warnings
-    (void) type;
-    (void) count;
-    (void) ttl;
-    (void) addresses;
+void CheckConnectivity::dns_callback(int result, char, int, int,
+                                     void *, void *opaque) {
+    auto that = static_cast<CheckConnectivity *>(opaque);
 
     switch (result) {
     case DNS_ERR_NONE:
@@ -59,20 +50,19 @@ Network::dns_callback(int result, char type, int count, int ttl,
     }
 }
 
-Network::Network(void)
-{
-    if ((evbase = event_base_new()) == NULL) {
+CheckConnectivity::CheckConnectivity() {
+    if ((evbase = event_base_new()) == nullptr) {
         cleanup();
         throw std::bad_alloc();
     }
 
-    if ((dnsbase = evdns_base_new(evbase, 1)) == NULL) {
+    if ((dnsbase = evdns_base_new(evbase, 1)) == nullptr) {
         cleanup();
         throw std::bad_alloc();
     }
 
     if (evdns_base_resolve_ipv4(dnsbase, "ebay.com", DNS_QUERY_NO_SEARCH,
-                                dns_callback, this) == NULL) {
+                                dns_callback, this) == nullptr) {
         cleanup();
         throw std::runtime_error("cannot resolve 'ebay.com'");
     }
@@ -89,4 +79,5 @@ Network::Network(void)
     }
 }
 
-}}
+} // namespace common
+} // namespace measurement_kit

--- a/test/dns/dns.cpp
+++ b/test/dns/dns.cpp
@@ -615,7 +615,7 @@ TEST_CASE("The system resolver works as expected") {
     // response fields from the system resolver.
     //
 
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
 
@@ -701,7 +701,7 @@ public:
 };
 
 TEST_CASE("It is safe to clear a request in its own callback") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     auto d = SafeToDeleteRequestInItsOwnCallback();
@@ -936,7 +936,7 @@ TEST_CASE("We can override the default number of tries") {
 
 TEST_CASE("The default custom resolver works as expected") {
 
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
 
@@ -1009,7 +1009,7 @@ TEST_CASE("The default custom resolver works as expected") {
 
 TEST_CASE("A specific custom resolver works as expected") {
 
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
 
@@ -1130,7 +1130,7 @@ TEST_CASE("A request to a nonexistent server times out") {
     //
     // So, I'm commentin out this check:
     //
-    //if (Network::is_down()) {
+    //if (CheckConnectivity::is_down()) {
     //    return;
     //}
     //
@@ -1163,7 +1163,7 @@ TEST_CASE("A request to a nonexistent server times out") {
 
 TEST_CASE("It is safe to cancel requests in flight") {
 
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
 

--- a/test/http/http.cpp
+++ b/test/http/http.cpp
@@ -193,7 +193,7 @@ TEST_CASE("Response parser eof() does not trigger immediate distruction") {
 }
 
 TEST_CASE("HTTP stream works as expected") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     //measurement_kit::set_verbose(1);
@@ -271,7 +271,7 @@ TEST_CASE("HTTP stream is robust to EOF") {
 }
 
 TEST_CASE("HTTP stream works as expected when using Tor") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     measurement_kit::set_verbose(1);
@@ -318,7 +318,7 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
 }
 
 TEST_CASE("HTTP stream receives connection errors") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     //measurement_kit::set_verbose(1);

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Ensure that the constructor socket-validity checks work") {
 }
 
 TEST_CASE("Connection::close() is idempotent") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     Connection s("PF_INET", "nexa.polito.it", "80");
@@ -99,7 +99,7 @@ TEST_CASE("Connection::close() is idempotent") {
 }
 
 TEST_CASE("It is safe to manipulate Connection after close") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     Connection s("PF_INET", "nexa.polito.it", "80");
@@ -119,7 +119,7 @@ TEST_CASE("It is safe to manipulate Connection after close") {
 }
 
 TEST_CASE("It is safe to close Connection while resolve is in progress") {
-    if (Network::is_down()) {
+    if (CheckConnectivity::is_down()) {
         return;
     }
     measurement_kit::set_verbose(1);


### PR DESCRIPTION
- Rename class CheckConnectivity for consistency

- Move documentation at doc/common/check_connectivity.md

- Modernize coding style

- Propagate changes to regress tests

This is part of the release engineering activities that I'm carrying out this weekend.

This pull request is simple-enough to qualify as hotfix. I will merge it shortly after travis-ci confirms that this is possible.