### PR TITLE
Improve android build scripts

### DIFF
--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -73,6 +73,14 @@ a single command using the `./scripts/build.sh` script. For example,
 
     $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ arm-linux-androideabi 9
 
+To build for all supported architectures, just omit the architecture:
+
+    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ 9
+
+If you omit API, 21 is used by default:
+
+    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/
+
 ## TODO next
 
 What is missing to continue this work is to compile and link

--- a/mobile/android/scripts/build.sh
+++ b/mobile/android/scripts/build.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -e
 
-ROOTDIR=$(cd $(dirname $(dirname $0)); pwd)
+ROOTDIR=$(cd $(dirname $(dirname $0)) && pwd -P)
+if [ $? -ne 0 ]; then
+    echo "$0: cannot determine root directory" 1>&2
+    exit 1
+fi
 
 if [ $# -eq 3 ]; then
     NDK_DIR=$1

--- a/mobile/android/scripts/build.sh
+++ b/mobile/android/scripts/build.sh
@@ -6,28 +6,36 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+ALL_ARCHS="aarch64-linux-android arm-linux-androideabi arm-linux-androideabi-v7a mipsel-linux-android mips64el-linux-android x86 x86_64"
+
 if [ $# -eq 3 ]; then
     NDK_DIR=$1
     ARCH=$2
     API=$3
-elif [ $# -eq 2 ]; then
+elif [ $# -eq 1 -o $# -eq 2 ]; then
     NDK_DIR=$1
-    API=$2
-    for arch in aarch64-linux-android arm-linux-androideabi \
-      arm-linux-androideabi-v7a mipsel-linux-android mips64el-linux-android  \
-      x86 x86_64; do
+    if [ $# -eq 2 ]; then
+        API=$2
+    else
+        API=21
+    fi
+    for arch in $ALL_ARCHS; do
         $0 $NDK_DIR $arch $API
     done
     exit 0
 else
-    echo "Usage: $0 NDK_DIR [ARCH] API" 1>&2
+    echo "Usage: $0 NDK_DIR [[ARCH] API]" 1>&2
     echo "  NDK_DIR: path where NDK is installed" 1>&2
     echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android mips64el-linux-android x86 x86_64" 1>&2
     echo "  API: 1 ... 21" 1>&2
+    echo "If you omit API, 21 is used." 1>&2
+    echo "If you omit ARCH, all archs are compiled." 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
     echo "  $0 /usr/local/Cellar/android-ndk/r10e/ x86 16" 1>&2
     echo "or" 1>&2
     echo "  $0 /usr/local/Cellar/android-ndk/r10e/ 16" 1>&2
+    echo "or" 1>&2
+    echo "  $0 /usr/local/Cellar/android-ndk/r10e/" 1>&2
     exit 1
 fi
 

--- a/mobile/android/scripts/build_target.sh
+++ b/mobile/android/scripts/build_target.sh
@@ -1,6 +1,11 @@
 #!/bin/sh -e
 
-ROOTDIR=$(cd $(dirname $(dirname $0)); pwd)
+ROOTDIR=$(cd $(dirname $(dirname $0)) && pwd -P)
+if [ $? -ne 0 ]; then
+    echo "$0: cannot determine root directory" 1>&2
+    exit 1
+fi
+
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 ARCH API" 1>&2


### PR DESCRIPTION
To test this, verify that by running `./mobile/android/scripts/build.sh $ndkpath` you recompile all the architectures available for Android without issues.