### PR TITLE
Improve async implementation

### DIFF
--- a/doc/common/async.md
+++ b/doc/common/async.md
@@ -1,0 +1,76 @@
+# NAME
+Async -- run tests asynchronously.
+
+# LIBRARY
+MeasurementKit (libmeasurement\_kit, -lmeasurement\_kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/foo.hpp>
+
+using namespace measurement_kit::common;
+using namespace measurement_kit::foo;
+
+Async *async = new Async;
+
+void on_run_test() {
+    SharedPointer<FooTest> test = std::make_shared<FooTest>(
+        // Test configuration params
+    );
+    test->set_verbose(1);
+    test->on_log([](const char *log_line) {
+        // Caution: str points to a static buffer, make sure you copy
+        // its content if you plan to use it at a later time
+        // Caution: this callback is called from a background thread
+    });
+    async->run_test(test, [](SharedPointer<NetTest> test) {
+        // Do something with the terminated test
+        // Caution: this callback is called from a background thread
+    });
+}
+
+// Tell async to break out of the event loop as soon as possible
+// Note: this function returns immediately
+async->break_loop();
+
+// Wait for async to break out of the event loop
+while (!async->empty()) {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+}
+```
+
+# DESCRIPTION
+
+`Async` allows the App programmer to run MeasurementKit tests
+in a background thread of execution.
+
+The `Async` object itself should be allocated on the heap to guarantee
+that it has the same lifecycle of the App.
+
+To schedule a test to run asynchronously, do the following:
+
+1. allocate the test object on the heap using `std::make_shared<T>`
+
+2. (optional) tell the test to produce verbose messages using
+   its `set_verbose` method
+
+3. (optional) tell the test where you want its logs to be sent, by providing
+   a log-line C++11 lambda. Be careful that the `const char *` pointer you
+   receive is a pointer to a static buffer. Thus, make sure you copy the
+   content over if you plan to use it later. Be careful that the log-line
+   lambda will be called from a background thread context.
+
+4. call `run_test` to schedule the test for execution, by providing a
+   test-complete C++11 lambda. Be careful that the test-complete C++11
+   lambda will be called from a background thread context.
+
+If you need to quickly interrupt the I/O loop running in the background
+thread, use `break_loop`. This method sets a flag telling the I/O loop to
+break as soon as possible and then returns. Afterwards, periodically
+call `empty()` to identify the moment in which no tests are running (and
+hence the moment in which the background thread is stopped).
+
+# HISTORY
+
+The `Async` class appeared in MeasurementKit 0.1.

--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -5,27 +5,21 @@
 #ifndef MEASUREMENT_KIT_COMMON_ASYNC_HPP
 #define MEASUREMENT_KIT_COMMON_ASYNC_HPP
 
-#include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/pointer.hpp>
-#include <measurement_kit/common/poller.hpp>
+
+#include <functional>
+#include <string>
 
 namespace measurement_kit {
 namespace common {
 
+class NetTest;
 struct AsyncState;
 
 class Async {
-    SharedPointer<AsyncState> state;
-
-    static void loop_thread(SharedPointer<AsyncState>);
-
   public:
-
     /// Default constructor
-    Async() : Async(SharedPointer<Poller>(new Poller())) {}
-
-    /// Constructor with specified poller
-    Async(SharedPointer<Poller> p);
+    Async();
 
     /// Run the specified network test and call a callback when done
     /// \param func Callback called when test is done
@@ -34,20 +28,18 @@ class Async {
       std::function<void(SharedPointer<NetTest>)> func);
 
     /// Break out of the loop
+    /// \remark This returns immediately, poll empty() to know when
+    /// the background thread has terminated.
     void break_loop();
-
-    /// Restart the background loop
-    void restart_loop();
 
     /// Returns true when no async jobs are running
     bool empty();
 
-    ///
-    /// Called when the tests queue is empty
-    /// \warn This function is called from a background thread
-    ///
-    void on_empty(std::function<void()>);
+  private:
+    SharedPointer<AsyncState> state;
+    static void loop_thread(SharedPointer<AsyncState>);
 };
 
-}}
+} // namespace net
+} // namespace measurement_kit
 #endif

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -70,12 +70,8 @@ TEST_CASE("The async engine works as expected") {
     measurement_kit::set_verbose(1);
     Async async;
 
-    // Note: the two following callbacks execute in a background thread
-    volatile bool complete = false;
-
     for (int i = 0; i < 4; ++i) {
         measurement_kit::debug("do another iteration of tests");
-        complete = false;
 
         // Create tests in temporary void functions to also check that we can
         // create them in functions that later return in real apps

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -72,10 +72,6 @@ TEST_CASE("The async engine works as expected") {
 
     // Note: the two following callbacks execute in a background thread
     volatile bool complete = false;
-    async.on_empty([&complete]() {
-        measurement_kit::debug("all tests completed");
-        complete = true;
-    });
 
     for (int i = 0; i < 4; ++i) {
         measurement_kit::debug("do another iteration of tests");
@@ -88,8 +84,8 @@ TEST_CASE("The async engine works as expected") {
         run_http_invalid_request_line(async);
         run_tcp_connect(async);
 
-        // TODO Maybe implement a better sync mechanism but for now polling will do
-        while (!complete) {
+        // TODO Need to implement a better sync mechanism?
+        while (!async.empty()) {
             sleep(1);
         }
     }


### PR DESCRIPTION
This pull request contains the good parts of #160. The part that is not included (i.e. code to avoid running callbacks in background threads) was removed after discussion with @lorenzoPrimi.

Detail of changes in this diff:

- Include what you use and other cosmetics.

- Move private variables at bottom.

- No custom poller to constructor. This is too early in the life of the Async class to have a custom poller.

- Document break_loop().

- Remove on_empty() and instead rely on empty().

- Restructure AsyncState to have variables for each state in the life cycle of a test.

- Add INSERT and GET macro to increase coding correctness.

- In event_loop() reset state->interrupted to false to counter the effect of a previous break_loop().

- Unify the code to break from the loop and make sure we cleanup everything while locked to avoid races.

- Rewrite running a test inside the loop to avoid passing smart pointers to closures. This change is designed to address #138.

- Rewrite code for removing a test from the loop to keep the test alive until the next iteration of the loop. Prevents use-after-free when the stack of the end() callback is rewinded.

- Remove state->changed that was only a source of complexity. If we notice a performance slowdown we can always reintroduce this.

 Closes #138.