### PR TITLE
Teach portolan traceroute about reply packets.

### DIFF
--- a/include/measurement_kit/traceroute/android.hpp
+++ b/include/measurement_kit/traceroute/android.hpp
@@ -100,6 +100,22 @@ private:
   ProbeResult on_socket_readable();
 
   /// Returns the source address of the error message.
+  /// \param s IPv4 socket address
+  /// \return source address of the error message
+  static std::string get_source_addr(const sockaddr_in *s);
+
+  /// Returns the source address of the error message.
+  /// \param s IPv6 socket address
+  /// \return source address of the error message
+  static std::string get_source_addr(const sockaddr_in6 *s);
+
+  /// Returns the source address of the error message.
+  /// \param use_ipv4 whether we are using IPv4
+  /// \param ss Pointer to sockaddr_storage struct
+  /// \return source address of the error message
+  static std::string get_source_addr(bool use_ipv4, const sockaddr_storage *ss);
+
+  /// Returns the source address of the error message.
   /// \param use_ipv4 whether we are using IPv4
   /// \param err socket error structure
   /// \return source address of the error message

--- a/include/measurement_kit/traceroute/interface.hpp
+++ b/include/measurement_kit/traceroute/interface.hpp
@@ -55,9 +55,10 @@ enum class ProbeResultMeaning {
   NO_ROUTE_TO_HOST = 1, ///< No route to host
   ADDRESS_UNREACH = 2,  ///< E.g., link down
   PROTO_NOT_IMPL = 3,   ///< UDP not implemented
-  DEST_REACHED = 4,     ///< Port is closed = dest. reached
+  PORT_IS_CLOSED = 4,   ///< Port is closed
   TTL_EXCEEDED = 5,     ///< TTL is too small
   ADMIN_FILTER = 6,     ///< E.g., firewall rule
+  GOT_REPLY_PACKET = 7, ///< We got a real reply packet
 };
 
 /// Result of a traceroute probe
@@ -70,6 +71,8 @@ public:
   unsigned char icmp_type = 255; ///< Raw ICMP/ICMPv6 type
   unsigned char icmp_code = 255; ///< Raw ICMP/ICMPv6 code
   ssize_t recv_bytes = 0;        ///< Bytes recv'd
+  bool valid_reply = false;      ///< Whether reply is valid
+  std::string reply;             ///< Reply packet data
 
   /// Maps ICMP/ICMPv6 type and code to a meaning
   ProbeResultMeaning get_meaning();

--- a/src/traceroute/android.cpp
+++ b/src/traceroute/android.cpp
@@ -148,6 +148,7 @@ void AndroidProber::send_probe(std::string addr, int port, int ttl,
     throw std::runtime_error("payload too large");
   if (sendto(sockfd_, payload.data(), payload.length(), 0, (sockaddr *)&ss,
              sslen) != (ssize_t)payload.length()) {
+    measurement_kit::warn("sendto() failed: errno %d", errno);
     throw std::runtime_error("sendto() failed");
   }
 

--- a/src/traceroute/android.cpp
+++ b/src/traceroute/android.cpp
@@ -200,14 +200,15 @@ ProbeResult AndroidProber::on_socket_readable() {
     if (errno == EAGAIN || errno == EWOULDBLOCK) { // Defensive
       measurement_kit::debug("it seems we received a valid reply packet back");
       memset(&storage, 0, sizeof (storage));
-      if ((r.recv_bytes = recvfrom(sockfd_, iov.iov_base, iov.iov_len, 0,
+      solen = sizeof (storage);
+      if ((r.recv_bytes = recvfrom(sockfd_, buff, sizeof (buff), 0,
                                    (sockaddr *) &storage, &solen)) < 0) {
         throw std::runtime_error("recv() failed");
       }
       measurement_kit::debug("recv_bytes = %lu", r.recv_bytes);
       r.valid_reply = true;
       measurement_kit::debug("valid_reply = %d", r.valid_reply);
-      r.reply = std::string((const char *) iov.iov_base, iov.iov_len);
+      r.reply = std::string((const char *) buff, r.recv_bytes);
       measurement_kit::debug("reply = <%lu bytes>", r.reply.length());
       r.interface_ip = get_source_addr(use_ipv4_, &storage);
       measurement_kit::debug("interface_ip = %s", r.interface_ip.c_str());

--- a/test/traceroute/android.cpp
+++ b/test/traceroute/android.cpp
@@ -52,6 +52,44 @@ TEST_CASE("Typical IPv4 traceroute usage") {
   prober.send_probe("8.8.8.8", 33434, ttl, payload, 1.0);
   measurement_kit::loop();
 }
+
+TEST_CASE("Check whether it works when destination sends reply") {
+
+  std::string payload(256, '\0');
+  auto prober = Prober<AndroidProber>(true, 11829);
+  auto ttl = 1;
+
+  prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
+    std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
+    if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
+      measurement_kit::break_loop();
+      return;
+    }
+    prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+  });
+
+  prober.on_timeout([&prober, &ttl, &payload]() {
+    std::cout << ttl << " *\n";
+    if (ttl >= 64) {
+      measurement_kit::break_loop();
+      return;
+    }
+    prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+  });
+
+  prober.on_error([&prober, &ttl, &payload](std::runtime_error err) {
+    std::cout << ttl << " error: " << err.what() << "\n";
+    if (ttl >= 64) {
+      measurement_kit::break_loop();
+      return;
+    }
+    prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+  });
+
+  prober.send_probe("208.67.222.222", 53, ttl, payload, 1.0);
+  measurement_kit::loop();
+}
+
 #else
 int main() { return 0; }
 #endif


### PR DESCRIPTION
<strike>This needs some **more testing before it can be merged**. However I'm opening a pull request to bind it to the upcoming milestone and know this is something to work on.</strike>

This has now been refined and moderately tested. Note that this is needed by *Portolan*.