### PR TITLE
Add instructions to use jansson and libmaxminddb

### DIFF
--- a/mobile/ios/scripts/build_arch.sh
+++ b/mobile/ios/scripts/build_arch.sh
@@ -33,6 +33,8 @@ export CXXFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer
                 --with-libevent=builtin \
                 --with-libyaml-cpp=builtin \
                 --with-libboost=builtin \
+                --with-jansson=builtin \
+                --with-libmaxminddb=builtin \
                 --prefix=/ \
                 $EXTRA_CONFIG
     make -j4 V=0


### PR DESCRIPTION
Like in [issue-208](https://github.com/measurement-kit/measurement-kit/issues/208).

To make sure that configure use the built-in version instead of the version in the system.


It works. ./configure prints no more this output:

    configure: WARNING: No jansson found: will use the builtin jansson
    configure: WARNING: No libmaxminddb found: will use the builtin libmaxminddb

Closes #208.