### PR TITLE
Release engineering of libevent.hpp

### DIFF
--- a/doc/common/bufferevent.md
+++ b/doc/common/bufferevent.md
@@ -1,0 +1,39 @@
+# NAME
+Bufferevent -- RAII wrapper for libevent bufferevent
+
+# LIBRARY
+MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+using namespace measurement_kit::common;
+
+// Create empty bufferevent
+Bufferevent bufev;
+
+// Create bufferevent attached to socket
+//   event_base *evbase
+//   evutil_socket_t sockfd
+Bufferevent bufev(evbase, sockfd, BEV_OPT_CLOSE_ON_FREE);
+
+// Attach bufferevent to another socket
+bufev.make(evbase, sockfd2, BEV_OPT_CLOSE_ON_FREE);
+
+// Convert if allocated otherwise throws
+bufferevent *p = bufev;
+```
+
+# DESCRIPTION
+
+The `Bufferevent` object is a smart pointer possibly containing a
+libevent `bufferevent` structure. It manages the life cycle of the
+underlying structure. It throws if the `Bufferevent` class is bound
+to a `nullptr` structure (this happens if you use the default
+constructor and never call `make()`). Of course the pointed structure,
+if allocated, is freed when the object goes out of scope.
+
+# HISTORY
+
+The `Bufferevent` class appeared in MeasurementKit 0.1.

--- a/doc/common/evbuffer.md
+++ b/doc/common/evbuffer.md
@@ -1,0 +1,27 @@
+# NAME
+Evbuffer -- RAII wrapper for libevent evbuffer
+
+# LIBRARY
+MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+using namespace measurement_kit::common;
+
+Evbuffer evbuf;
+evbuffer *p = evbuf; // Conversion done automatically
+```
+
+# DESCRIPTION
+
+The `Evbuffer` object is a container for an `evbuffer` structure of
+libevent. The advantages of the container are that allocation is lazy
+and on-demand. Moreover the container checks whether allocation of
+the `evbuffer` fails (and raises an exception if so). Also the container
+automatically frees the underlying evbuffer when it goes out of scope.
+
+# HISTORY
+
+The `Evbuffer` class appeared in MeasurementKit 0.1.

--- a/doc/common/libs.md
+++ b/doc/common/libs.md
@@ -1,0 +1,43 @@
+# NAME
+Libs -- Wrappers for C libraries functions.
+
+# LIBRARY
+MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+using namespace measurement_kit::common;
+
+// Suppose you want to check whether the Poller constructor deals
+// well with `event_base_new()` returning `nullptr`, then:
+
+Libs libs;
+libs.event_base_new = []() { return nullptr; };
+bool exc = false;
+try {
+    Poller poller(&libs);
+} catch (std::bad_alloc &) {
+    exc = true;
+}
+if (!exc) { /* test failed, do something */ }
+```
+
+# DESCRIPTION
+
+The `Libs` object contains C++11 lambdas mocking the APIs of many
+low-level APIs used by MeasurementKit. For example, `Libs` contains
+a C++11 lambda mocking `event_base_new()`.
+
+By default, those lambdas are initialized to the corresponding APIs
+such that, when you call `libs.event_base_new()` what is
+actually called is `::event_base_new()`.
+
+Many MeasurementKit objects take an optional constructor argument
+that is a pointer to a `Libs` object. This allows the programmer to
+simulate API failure in regress tests as shown above.
+
+# HISTORY
+
+The `Libs` class appeared in MeasurementKit 0.1.

--- a/include/measurement_kit/common.hpp
+++ b/include/measurement_kit/common.hpp
@@ -6,10 +6,12 @@
 #define MEASUREMENT_KIT_COMMON_HPP
 
 #include <measurement_kit/common/async.hpp>
+#include <measurement_kit/common/bufferevent.hpp>
 #include <measurement_kit/common/check_connectivity.hpp>
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/libevent.hpp>
+#include <measurement_kit/common/evbuffer.hpp>
+#include <measurement_kit/common/libs.hpp>
 #include <measurement_kit/common/log.hpp>
 #include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/pointer.hpp>

--- a/include/measurement_kit/common/bufferevent.hpp
+++ b/include/measurement_kit/common/bufferevent.hpp
@@ -1,0 +1,70 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#ifndef MEASUREMENT_KIT_COMMON_BUFFEREVENT_HPP
+#define MEASUREMENT_KIT_COMMON_BUFFEREVENT_HPP
+
+#include <measurement_kit/common/constraints.hpp>
+#include <measurement_kit/common/libs.hpp>
+
+#include <event2/util.h> // for evutil_socket_t
+#include <functional>    // for function
+#include <new>           // for bad_alloc
+#include <stdexcept>     // for runtime_error
+
+struct bufferevent;
+struct event_base;
+
+namespace measurement_kit {
+namespace common {
+
+/// RAII wrapper for bufferevent socket
+class Bufferevent : public NonCopyable, public NonMovable {
+  public:
+    /// Default constructor
+    Bufferevent(Libs *libs = Libs::global()) : libs_(libs) {}
+
+    /// Constructor with socket
+    Bufferevent(event_base *base, evutil_socket_t fd, int options,
+                Libs *libs = Libs::global()) {
+        make(base, fd, options, libs);
+    }
+
+    /// Attach to event base and socket
+    void make(event_base *base, evutil_socket_t fd, int options,
+              Libs *libs = Libs::global()) {
+        close();
+        libs_ = libs;
+        bev_ = libs_->bufferevent_socket_new(base, fd, options);
+        if (bev_ == nullptr) throw std::bad_alloc();
+    }
+
+    /// Destructor
+    ~Bufferevent() { close(); }
+
+    /// Idempotent close function
+    void close() {
+        if (bev_ != nullptr) {
+            libs_->bufferevent_free(bev_);
+            bev_ = nullptr;
+        }
+    }
+
+    /// Automatic cast to pointer to bufferevent
+    operator bufferevent *() {
+        if (bev_ == nullptr) throw std::runtime_error("nullptr bufferevent");
+        return (bev_);
+    }
+
+    /// Access underlying libs
+    Libs *get_libs() { return (libs_); }
+
+  private:
+    Libs *libs_ = Libs::global();
+    bufferevent *bev_ = nullptr;
+};
+
+} // namespace common
+} // namespace measurement_kit
+#endif

--- a/include/measurement_kit/common/evbuffer.hpp
+++ b/include/measurement_kit/common/evbuffer.hpp
@@ -1,0 +1,47 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#ifndef MEASUREMENT_KIT_COMMON_EVBUFFER_HPP
+#define MEASUREMENT_KIT_COMMON_EVBUFFER_HPP
+
+#include <measurement_kit/common/constraints.hpp>
+#include <measurement_kit/common/libs.hpp>
+
+#include <functional>
+#include <new>
+
+struct evbuffer;
+
+namespace measurement_kit {
+namespace common {
+
+/// RAII wrapper for evbuffer
+class Evbuffer : public NonCopyable, public NonMovable {
+  public:
+    /// Constructor with optional libevent pointer
+    Evbuffer(Libs *libs = Libs::global()) : libs_(libs) {}
+
+    /// Destructor
+    ~Evbuffer() {
+        if (evbuf_ != nullptr) libs_->evbuffer_free(evbuf_);
+    }
+
+    /// Cast to evbuffer-* operator
+    operator evbuffer *() {
+        if (evbuf_ == nullptr && (evbuf_ = libs_->evbuffer_new()) == nullptr)
+            throw std::bad_alloc();
+        return (evbuf_);
+    }
+
+    /// Access the underlying libevent
+    Libs *get_libevent() { return (libs_); }
+
+  private:
+    Libs *libs_ = Libs::global();
+    evbuffer *evbuf_ = nullptr;
+};
+
+} // namespace common
+} // namespace measurement_kit
+#endif

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -6,7 +6,7 @@
 #define MEASUREMENT_KIT_COMMON_POLLER_HPP
 
 #include <measurement_kit/common/constraints.hpp>
-#include <measurement_kit/common/libevent.hpp>
+#include <measurement_kit/common/libs.hpp>
 
 #include <functional>
 
@@ -22,13 +22,13 @@ class DelayedCall : public NonCopyable, public NonMovable {
      */
     std::function<void(void)> *func = NULL;
     event *evp = NULL;
-    Libevent *libevent = GlobalLibevent::get();
+    Libs *libs = Libs::global();
 
     // Callback for libevent
     static void dispatch(evutil_socket_t, short, void *);
 
   public:
-    DelayedCall(double, std::function<void(void)> &&, Libevent *libevent = NULL,
+    DelayedCall(double, std::function<void(void)> &&, Libs *libs = NULL,
                 event_base *evbase = NULL);
     ~DelayedCall(void);
 };
@@ -39,10 +39,10 @@ class Poller : public NonCopyable, public NonMovable {
     evdns_base *dnsbase;
     event *evsignal; /* for SIGINT on UNIX */
 
-    Libevent *libevent = GlobalLibevent::get();
+    Libs *libs = Libs::global();
 
   public:
-    Poller(Libevent *libevent = NULL);
+    Poller(Libs *libs = NULL);
     ~Poller(void);
 
     event_base *get_event_base(void) { return (this->base); }

--- a/include/measurement_kit/dns/dns.hpp
+++ b/include/measurement_kit/dns/dns.hpp
@@ -68,7 +68,7 @@ public:
      * \param started time when the DNS request was started.
      * \param addresses data returned by evdns as an opaque pointer.
      * \param lp pointer to custom logger object.
-     * \param libevent optional pointer to igth's libevent wrapper.
+     * \param libs optional pointer to igth's libs wrapper.
      * \param start_from optional parameter to start from the specified
      *        record, rather than from zero, when processing the results
      *        (this is only used for implementing some test cases).
@@ -76,7 +76,7 @@ public:
     Response(int code, char type, int count, int ttl, double started,
              void *addresses,
              SharedPointer<Logger> lp = DefaultLogger::get(),
-             Libevent *libevent = NULL,
+             Libs *libs = NULL,
              int start_from = 0);
 
     /*!
@@ -204,8 +204,8 @@ public:
      *        default one. This parameter is not meant to be used directly
      *        by the programmer. To issue requests using a specific evdns_base
      *        with specific options, you should instead use a Resolver.
-     * \param libevent Optional pointer to a mocked implementation of
-     *        the libevent object (mainly useful to write unit tests).
+     * \param libs Optional pointer to a mocked implementation of
+     *        the libs object (mainly useful to write unit tests).
      * \throws std::bad_alloc if some allocation fails.
      * \throws std::runtime_error if some edvns API fails.
      */
@@ -213,7 +213,7 @@ public:
             std::function<void(Response&&)>&& func,
             SharedPointer<Logger> lp = DefaultLogger::get(),
             evdns_base *dnsb = NULL,
-            Libevent *libevent = NULL);
+            Libs *libs = NULL);
 
     Request(Request&) = default;
     Request& operator=(Request&) = default;
@@ -271,7 +271,7 @@ class Resolver : public NonCopyable, public NonMovable {
 
 protected:
     Settings settings;
-    Libevent *libevent = GlobalLibevent::get();
+    Libs *libs = Libs::global();
     Poller *poller = measurement_kit::get_global_poller();
     evdns_base *base = NULL;
     SharedPointer<Logger> logger = DefaultLogger::get();
@@ -301,9 +301,9 @@ public:
      */
     Resolver(Settings settings_,
              SharedPointer<Logger> lp = DefaultLogger::get(),
-             Libevent *lev = NULL, Poller *plr = NULL) {
+             Libs *lev = NULL, Poller *plr = NULL) {
         if (lev != NULL) {
-            libevent = lev;
+            libs = lev;
         }
         if (plr != NULL) {
             poller = plr;

--- a/include/measurement_kit/net/connection.hpp
+++ b/include/measurement_kit/net/connection.hpp
@@ -5,6 +5,7 @@
 #ifndef MEASUREMENT_KIT_NET_CONNECTION_HPP
 #define MEASUREMENT_KIT_NET_CONNECTION_HPP
 
+#include <measurement_kit/common/bufferevent.hpp>
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/log.hpp>
@@ -32,7 +33,7 @@ using namespace measurement_kit::dns;
 
 class ConnectionState {
 
-    BuffereventSocket bev;
+    Bufferevent bev;
     dns::Request dns_request;
     unsigned int connecting = 0;
     char *address = NULL;

--- a/include/measurement_kit/ooni/net_test.hpp
+++ b/include/measurement_kit/ooni/net_test.hpp
@@ -87,7 +87,7 @@ class NetTest : public measurement_kit::common::NetTest {
   std::string get_report_filename();
 
 protected:
-  Libevent *libevent = GlobalLibevent::get();
+  Libs *libs = Libs::global();
 
   virtual void setup(std::string input);
   virtual void setup();

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -13,14 +13,16 @@ libmeasurement_kit_la_LIBADD += src/common/libcommon.la
 commonincludedir = $(includedir)/measurement_kit/common
 commoninclude_HEADERS = \
     include/measurement_kit/common/async.hpp \
+    include/measurement_kit/common/bufferevent.hpp \
     include/measurement_kit/common/check_connectivity.hpp \
     include/measurement_kit/common/constraints.hpp \
+    include/measurement_kit/common/evbuffer.hpp \
     include/measurement_kit/common/net_test.hpp \
     include/measurement_kit/common/pointer.hpp \
     include/measurement_kit/common/settings.hpp \
     include/measurement_kit/common/utils.hpp \
     include/measurement_kit/common/error.hpp \
-    include/measurement_kit/common/libevent.hpp \
+    include/measurement_kit/common/libs.hpp \
     include/measurement_kit/common/log.hpp \
     include/measurement_kit/common/poller.hpp \
     include/measurement_kit/common/string_vector.hpp

--- a/src/ooni/dns_test.cpp
+++ b/src/ooni/dns_test.cpp
@@ -18,7 +18,7 @@ DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
     resolver = std::make_shared<Resolver>(Settings{
         {"nameserver", nameserver},
         {"attempts", "1"},
-    }, logger, libevent);
+    }, logger, libs);
 
     std::string nameserver_part;
     std::stringstream nameserver_ss(nameserver);

--- a/test/common/bufferevent.cpp
+++ b/test/common/bufferevent.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/common/libevent.h's Bufferevent
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
@@ -15,21 +11,21 @@ using namespace measurement_kit::common;
 
 TEST_CASE("Constructors") {
   
-  SECTION("Create a BuffereventSocket instance with an empty constructor") {
-    auto libevent = Libevent();
+  SECTION("Create a Bufferevent instance with an empty constructor") {
+    auto libs = Libs();
     auto calls = 0;
 
-    libevent.bufferevent_socket_new = [&](event_base *,
+    libs.bufferevent_socket_new = [&](event_base *,
         evutil_socket_t, int) {
       ++calls;
       return ((bufferevent *) NULL);
     };
-    libevent.bufferevent_free = [&](bufferevent *) {
+    libs.bufferevent_free = [&](bufferevent *) {
       ++calls;
     };
 
     {
-      BuffereventSocket b(&libevent);
+      Bufferevent b(&libs);
     }
     
     REQUIRE(calls == 0);
@@ -37,81 +33,81 @@ TEST_CASE("Constructors") {
 
   SECTION("An exception should be raised if bufferevent is NULL") {
     REQUIRE_THROWS_AS([](void) {
-        BuffereventSocket b;
+        Bufferevent b;
         auto p = (bufferevent *) b;
         (void) p;
         return;
     }(), std::runtime_error);
   }
 
-  SECTION("Proper construction of BuffereventSocket") {
-    auto libevent = Libevent();
+  SECTION("Proper construction of Bufferevent") {
+    auto libs = Libs();
     auto calls = 0;
 
-    libevent.bufferevent_socket_new = [&](
+    libs.bufferevent_socket_new = [&](
         event_base *b, evutil_socket_t s, int o) {
       ++calls;
       return (::bufferevent_socket_new(b, s, o));
     };
-    libevent.bufferevent_free = [&](bufferevent *b) {
+    libs.bufferevent_free = [&](bufferevent *b) {
       ++calls;
       ::bufferevent_free(b);
     };
 
     {
       auto poller = GlobalPoller::get();
-      BuffereventSocket b(poller->get_event_base(),
-          -1, 0, &libevent);
+      Bufferevent b(poller->get_event_base(),
+          -1, 0, &libs);
     }
 
     REQUIRE(calls == 2);
   }
 
   SECTION("bufferevent_socket_new return NULL results in bad_alloc exception") {
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto raised = 0;
 
-    libevent.bufferevent_socket_new = [&](event_base *,
+    libs.bufferevent_socket_new = [&](event_base *,
         evutil_socket_t, int) {
       return ((bufferevent *) NULL);
     };
 
     auto base = GlobalPoller::get()->get_event_base();
 
-    REQUIRE_THROWS_AS(BuffereventSocket(base, 0, 0, &libevent),
+    REQUIRE_THROWS_AS(Bufferevent(base, 0, 0, &libs),
                       std::bad_alloc);
   }
 }
 
-TEST_CASE("BuffereventSocket operations") {
+TEST_CASE("Bufferevent operations") {
 
   SECTION("Accessing underlying bev") {
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto underlying = (bufferevent *) NULL;
 
-    libevent.bufferevent_socket_new = [&](event_base *b,
+    libs.bufferevent_socket_new = [&](event_base *b,
         evutil_socket_t s, int o) {
       return (underlying = ::bufferevent_socket_new(b, s, o));
     };
 
     auto poller = GlobalPoller::get();
-    BuffereventSocket b(poller->get_event_base(), -1, 0,
-        &libevent);
+    Bufferevent b(poller->get_event_base(), -1, 0,
+        &libs);
 
     REQUIRE(underlying == (bufferevent *) b);
   }
 
   SECTION("The close() method is safe and idempotent") {
 
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto called = 0;
-    libevent.bufferevent_free = [&called](bufferevent *bev) {
+    libs.bufferevent_free = [&called](bufferevent *bev) {
       ++called;
       ::bufferevent_free(bev);
     };
 
-    BuffereventSocket b(measurement_kit::get_global_event_base(), -1,
-        0, &libevent);
+    Bufferevent b(measurement_kit::get_global_event_base(), -1,
+        0, &libs);
 
     b.close();
 
@@ -129,15 +125,15 @@ TEST_CASE("BuffereventSocket operations") {
 
   SECTION("The make() method calls close() when a previous bufev exists") {
 
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto called = 0;
-    libevent.bufferevent_free = [&called](bufferevent *bev) {
+    libs.bufferevent_free = [&called](bufferevent *bev) {
       ++called;
       ::bufferevent_free(bev);
     };
 
-    BuffereventSocket b(measurement_kit::get_global_event_base(), -1,
-        0, &libevent);
+    Bufferevent b(measurement_kit::get_global_event_base(), -1,
+        0, &libs);
 
     b.make(measurement_kit::get_global_event_base(), -1, 0);
 
@@ -147,14 +143,14 @@ TEST_CASE("BuffereventSocket operations") {
 
   SECTION("The make() method does not close() when not needed") {
 
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto called = 0;
-    libevent.bufferevent_free = [&called](bufferevent *bev) {
+    libs.bufferevent_free = [&called](bufferevent *bev) {
       ++called;
       ::bufferevent_free(bev);
     };
 
-    BuffereventSocket b(&libevent);
+    Bufferevent b(&libs);
 
     b.make(measurement_kit::get_global_event_base(), -1, 0);
 
@@ -165,18 +161,18 @@ TEST_CASE("BuffereventSocket operations") {
   SECTION("The make() method calls bufferevent_socket_new()") {
 
     bufferevent *bevp = nullptr;
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto called = 0;
-    libevent.bufferevent_socket_new = [&bevp, &called](event_base *evb,
+    libs.bufferevent_socket_new = [&bevp, &called](event_base *evb,
         evutil_socket_t fd, int options) {
       bevp = ::bufferevent_socket_new(evb, fd, options);
       ++called;
       return bevp;
     };
 
-    BuffereventSocket b(measurement_kit::get_global_event_base(), -1, 0);
+    Bufferevent b(measurement_kit::get_global_event_base(), -1, 0);
 
-    b.make(measurement_kit::get_global_event_base(), -1, 0, &libevent);
+    b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
 
     // Ensure that bufferevent_socket_new() was called
     REQUIRE(bevp == (bufferevent *) b);
@@ -184,45 +180,45 @@ TEST_CASE("BuffereventSocket operations") {
 
   SECTION("Many subsequent make() calles behave correctly") {
 
-    auto libevent = Libevent();
+    auto libs = Libs();
     auto free_called = 0;
     auto new_called = 0;
-    libevent.bufferevent_free = [&free_called](bufferevent *bev) {
+    libs.bufferevent_free = [&free_called](bufferevent *bev) {
       ++free_called;
       ::bufferevent_free(bev);
     };
-    libevent.bufferevent_socket_new = [&new_called](event_base *evb,
+    libs.bufferevent_socket_new = [&new_called](event_base *evb,
         evutil_socket_t fd, int options) {
       auto bevp = ::bufferevent_socket_new(evb, fd, options);
       ++new_called;
       return bevp;
     };
 
-    BuffereventSocket b(&libevent);
+    Bufferevent b(&libs);
 
-    b.make(measurement_kit::get_global_event_base(), -1, 0, &libevent);
-    b.make(measurement_kit::get_global_event_base(), -1, 0, &libevent);
-    b.make(measurement_kit::get_global_event_base(), -1, 0, &libevent);
+    b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
+    b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
+    b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
 
     REQUIRE(new_called == 3);
     REQUIRE(free_called == 2);
   }
 
-  SECTION("The make() method allows to change the underlying libevent") {
-    auto libevent = Libevent();
+  SECTION("The make() method allows to change the underlying libs") {
+    auto libs = Libs();
 
-    BuffereventSocket b(&libevent);
+    Bufferevent b(&libs);
 
     b.make(measurement_kit::get_global_event_base(), -1, 0);
 
-    // Check whether the libevent is changed as it ought to be
-    REQUIRE(b.get_libevent() == GlobalLibevent::get());
+    // Check whether the libs is changed as it ought to be
+    REQUIRE(b.get_libs() == Libs::global());
 
-    auto libevent2 = Libevent();
-    b.make(measurement_kit::get_global_event_base(), -1, 0, &libevent2);
+    auto libs2 = Libs();
+    b.make(measurement_kit::get_global_event_base(), -1, 0, &libs2);
 
-    // Check whether the libevent is changed as it ought to be
-    REQUIRE(b.get_libevent() == &libevent2);
+    // Check whether the libs is changed as it ought to be
+    REQUIRE(b.get_libs() == &libs2);
   }
 
 }

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -14,40 +14,40 @@
 using namespace measurement_kit::common;
 
 TEST_CASE("Bad allocations triggers a failure ") {
-	Libevent libevent;
+	Libs libs;
 
-	libevent.event_new = [](event_base*, evutil_socket_t, short,
+	libs.event_new = [](event_base*, evutil_socket_t, short,
 	    event_callback_fn, void *) {
 		return ((event *) NULL);
 	};
 
-	REQUIRE_THROWS_AS(DelayedCall(0.0, [](void) { }, &libevent),
+	REQUIRE_THROWS_AS(DelayedCall(0.0, [](void) { }, &libs),
                     std::bad_alloc&);
 }
 
 TEST_CASE("If event_add returns -1 then an exception should be raised") {
-	Libevent libevent;
-	libevent.event_add = [](event*, timeval *) {
+	Libs libs;
+	libs.event_add = [](event*, timeval *) {
 		return (-1);
 	};
 
-	REQUIRE_THROWS_AS(DelayedCall(0.0, [](void) { }, &libevent),
+	REQUIRE_THROWS_AS(DelayedCall(0.0, [](void) { }, &libs),
                     std::runtime_error&);
 
 }
 
 TEST_CASE("Check that the event callbacks are fired") {
-	Libevent libevent;
+	Libs libs;
 
   SECTION("event_free must be called") {
     auto event_free_called = false;
 
-    libevent.event_free = [&event_free_called](event *evp) {
+    libs.event_free = [&event_free_called](event *evp) {
       event_free_called = true;
       ::event_free(evp);
     };
 
-    DelayedCall(0.0, [](void) { }, &libevent);
+    DelayedCall(0.0, [](void) { }, &libs);
 
     REQUIRE(event_free_called == true);
   }

--- a/test/common/evbuffer.cpp
+++ b/test/common/evbuffer.cpp
@@ -15,19 +15,19 @@ using namespace measurement_kit::common;
 
 TEST_CASE("The constructor is lazy") {
 
-	auto libevent = Libevent();
+	auto libs = Libs();
 	auto calls = 0;
 
-	libevent.evbuffer_new = [&](void) {
+	libs.evbuffer_new = [&](void) {
 		++calls;
 		return ((evbuffer *) NULL);
 	};
-	libevent.evbuffer_free = [&](evbuffer *) {
+	libs.evbuffer_free = [&](evbuffer *) {
 		++calls;
 	};
 
 	{
-		Evbuffer evbuf(&libevent);
+		Evbuffer evbuf(&libs);
 	}
 
 	REQUIRE(calls == 0);
@@ -35,20 +35,20 @@ TEST_CASE("The constructor is lazy") {
 
 TEST_CASE("The (evbuffer*) operation allocates the internal evbuffer") {
 
-	auto libevent = Libevent();
+	auto libs = Libs();
 	auto calls = 0;
 
-	libevent.evbuffer_new = [&](void) {
+	libs.evbuffer_new = [&](void) {
 		++calls;
 		return (::evbuffer_new());
 	};
-	libevent.evbuffer_free = [&](evbuffer *e) {
+	libs.evbuffer_free = [&](evbuffer *e) {
 		++calls;
 		evbuffer_free(e);
 	};
 
 	{
-		Evbuffer evbuf(&libevent);
+		Evbuffer evbuf(&libs);
 		auto p = (evbuffer *) evbuf;
 		(void) p;
 	}
@@ -58,15 +58,15 @@ TEST_CASE("The (evbuffer*) operation allocates the internal evbuffer") {
 
 TEST_CASE("The (evbuffer *) operation is idempotent") {
 
-	auto libevent = Libevent();
+	auto libs = Libs();
 	auto calls = 0;
 
-	libevent.evbuffer_new = [&](void) {
+	libs.evbuffer_new = [&](void) {
 		++calls;
 		return (::evbuffer_new());
 	};
 
-	Evbuffer evbuf(&libevent);
+	Evbuffer evbuf(&libs);
 	auto p1 = (evbuffer *) evbuf;
 	auto p2 = (evbuffer *) evbuf;
 
@@ -76,15 +76,15 @@ TEST_CASE("The (evbuffer *) operation is idempotent") {
 
 TEST_CASE("std::bad_alloc is raised when out of memory") {
 
-	auto libevent = Libevent();
+	auto libs = Libs();
 
-	libevent.evbuffer_new = [&](void) {
+	libs.evbuffer_new = [&](void) {
 		return ((evbuffer *) NULL);
 	};
 
 	REQUIRE_THROWS_AS([&](void) {
 		/* Yes, I really really love inline functions <3 */
-		Evbuffer evbuf(&libevent);
+		Evbuffer evbuf(&libs);
 		auto p = (evbuffer *) evbuf;
 		(void) p;
 	}(), std::bad_alloc);


### PR DESCRIPTION
- rename libs.hpp and Libs because more than libevent is wrapped

- add documentation

- move BuffereventSocket and Evbuffer to separate headers

- rename BuffereventSocket Bufferevent for consistency

Will merge this as soon as travis-ci confirms that it's possible to proceed