### PR TITLE
Update Query copy/move strategy

### DIFF
--- a/include/measurement_kit/dns/query.hpp
+++ b/include/measurement_kit/dns/query.hpp
@@ -39,8 +39,28 @@ class Query {
           Logger *lp = Logger::global(), evdns_base *dnsb = nullptr,
           Libs *libs = nullptr);
 
-    Query(Query &) = default;
-    Query &operator=(Query &) = default;
+    /*
+     * Following the rule of the three, we have a fancy destructor and we
+     * need to also define all the following operations.
+     *
+     * The copy operations are deleted and only moving is allowed. This is
+     * because the destructor sets to `false` the shared flag when exits the
+     * scope. Hence we want only one Query bound to a QueryImpl at a time,
+     * otherwise, in a scenario with multiple copies, when the first copy of
+     * Query leaves the scope, the flag is the to `false`, and the callback
+     * is not invoked even though one or more Queries are still alive.
+     *
+     * A better implementation would allow both copying and moving, and
+     * would callback only if the shared pointer count is greater than one,
+     * i.e. when at least a Query object is alive.
+     *
+     * Apparently asking for default move constructor is needed to enforce
+     * the move constructor of the SharedPointer as opposed to a constructor
+     * that only trivially copies. This was noticed removing the four lines
+     * and acknowledging that DNS code was not working anymore.
+     */
+    Query(Query &) = delete;
+    Query &operator=(Query &) = delete;
     Query(Query &&) = default;
     Query &operator=(Query &&) = default;
 


### PR DESCRIPTION
- forbid copy that will break our code

- explain why

- document need to use default move operations

- document how a simpler implementation would look like

(not reimplementing now, with the pending release and lots of things in the TODO list, due to other priorities. Also this is simple enough to qualify as an hotfix.)