### PR TITLE
Modify libevent to compile for all Android archs

### DIFF
--- a/mobile/android/scripts/build.sh
+++ b/mobile/android/scripts/build.sh
@@ -9,7 +9,9 @@ if [ $# -eq 3 ]; then
 elif [ $# -eq 2 ]; then
     NDK_DIR=$1
     API=$2
-    for arch in arm-linux-androideabi mipsel-linux-android x86; do
+    for arch in aarch64-linux-android arm-linux-androideabi \
+      arm-linux-androideabi-v7a mipsel-linux-android mips64el-linux-android  \
+      x86 x86_64; do
         $0 $NDK_DIR $arch $API
     done
     exit 0

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -25,7 +25,7 @@ get boostorg/type_traits boost-1.56.0 boost/type_traits
 get boostorg/typeof boost-1.56.0 boost/typeof
 get boostorg/utility boost-1.56.0 boost/utility
 get joyent/http-parser v2.1-47-g1b31580 http-parser
-get measurement-kit/libevent release-2.0.22-stable-12-g8aad8b7 libevent
+get measurement-kit/libevent release-2.0.22-stable-18-gf1feb10 libevent
 get bassosimone/yaml-cpp master yaml-cpp
 get akheron/jansson master jansson
 get measurement-kit/libmaxminddb master libmaxminddb

--- a/src/ext/libevent/.gitignore
+++ b/src/ext/libevent/.gitignore
@@ -96,3 +96,6 @@ libevent_openssl.pc
 /test/test-weof
 /test/test-changelist
 
+.travis.yml
+.DS_Store
+test-driver

--- a/src/ext/libevent/Makefile.am
+++ b/src/ext/libevent/Makefile.am
@@ -86,10 +86,6 @@ VERSION_INFO = 6:10:1
 # is user-visible, and so we can pretty much guarantee that release
 # series won't be binary-compatible.
 
-if INSTALL_LIBEVENT
-dist_bin_SCRIPTS = event_rpcgen.py
-endif
-
 pkgconfigdir=$(libdir)/pkgconfig
 LIBEVENT_PKGCONFIG=libevent.pc
 
@@ -122,12 +118,11 @@ endif
 
 if INSTALL_LIBEVENT
 lib_LTLIBRARIES = $(LIBEVENT_LIBS_LA)
-pkgconfig_DATA = $(LIBEVENT_PKGCONFIG)
 else
 noinst_LTLIBRARIES =  $(LIBEVENT_LIBS_LA)
 endif
 
-SUBDIRS = . include sample test
+SUBDIRS = . include
 
 if BUILD_WIN32
 

--- a/src/ext/libevent/configure.ac
+++ b/src/ext/libevent/configure.ac
@@ -290,7 +290,7 @@ AC_HEADER_TIME
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS([gettimeofday vasprintf fcntl clock_gettime strtok_r strsep])
-AC_CHECK_FUNCS([getnameinfo strlcpy inet_ntop inet_pton signal sigaction strtoll inet_aton pipe eventfd sendfile mmap splice arc4random arc4random_buf issetugid geteuid getegid getprotobynumber setenv unsetenv putenv sysctl])
+AC_CHECK_FUNCS([getnameinfo strlcpy inet_ntop inet_pton signal sigaction strtoll inet_aton pipe eventfd sendfile mmap splice arc4random arc4random_buf arc4random_addrandom issetugid geteuid getegid getprotobynumber setenv unsetenv putenv sysctl])
 AC_CHECK_FUNCS([umask])
 
 AC_CACHE_CHECK(

--- a/src/ext/libevent/evutil_rand.c
+++ b/src/ext/libevent/evutil_rand.c
@@ -165,6 +165,16 @@ ev_arc4random_buf(void *buf, size_t n)
 	arc4random_buf(buf, n);
 }
 
+/*
+ * The arc4random included in libevent implements arc4random_addrandom().
+ *
+ * OpenBSD libc/crypt/arc4random.c migrated to ChaCha20 since 1.25 and
+ * have removed arc4random_addrandom() since 1.26. Since then, other libcs
+ * followed suit (e.g. Android's own libc). But libevent's arc4random.c
+ * copy still implement arc4random_addrandom().
+ */
+#define _EVENT_HAVE_ARC4RANDOM_ADDRANDOM 1
+
 #endif /* } !_EVENT_HAVE_ARC4RANDOM */
 
 void
@@ -176,7 +186,8 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
 void
 evutil_secure_rng_add_bytes(const char *buf, size_t n)
 {
+#if defined _EVENT_HAVE_ARC4RANDOM_ADDRANDOM
 	arc4random_addrandom((unsigned char*)buf,
 	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
+#endif
 }
-


### PR DESCRIPTION
This pull request has been updated and now only contains:

- changes in Makefile.am to reduce the compile time to recompile libevent for Android and iOS (rationale: we're integrating libevent, we're not developing it)

- the [arc4random_addrandom fix v2](https://github.com/measurement-kit/libevent/commit/8b275d967d7ffd95d5cc12069aef35669126c6d9) fix, needed to compile on Android under most architectures

- a revert for e7ea40bd9ad so that all Android architectures are built

To test this diff, I suggest to take the low-level approach of recompiling everything:

```
make distclean
git clean -dfx
cd mobile/android
# read README.md
./scripts/build.sh /path/to/ndk 21
```

and then do the following for each architecture:

- check `build/$arch/config.h` and see whether `arc4random` and `arc4random_addrandom` are supported

- disassemble `jni/$arch/libevent.a` (names change unfortunately between build and arch, see `./scripts/build_target.sh` for the mapping) and check `evutil_secure_rng_add_bytes()`:

    - if both `arc4random` and `arc4random_addrandom` are supported, you should see that the function calls `_arc4random_addrandom` (this is what happens on MacOS)

    - if only `arc4random` is supported, you should see the few assembly instructions that make an empty function (this is what should happen on OpenBSD and on selected Android architectures)

    - if both are not supported, you should see the inline implementation of libevent's `arc4random_addrandom` that at a certain point should call `arc4_stir` (this is what happens on Linux)