### PR TITLE
Release engineering of common/net_test.hpp

### DIFF
--- a/include/measurement_kit/common/net_test.hpp
+++ b/include/measurement_kit/common/net_test.hpp
@@ -5,52 +5,47 @@
 #ifndef MEASUREMENT_KIT_COMMON_NET_TEST_HPP
 #define MEASUREMENT_KIT_COMMON_NET_TEST_HPP
 
-///
-/// \brief Base class of all network tests.
-///
-
+#include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/settings.hpp>
 
 #include <functional>
-#include <string>
 
 namespace measurement_kit {
 namespace common {
 
-/// \brief The generic network test
-struct NetTest : public NonCopyable, public NonMovable {
-
-  protected:
-    Logger logger;
-
+/// The generic network test
+class NetTest : public NonCopyable, public NonMovable {
   public:
-    /// \brief Set log function used by this test.
-    virtual void set_log_function(std::function<void(const char *)> func) {
+    /// Set log function used by this test.
+    virtual void on_log(std::function<void(const char *)> func) {
         logger.on_log(func);
     }
 
-    /// \brief Make this test log verbose.
-    virtual void set_log_verbose(int verbose) {
+    /// Make this test log verbose.
+    virtual void set_verbose(int verbose) {
         logger.set_verbose(verbose);
     }
 
-    /// \brief Start iterating over the input.
+    /// Start iterating over the input.
     /// \param func Callback called when we are done.
     virtual void begin(std::function<void()> func) = 0;
 
-    /// \brief Make sure that report is written.
+    /// Make sure that report is written.
     /// \param func Callback invoked when report is written.
     virtual void end(std::function<void()> func) = 0;
 
-    /// \brief Return the unique identifier of this test.
+    /// Return the unique identifier of this test.
     virtual unsigned long long identifier() {
         return (unsigned long long) this;
     }
 
-    /// \brief Default destructor.
-    virtual ~NetTest() {}
+    /// Default destructor.
+    virtual ~NetTest();
+
+  protected:
+    Logger logger;
 };
 
-}}
+} // namespace common
+} // namespace measurement_kit
 #endif

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -4,6 +4,7 @@ src_common_libcommon_la_SOURCES = \
 	src/common/async.cpp \
 	src/common/check_connectivity.cpp \
 	src/common/logger.cpp \
+	src/common/net_test.cpp \
 	src/common/poller.cpp \
 	src/common/string_vector.cpp \
 	src/common/utils.cpp

--- a/src/common/net_test.cpp
+++ b/src/common/net_test.cpp
@@ -1,0 +1,13 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include <measurement_kit/common/net_test.hpp>
+
+namespace measurement_kit {
+namespace common {
+
+NetTest::~NetTest() {}
+
+} // namespace common
+} // namespace measurement_kit

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -23,8 +23,8 @@ static void run_http_invalid_request_line(Async &async) {
             {"backend", "http://nexa.polito.it/"},
         })
     );
-    test->set_log_verbose(1);
-    test->set_log_function([](const char *s) {
+    test->set_verbose(1);
+    test->on_log([](const char *s) {
         (void) fprintf(stderr, "test #1: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());
@@ -39,8 +39,8 @@ static void run_dns_injection(Async& async) {
             {"nameserver", "8.8.8.8:53"},
         })
     );
-    test->set_log_verbose(1);
-    test->set_log_function([](const char *s) {
+    test->set_verbose(1);
+    test->on_log([](const char *s) {
         (void) fprintf(stderr, "test #3: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());
@@ -55,8 +55,8 @@ static void run_tcp_connect(Async& async) {
             {"port", "80"},
         })
     );
-    test->set_log_verbose(1);
-    test->set_log_function([](const char *s) {
+    test->set_verbose(1);
+    test->on_log([](const char *s) {
         (void) fprintf(stderr, "test #4: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());


### PR DESCRIPTION
- use class, not struct

- rename on_log() for consistency

- rename set_verbose()

- coding style

- move destructor in .cpp file to avoid weak-vtable warning