### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: cpp
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get install -qq gcc-4.8 g++-4.8
+  - sudo apt-get install -qq -y --force-yes gcc-4.8 g++-4.8
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo apt-get install tor
 install: autoreconf -i
-script: ./configure && make && make check-am
+script: ./configure && make -j2 V=0 && make -j2 check-am V=0
 compiler:
   - clang
   - g++


### PR DESCRIPTION
- force install of gcc-4.8 and g++-4.8

- quiet build

- use two cores to speed up

(Triggered by failures of travis-ci because gcc-4.8 was not installed anymore.)