### PR TITLE
Allow connection with custom poller

### DIFF
--- a/include/measurement_kit/net/connection.hpp
+++ b/include/measurement_kit/net/connection.hpp
@@ -47,6 +47,7 @@ class Connection : public Dumb {
     unsigned int must_resolve_ipv4 = 0;
     unsigned int must_resolve_ipv6 = 0;
     DelayedCall start_connect;
+    Poller *poller = Poller::global();
 
     // Libevent callbacks
     static void handle_read(bufferevent *, void *);


### PR DESCRIPTION
This should be part of MeasurementKit 0.1.0. Before it can be merged, it should be rebased and the conflicts below should be solved. This is needed by *Portolan*.