### PR TITLE
Support for mapping errors to OONI errors

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -5,14 +5,19 @@
 #ifndef MEASUREMENT_KIT_COMMON_ERROR_HPP
 #define MEASUREMENT_KIT_COMMON_ERROR_HPP
 
+#include <iosfwd>
+#include <string>
+
 namespace measurement_kit {
 namespace common {
 
 /// An error that occurred
 class Error {
   public:
-    Error() : Error(0) {}                   ///< Default constructor (no error)
-    Error(int e) { error_ = e; }            ///< Constructor with error code
+    /// Constructor with error code and OONI error
+    Error(int e, std::string ooe) : error_(e), ooni_error_(ooe) {}
+
+    Error() : Error(0, "") {}               ///< Default constructor (no error)
     operator int() const { return error_; } ///< Cast to integer
 
     /// Equality operator
@@ -27,17 +32,25 @@ class Error {
     /// Unequality operator
     bool operator!=(Error e) const { return error_ != e.error_; }
 
+    /// Return error as OONI error
+    std::string as_ooni_error() { return ooni_error_; }
+
   private:
     int error_ = 0;
+    std::string ooni_error_;
 };
 
-/// 1 - Generic error
+/// No error
+class NoError : public Error {
+  public:
+    NoError() : Error() {} ///< Default constructor
+};
+
+/// Generic error
 class GenericError : public Error {
   public:
-    GenericError() : Error(1) {} ///< Default constructor
+    GenericError() : Error(1, "unknown_failure 1") {} ///< Default constructor
 };
-
-#define MEASUREMENT_KIT_NET_ERROR_BASE 256
 
 } // namespace common
 } // namespace measurement_kit

--- a/include/measurement_kit/http/request.hpp
+++ b/include/measurement_kit/http/request.hpp
@@ -142,7 +142,7 @@ public:
 
             stream->on_end([&]() {
                 logger->debug("http: we have reached end of response");
-                emit_end(Error(0), std::move(response));
+                emit_end(NoError(), std::move(response));
             });
 
         });

--- a/include/measurement_kit/net/buffer.hpp
+++ b/include/measurement_kit/net/buffer.hpp
@@ -145,7 +145,7 @@ class Buffer {
         if (search_result.pos < 0) {
             if (length() > maxline)
                 return std::make_tuple(EOLNotFoundError(), "");
-            return std::make_tuple(0, "");
+            return std::make_tuple(common::NoError(), "");
         }
 
         /*
@@ -158,7 +158,7 @@ class Buffer {
         if (len > maxline)
             return std::make_tuple(LineTooLongError(), "");
 
-        return std::make_tuple(0, read(len));
+        return std::make_tuple(common::NoError(), read(len));
     }
 
     /*

--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -14,72 +14,72 @@ namespace net {
 class EOFError : public common::Error {
   public:
     /// Default constructor
-    EOFError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 1) {}
+    EOFError() : Error(1000, "unknown_failure 1000") {}
 };
 
 /// Timeout error
 class TimeoutError : public common::Error {
   public:
     /// Default constructor
-    TimeoutError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 2) {}
+    TimeoutError() : Error(1001, "generic_timeout_error") {}
 };
 
 /// Socket error
 class SocketError : public common::Error {
   public:
     /// Default constructor
-    SocketError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 3) {}
+    SocketError() : Error(1002, "unknown_failure 1002") {}
 };
 
 /// Connect failed error
 class ConnectFailedError : public common::Error {
   public:
     /// Default constructor
-    ConnectFailedError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 4) {}
+    ConnectFailedError() : Error(1003, "unknown_failure 1003") {}
 };
 
 /// DNS generic error
 class DNSGenericError : public common::Error {
   public:
     /// Default constructor
-    DNSGenericError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 5) {}
+    DNSGenericError() : Error(1004, "unknown_failure 1004") {}
 };
 
 /// Bad SOCKS version error
 class BadSocksVersionError : public common::Error {
   public:
     /// Default constructor
-    BadSocksVersionError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 6) {}
+    BadSocksVersionError() : Error(1005, "socks_error") {}
 };
 
 /// SOCKS address too long
 class SocksAddressTooLongError : public common::Error {
   public:
-    SocksAddressTooLongError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 7) {}
+    SocksAddressTooLongError() : Error(1006, "unknown_failure 1006") {}
 };
 
 /// SOCKS invalid port
 class SocksInvalidPortError : public common::Error {
   public:
-    SocksInvalidPortError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 8) {}
+    SocksInvalidPortError() : Error(1007, "unknown_failure 1007") {}
 };
 
 /// SOCKS generic error
 class SocksGenericError : public common::Error {
   public:
-    SocksGenericError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 9) {}
+    SocksGenericError() : Error(1008, "socks_error") {}
 };
 
 /// EOL not found error
 class EOLNotFoundError : public common::Error {
   public:
-    EOLNotFoundError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 10) {}
+    EOLNotFoundError() : Error(1009, "unknown_failure 1009") {}
 };
 
 /// Line too long error
 class LineTooLongError : public common::Error {
   public:
-    LineTooLongError() : Error(MEASUREMENT_KIT_NET_ERROR_BASE + 11) {}
+    LineTooLongError() : Error(1010, "unknown_failure 1010") {}
 };
 
 } // namespace net

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -78,7 +78,7 @@ TEST_CASE("HTTP request behaves correctly when EOF indicates body END") {
     data << "\r\n";
     data << "1234567";
     transport.emit_data(data);
-    transport.emit_error(0);
+    transport.emit_error(NoError());
 
     REQUIRE(called == 1);
 }

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -88,7 +88,7 @@ TEST_CASE("HTTP stream is robust to EOF") {
         data << "1234567";
 
         transport.emit_data(data);
-        transport.emit_error(0);
+        transport.emit_error(NoError());
     });
 
     transport.emit_connect();


### PR DESCRIPTION
Will be used soon to report errors that more naturally map onto the errors of OONI without too much verbosity required.