### PR TITLE
traceroute: make constructor lazy 

### DIFF
--- a/include/measurement_kit/traceroute/android.hpp
+++ b/include/measurement_kit/traceroute/android.hpp
@@ -59,7 +59,6 @@ public:
   /// \param use_ipv4 Whether to use IPv4
   /// \param port The port to bind
   /// \param evbase Event base to use (optional)
-  /// \throws Exception on error
   AndroidProber(bool use_ipv4, int port,
                 event_base *evbase = measurement_kit::get_global_event_base());
 
@@ -86,6 +85,7 @@ private:
   bool use_ipv4_ = true;         ///< using IPv4?
   event_base *evbase_ = nullptr; ///< event base
   event *evp_ = nullptr;         ///< event pointer
+  int port_ = 0;                 ///< socket port
 
   std::function<void(ProbeResult)> result_cb_;       ///< on result callback
   std::function<void()> timeout_cb_;                 ///< on timeout callback
@@ -93,6 +93,9 @@ private:
 
   /// Call this when you don't receive a response within timeout
   void on_timeout() { probe_pending_ = false; }
+
+  /// Initialize socket
+  void init();
 
   /// Call this as soon as the socket is readable to get
   /// the result ICMP error received by the socket and to


### PR DESCRIPTION
AndroidProber constructor body is empty. Errors are passed to error_cb_ by init function.

With gcc 5.2.0  this warning are shown:

```
src/traceroute/interface.cpp: In member function ‘measurement_kit::traceroute::ProbeResultMeaning measurement_kit::traceroute::ProbeResult::get_meaning()’:
src/traceroute/interface.cpp:77:72: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘measurement_kit::traceroute::ProbeResultMeaning’ [-Wformat=]
                            icmp_type, icmp_code, PRM_::GOT_REPLY_PACKET);
                                                                        ^
src/traceroute/interface.cpp:84:40: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘measurement_kit::traceroute::ProbeResultMeaning’ [-Wformat=]
                              m->meaning);
                                        ^
src/traceroute/interface.cpp:89:48: warning: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘measurement_kit::traceroute::ProbeResultMeaning’ [-Wformat=]
                          icmp_code, PRM_::OTHER);
                                                ^
```

Closes #198.