### PR TITLE
More simple dns changes

### DIFF
--- a/include/measurement_kit/dns/query.hpp
+++ b/include/measurement_kit/dns/query.hpp
@@ -35,7 +35,7 @@ class Query {
 
     /// Start an async DNS request.
     Query(std::string query, std::string address,
-          std::function<void(Response &&)> &&func,
+          std::function<void(Response)> func,
           Logger *lp = Logger::global(), evdns_base *dnsb = nullptr,
           Libs *libs = nullptr);
 

--- a/include/measurement_kit/dns/resolver.hpp
+++ b/include/measurement_kit/dns/resolver.hpp
@@ -59,7 +59,7 @@ class Resolver : public NonCopyable, public NonMovable {
 
     /// Issue a Query using this resolver.
     void query(std::string query, std::string address,
-               std::function<void(Response &&)> &&func);
+               std::function<void(Response)> func);
 
     /// Default destructor.
     ~Resolver() { cleanup(); }

--- a/include/measurement_kit/dns/response.hpp
+++ b/include/measurement_kit/dns/response.hpp
@@ -26,7 +26,7 @@ class Response {
     int code = 66 /* = DNS_ERR_UNKNOWN */;
     double rtt = 0.0;
     int ttl = 0;
-
+    char type = 0;
     std::vector<std::string> results;
 
   public:
@@ -61,6 +61,9 @@ class Response {
     /// Get the time elapsed since the request was sent until
     /// the response was received.
     double get_rtt() { return rtt; }
+
+    /// Return the evdns type (e.g. DNS_IPv4_A)
+    char get_type() { return type; }
 
     /// Static function to map evdns status codes to OONI failures.
     static std::string map_failure_(int code);

--- a/include/measurement_kit/ooni/dns_test.hpp
+++ b/include/measurement_kit/ooni/dns_test.hpp
@@ -38,7 +38,7 @@ public:
 
     void query(QueryType query_type, QueryClass query_class,
         std::string query_name, std::string nameserver,
-        std::function<void(Response&&)>&& cb);
+        std::function<void(Response)> cb);
 
 };
 

--- a/src/dns/query.cpp
+++ b/src/dns/query.cpp
@@ -26,7 +26,7 @@ namespace dns {
 using namespace measurement_kit::common;
 
 Query::Query(std::string query, std::string address,
-             std::function<void(Response &&)> &&func, Logger *lp,
+             std::function<void(Response)> func, Logger *lp,
              evdns_base *dnsb, Libs *libs) {
     if (dnsb == nullptr) {
         dnsb = measurement_kit::get_global_evdns_base();
@@ -36,8 +36,7 @@ Query::Query(std::string query, std::string address,
     }
     cancelled = SharedPointer<bool>(new bool());
     *cancelled = false;
-    QueryImpl::issue(query, address, std::move(func), lp, dnsb, libs,
-                     cancelled);
+    QueryImpl::issue(query, address, func, lp, dnsb, libs, cancelled);
 }
 
 void Query::cancel(void) {

--- a/src/dns/query_impl.hpp
+++ b/src/dns/query_impl.hpp
@@ -51,7 +51,7 @@ class QueryImpl {
     // variable to keep track of cancelled requests.
     //
 
-    std::function<void(Response &&)> callback;
+    std::function<void(Response)> callback;
     double ticks = 0.0; // just to initialize to something
     Libs *libs;         // should not be nullptr (this is asserted below)
     SharedPointer<bool> cancelled;
@@ -100,7 +100,7 @@ class QueryImpl {
 
     // Private to enforce usage through issue()
     QueryImpl(std::string query, std::string address,
-              std::function<void(Response &&)> &&f, Logger *lp,
+              std::function<void(Response)> f, Logger *lp,
               evdns_base *base, Libs *lev, SharedPointer<bool> cancd)
         : callback(f), libs(lev), cancelled(cancd), logger(lp) {
 
@@ -145,10 +145,9 @@ class QueryImpl {
 
   public:
     static void issue(std::string query, std::string address,
-                      std::function<void(Response &&)> &&func, Logger *logger,
+                      std::function<void(Response)> func, Logger *logger,
                       evdns_base *base, Libs *lev, SharedPointer<bool> cancd) {
-        new QueryImpl(query, address, std::move(func), logger, base, lev,
-                      cancd);
+        new QueryImpl(query, address, func, logger, base, lev, cancd);
     }
 };
 

--- a/src/dns/resolver.cpp
+++ b/src/dns/resolver.cpp
@@ -104,7 +104,7 @@ evdns_base *Resolver::get_evdns_base(void) {
 }
 
 void Resolver::query(std::string query, std::string address,
-                     std::function<void(Response &&)> &&func) {
+                     std::function<void(Response)> func) {
     //
     // Note: QueryImpl implements the autodelete behavior, meaning that
     // it shall delete itself once its callback is called. The callback
@@ -114,7 +114,7 @@ void Resolver::query(std::string query, std::string address,
     //
     auto cancelled = SharedPointer<bool>(new bool());
     *cancelled = false;
-    QueryImpl::issue(query, address, std::move(func), logger, get_evdns_base(),
+    QueryImpl::issue(query, address, func, logger, get_evdns_base(),
                      libs, cancelled);
 }
 

--- a/src/dns/response.cpp
+++ b/src/dns/response.cpp
@@ -22,9 +22,9 @@ namespace dns {
 
 using namespace measurement_kit::common;
 
-Response::Response(int code_, char type, int count, int ttl_, double started,
+Response::Response(int code_, char type_, int count, int ttl_, double started,
                    void *addresses, Logger *logger, Libs *libs, int start_from)
-    : code(code_), ttl(ttl_) {
+    : code(code_), ttl(ttl_), type(type_) {
     assert(start_from >= 0);
 
     if (libs == NULL) {

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -216,8 +216,9 @@ bool Connection::resolve_internal(char type) {
 
     try {
         dns_request = dns::Query(query, address,
-                                   [this, type](dns::Response &&resp) {
-            handle_resolve(resp.get_evdns_status(), type, resp.get_results());
+                                   [this](dns::Response resp) {
+            handle_resolve(resp.get_evdns_status(), resp.get_type(),
+                           resp.get_results());
         });
     } catch (...) {
         return false; /* TODO: save the error */

--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -19,7 +19,7 @@ DNSInjection::main(std::string input, Settings options,
     have_entry = cb;
     query(QueryType::A, QueryClass::IN,
                    input, options["nameserver"], [this](
-                              Response&& response) {
+                              Response response) {
         logger.debug("dns_injection: got response");
         if (response.get_evdns_status() == DNS_ERR_NONE) {
             entry["injected"] = true;

--- a/src/ooni/dns_test.cpp
+++ b/src/ooni/dns_test.cpp
@@ -13,7 +13,7 @@ using namespace measurement_kit::common;
 void
 DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
                std::string query_name, std::string nameserver,
-               std::function<void(Response&&)>&& cb)
+               std::function<void(Response)> cb)
 {
     resolver = std::make_shared<Resolver>(Settings{
         {"nameserver", nameserver},
@@ -35,7 +35,7 @@ DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
     }
     resolver->query(
         query, query_name, 
-        [=](Response&& response) {
+        [=](Response response) {
             logger.debug("dns_test: got response!");
             YAML::Node query_entry;
             if (query_type == QueryType::A) {
@@ -66,7 +66,7 @@ DNSTest::query(QueryType query_type, QueryClass /*query_class*/,
             // query_entry["bytes"] = response.get_bytes();
             entry["queries"].push_back(query_entry);
             logger.debug("dns_test: callbacking");
-            cb(std::move(response));
+            cb(response);
             logger.debug("dns_test: callback called");
     });
 }

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Query::cancel() is idempotent") {
     // we check that we can get rid of a pending request.
     //
 
-    auto r1 = Query("A", "www.neubot.org", [&](Response && /*response*/) {
+    auto r1 = Query("A", "www.neubot.org", [&](Response /*response*/) {
         // nothing
     });
 
@@ -162,7 +162,7 @@ TEST_CASE("Query::cancel() is safe when a request is pending") {
 
     auto failed = false;
     {
-        auto r1 = Query("A", "www.neubot.org", [&](Response && /*response*/) {
+        auto r1 = Query("A", "www.neubot.org", [&](Response /*response*/) {
             //
             // This callback should not be invoked, because QueryImpl
             // should honor its `cancelled` field and therefore should delete
@@ -200,7 +200,7 @@ TEST_CASE("Move semantic works for request") {
 
         REQUIRE_THROWS(*r1.get_cancelled_());
 
-        TransparentQuery r2{"A", "www.neubot.org", [](Response &&) {
+        TransparentQuery r2{"A", "www.neubot.org", [](Response) {
                                 /* nothing */
                             }};
         REQUIRE(*r2.get_cancelled_() == false);
@@ -213,7 +213,7 @@ TEST_CASE("Move semantic works for request") {
     }
 
     SECTION("Move constructor") {
-        TransparentQuery r2{"A", "www.neubot.org", [](Response &&) {
+        TransparentQuery r2{"A", "www.neubot.org", [](Response) {
                                 /* nothing */
                             }};
         REQUIRE(*r2.get_cancelled_() == false);
@@ -252,7 +252,7 @@ TEST_CASE("The system resolver works as expected") {
         measurement_kit::break_loop();
     });
 
-    auto r1 = Query("A", "www.neubot.org", [&](Response &&response) {
+    auto r1 = Query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -264,7 +264,7 @@ TEST_CASE("The system resolver works as expected") {
     });
     measurement_kit::loop();
 
-    auto r2 = Query("REVERSE_A", "130.192.16.172", [&](Response &&response) {
+    auto r2 = Query("REVERSE_A", "130.192.16.172", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -276,7 +276,7 @@ TEST_CASE("The system resolver works as expected") {
     });
     measurement_kit::loop();
 
-    auto r3 = Query("AAAA", "ooni.torproject.org", [&](Response &&response) {
+    auto r3 = Query("AAAA", "ooni.torproject.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -296,7 +296,7 @@ TEST_CASE("The system resolver works as expected") {
 
     auto r4 = Query(
         "REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
-        [&](Response &&response) {
+        [&](Response response) {
             REQUIRE(response.get_reply_authoritative() == "unknown");
             REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
             REQUIRE(response.get_failure() == "");
@@ -316,9 +316,9 @@ class SafeToDeleteQueryInItsOwnCallback {
 
   public:
     SafeToDeleteQueryInItsOwnCallback() {
-        request = Query("A", "nexa.polito.it", [this](Response &&) {
+        request = Query("A", "nexa.polito.it", [this](Response) {
             // This assignment should trigger the original request's destructor
-            request = Query("AAAA", "nexa.polito.it", [this](Response &&) {
+            request = Query("AAAA", "nexa.polito.it", [this](Response) {
                 measurement_kit::break_loop();
             });
         });

--- a/test/dns/resolver.cpp
+++ b/test/dns/resolver.cpp
@@ -185,7 +185,7 @@ TEST_CASE("We can override the default timeout") {
                            {"timeout", "0.5"}});
 
     auto ticks = measurement_kit::time_now();
-    reso.query("A", "www.neubot.org", [&](Response &&response) {
+    reso.query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_results().size() == 0);
         REQUIRE(response.get_evdns_status() == DNS_ERR_TIMEOUT);
@@ -212,7 +212,7 @@ TEST_CASE("We can override the default number of tries") {
     });
 
     auto ticks = measurement_kit::time_now();
-    reso.query("A", "www.neubot.org", [&](Response &&response) {
+    reso.query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_results().size() == 0);
         REQUIRE(response.get_evdns_status() == DNS_ERR_TIMEOUT);
@@ -251,7 +251,7 @@ TEST_CASE("The default custom resolver works as expected") {
 
     Resolver reso;
 
-    reso.query("A", "www.neubot.org", [&](Response &&response) {
+    reso.query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -263,7 +263,7 @@ TEST_CASE("The default custom resolver works as expected") {
     });
     measurement_kit::loop();
 
-    reso.query("REVERSE_A", "130.192.16.172", [&](Response &&response) {
+    reso.query("REVERSE_A", "130.192.16.172", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -275,7 +275,7 @@ TEST_CASE("The default custom resolver works as expected") {
     });
     measurement_kit::loop();
 
-    reso.query("AAAA", "ooni.torproject.org", [&](Response &&response) {
+    reso.query("AAAA", "ooni.torproject.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -294,7 +294,7 @@ TEST_CASE("The default custom resolver works as expected") {
     measurement_kit::loop();
 
     reso.query("REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
-               [&](Response &&response) {
+               [&](Response response) {
                    REQUIRE(response.get_reply_authoritative() == "unknown");
                    REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
                    REQUIRE(response.get_failure() == "");
@@ -327,7 +327,7 @@ TEST_CASE("A specific custom resolver works as expected") {
         {"nameserver", "8.8.4.4"},
     }));
 
-    reso.query("A", "www.neubot.org", [&](Response &&response) {
+    reso.query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -339,7 +339,7 @@ TEST_CASE("A specific custom resolver works as expected") {
     });
     measurement_kit::loop();
 
-    reso.query("REVERSE_A", "130.192.16.172", [&](Response &&response) {
+    reso.query("REVERSE_A", "130.192.16.172", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -351,7 +351,7 @@ TEST_CASE("A specific custom resolver works as expected") {
     });
     measurement_kit::loop();
 
-    reso.query("AAAA", "ooni.torproject.org", [&](Response &&response) {
+    reso.query("AAAA", "ooni.torproject.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
         REQUIRE(response.get_failure() == "");
@@ -370,7 +370,7 @@ TEST_CASE("A specific custom resolver works as expected") {
     measurement_kit::loop();
 
     reso.query("REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
-               [&](Response &&response) {
+               [&](Response response) {
                    REQUIRE(response.get_reply_authoritative() == "unknown");
                    REQUIRE(response.get_evdns_status() == DNS_ERR_NONE);
                    REQUIRE(response.get_failure() == "");
@@ -397,7 +397,7 @@ TEST_CASE("If the resolver dies the requests are aborted") {
         {"nameserver", "130.192.91.231"},
     }));
 
-    reso->query("A", "www.neubot.org", [&](Response &&response) {
+    reso->query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_results().size() == 0);
         REQUIRE(response.get_evdns_status() == DNS_ERR_SHUTDOWN);
@@ -443,7 +443,7 @@ TEST_CASE("A request to a nonexistent server times out") {
     Resolver reso(Settings{
         {"nameserver", "130.192.91.231"}, {"attempts", "1"},
     });
-    reso.query("A", "www.neubot.org", [&](Response &&response) {
+    reso.query("A", "www.neubot.org", [&](Response response) {
         REQUIRE(response.get_reply_authoritative() == "unknown");
         REQUIRE(response.get_results().size() == 0);
         REQUIRE(response.get_evdns_status() == DNS_ERR_TIMEOUT);
@@ -489,7 +489,7 @@ TEST_CASE("It is safe to cancel requests in flight") {
     auto total = 0.0;
     auto count = 0;
     for (auto i = 0; i < 16; ++i) {
-        reso.query("A", "www.neubot.org", [&](Response &&response) {
+        reso.query("A", "www.neubot.org", [&](Response response) {
             if (response.get_evdns_status() == DNS_ERR_NONE) {
                 total += response.get_rtt();
                 count += 1;
@@ -507,7 +507,7 @@ TEST_CASE("It is safe to cancel requests in flight") {
 
     // for (;;) {  // only try this at home
     for (auto i = 0; i < 16; ++i) {
-        auto r = new Query("A", "www.neubot.org", [&](Response &&response) {
+        auto r = new Query("A", "www.neubot.org", [&](Response response) {
             auto status_ok = (response.get_evdns_status() == DNS_ERR_CANCEL ||
                               response.get_evdns_status() == DNS_ERR_NONE);
             REQUIRE(status_ok);


### PR DESCRIPTION
1. Use less &&value and less std::move(). Since I don't fully understand what those two C++11 features do in practice, I've decided not to use them. I will do more research after the release to understand whether we need this stuff or not.

2. Save and export response evdns type. Useful to avoid storing context in a lambda in src/connection.cpp