### PR TITLE
Rename SharedPointer<T> to Var<T>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,9 @@ test/common/delayed_call
 test/common/evbuffer
 test/common/log
 test/common/poller
-test/common/pointer
 test/common/socket_valid
 test/common/utils
+test/common/var
 test/echo_client
 test/echo_client2
 test/echo_client_evbuf

--- a/README.md
+++ b/README.md
@@ -198,13 +198,13 @@ using namespace measurement_kit::common;
 using namespace measurement_kit;
 
 int main() {
-    SharedPointer<Async> async(new Async);
-    SharedPointer<NetTest> test(new ooni::HTTPInvalidRequestLine(Settings{
+    Var<Async> async(new Async);
+    Var<NetTest> test(new ooni::HTTPInvalidRequestLine(Settings{
         {"backend", "http://nexa.polito.it/"}
     }));
     test->set_verbose(1);
     test->on_log([](const char *s) { std::clog << s << "\n"; });
-    async->run_test(test, [async](SharedPointer<NetTest> test) {
+    async->run_test(test, [async](Var<NetTest> test) {
         std::clog << "Test complete: " << test->identifier() << "\n";
         async->break_loop();
     });

--- a/doc/api/c++/common/var.md
+++ b/doc/api/c++/common/var.md
@@ -1,5 +1,5 @@
 # NAME
-SharedPointer -- Smart shared pointer with nullptr checks
+Var -- Shared-pointer with JavaScript-var-like semantic
 
 # LIBRARY
 MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
@@ -12,10 +12,8 @@ using namespace measurement_kit::common;
 
 // Construct as a shared_ptr<T>
 
-SharedPointer<T> p;                         // pointer is nullptr
-SharedPointer<T> p(std::make_shared<T>());  // construct from shared_ptr
-SharedPointer<T> p(new T());                // construct from raw pointer
-p = std::make_shared<T>();                  // assign from shared_ptr
+Var<T> p;                         // pointer is nullptr
+Var<T> p(new T());                // construct from raw pointer
 
 // The three overriden operations
 
@@ -26,34 +24,34 @@ T value = *p;            // Return pointed value or raise
 
 # DESCRIPTION
 
-`SharedPointer<T>` template class is a drop-in replacement for the
+`Var<T>` template class is a drop-in replacement for the
 standard library `std::shared_ptr<T>` template. It reimplements common
 `std::shared_ptr<T>` operations by checking that the pointee is not
 `nullptr`. Otherwise, a runtime exception is raised.
 
 Whenever possible RAII should be used within MeasurementKit to guarantee
 resources deallocation. In the few specific cases in which a pointer is
-needed instead, a `SharedPointer<T>` should be used to guarantee that the
+needed instead, a `Var<T>` should be used to guarantee that the
 impact of programming errors (i.e. null pointers) is low.
 
-It is safe to construct (or to assign) a `SharedPointer<T>` from an
-`std::shared_ptr<T>`. In fact `SharedPointer<T>` is implemented overriding
+It is safe to construct (or to assign) a `Var<T>` from an
+`std::shared_ptr<T>`. In fact `Var<T>` is implemented overriding
 the three basic operations of `std::shared_ptr<T>`.
 
 # BUGS
 
-Since `SharedPointer<T>` overrides `std::shared_ptr<T>` and since it is
+Since `Var<T>` overrides `std::shared_ptr<T>` and since it is
 meant to be used as a class (not as a pointer or as a reference), one should
-remember not to add attributes to `SharedPointer<T>` implementation. This
+remember not to add attributes to `Var<T>` implementation. This
 guarantees that the following:
 
 ```C++
-SharedPointer<T> p = std::make_shared<T>();
+Var<T> p = std::make_shared<T>();
 ```
 
 does not result in object slicing (i.e. in the construction of a
-`SharedPointer<T>` with possibly uninitialized attributes).
+`Var<T>` with possibly uninitialized attributes).
 
 # HISTORY
 
-The `SharedPointer` class appeared in MeasurementKit 0.1.
+The `Var` class appeared in MeasurementKit 0.1.

--- a/include/measurement_kit/common.hpp
+++ b/include/measurement_kit/common.hpp
@@ -15,9 +15,9 @@
 #include <measurement_kit/common/libs.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/net_test.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/utils.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #endif

--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -5,7 +5,7 @@
 #ifndef MEASUREMENT_KIT_COMMON_ASYNC_HPP
 #define MEASUREMENT_KIT_COMMON_ASYNC_HPP
 
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <functional>
 #include <string>
@@ -24,8 +24,7 @@ class Async {
     /// Run the specified network test and call a callback when done
     /// \param func Callback called when test is done
     /// \warn The callback is called from a background thread
-    void run_test(SharedPointer<NetTest> test,
-      std::function<void(SharedPointer<NetTest>)> func);
+    void run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> func);
 
     /// Break out of the loop
     /// \remark This returns immediately, poll empty() to know when
@@ -36,8 +35,8 @@ class Async {
     bool empty();
 
   private:
-    SharedPointer<AsyncState> state;
-    static void loop_thread(SharedPointer<AsyncState>);
+    Var<AsyncState> state;
+    static void loop_thread(Var<AsyncState>);
 };
 
 } // namespace net

--- a/include/measurement_kit/common/delayed_call.hpp
+++ b/include/measurement_kit/common/delayed_call.hpp
@@ -7,7 +7,7 @@
 
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/libs.hpp>
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <functional>
 
@@ -41,7 +41,7 @@ class DelayedCall {
         state_.reset(new DelayedCallState(delay, func, libs, evbase));
     }
   private:
-    SharedPointer<DelayedCallState> state_;
+    Var<DelayedCallState> state_;
 };
 
 } // namespace common

--- a/include/measurement_kit/common/var.hpp
+++ b/include/measurement_kit/common/var.hpp
@@ -2,8 +2,8 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#ifndef MEASUREMENT_KIT_COMMON_POINTER_HPP
-#define MEASUREMENT_KIT_COMMON_POINTER_HPP
+#ifndef MEASUREMENT_KIT_COMMON_VAR_HPP
+#define MEASUREMENT_KIT_COMMON_VAR_HPP
 
 #include <memory>
 #include <stdexcept>
@@ -12,7 +12,7 @@ namespace measurement_kit {
 namespace common {
 
 /// Improved std::shared_ptr<T> with null pointer checks
-template <typename T> class SharedPointer : public std::shared_ptr<T> {
+template <typename T> class Var : public std::shared_ptr<T> {
     using std::shared_ptr<T>::shared_ptr;
 
   public:

--- a/include/measurement_kit/dns/query.hpp
+++ b/include/measurement_kit/dns/query.hpp
@@ -7,7 +7,7 @@
 
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/dns/defines.hpp>
 
@@ -30,7 +30,7 @@ using namespace measurement_kit::common;
 class Query {
 
   protected:
-    SharedPointer<bool> cancelled;
+    Var<bool> cancelled;
 
   public:
      /// Default constructor.
@@ -58,7 +58,7 @@ class Query {
      * i.e. when at least a Query object is alive.
      *
      * Apparently asking for default move constructor is needed to enforce
-     * the move constructor of the SharedPointer as opposed to a constructor
+     * the move constructor of the Var<T> as opposed to a constructor
      * that only trivially copies. This was noticed removing the four lines
      * and acknowledging that DNS code was not working anymore.
      */

--- a/include/measurement_kit/http/request.hpp
+++ b/include/measurement_kit/http/request.hpp
@@ -9,7 +9,7 @@
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/net/buffer.hpp>
 #include <measurement_kit/net/error.hpp>
@@ -43,7 +43,7 @@ class Request : public NonCopyable, public NonMovable {
 
     RequestCallback callback;
     RequestSerializer serializer;
-    SharedPointer<Stream> stream;
+    Var<Stream> stream;
     Response response;
     std::set<Request *> *parent = nullptr;
     Logger *logger = Logger::global();
@@ -148,7 +148,7 @@ public:
         });
     }
 
-    SharedPointer<Stream> get_stream() {
+    Var<Stream> get_stream() {
         return stream;
     }
 

--- a/include/measurement_kit/http/stream.hpp
+++ b/include/measurement_kit/http/stream.hpp
@@ -8,7 +8,7 @@
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/net/error.hpp>
 #include <measurement_kit/net/transport.hpp>
@@ -41,7 +41,7 @@ using namespace measurement_kit::net;
  */
 class Stream {
     Transport connection;
-    SharedPointer<ResponseParser> parser;
+    Var<ResponseParser> parser;
     std::function<void(Error)> error_handler;
     std::function<void()> connect_handler;
 
@@ -73,7 +73,7 @@ public:
      * \brief Get response parser.
      * This is useful for writing tests.
      */
-    SharedPointer<ResponseParser> get_parser() {
+    Var<ResponseParser> get_parser() {
         return parser;
     }
 

--- a/include/measurement_kit/net/connection.hpp
+++ b/include/measurement_kit/net/connection.hpp
@@ -10,7 +10,6 @@
 #include <measurement_kit/common/delayed_call.hpp>
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/utils.hpp>
 

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -15,8 +15,8 @@
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/settings.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/net/buffer.hpp>
 
@@ -121,7 +121,7 @@ class Transport : public TransportInterface {
     std::string socks5_port() override { return t->socks5_port(); }
 
   private:
-    SharedPointer<TransportInterface> t;
+    Var<TransportInterface> t;
 };
 
 Transport connect(Settings, Logger * = Logger::global());

--- a/include/measurement_kit/ooni/dns_test.hpp
+++ b/include/measurement_kit/ooni/dns_test.hpp
@@ -5,7 +5,7 @@
 #ifndef MEASUREMENT_KIT_OONI_DNS_TEST_HPP
 #define MEASUREMENT_KIT_OONI_DNS_TEST_HPP
 
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/dns.hpp>
 #include <measurement_kit/ooni/net_test.hpp>
@@ -19,7 +19,7 @@ using namespace measurement_kit::dns;
 class DNSTest : public ooni::NetTest {
     using ooni::NetTest::NetTest;
 
-    SharedPointer<Resolver> resolver;
+    Var<Resolver> resolver;
 
 public:
     DNSTest(std::string input_filepath_, Settings options_) :

--- a/include/measurement_kit/ooni/net_test.hpp
+++ b/include/measurement_kit/ooni/net_test.hpp
@@ -12,7 +12,6 @@
 #include <measurement_kit/report/file.hpp>
 
 #include <measurement_kit/common/delayed_call.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/logger.hpp>

--- a/include/measurement_kit/ooni/tcp_test.hpp
+++ b/include/measurement_kit/ooni/tcp_test.hpp
@@ -8,9 +8,9 @@
 #include <measurement_kit/net/buffer.hpp>
 #include <measurement_kit/net/connection.hpp>
 
-#include <measurement_kit/common/pointer.hpp>
-#include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common/settings.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/ooni/net_test.hpp>
 
@@ -20,7 +20,7 @@ namespace ooni {
 using namespace measurement_kit::common;
 using namespace measurement_kit::net;
 
-typedef SharedPointer<Connection> TCPClient;           /* XXX */
+typedef Var<Connection> TCPClient;           /* XXX */
 
 class TCPTest : public ooni::NetTest {
     using ooni::NetTest::NetTest;

--- a/src/common/include.am
+++ b/src/common/include.am
@@ -20,10 +20,10 @@ commoninclude_HEADERS = \
     include/measurement_kit/common/delayed_call.hpp \
     include/measurement_kit/common/evbuffer.hpp \
     include/measurement_kit/common/net_test.hpp \
-    include/measurement_kit/common/pointer.hpp \
     include/measurement_kit/common/settings.hpp \
     include/measurement_kit/common/utils.hpp \
     include/measurement_kit/common/error.hpp \
     include/measurement_kit/common/libs.hpp \
     include/measurement_kit/common/logger.hpp \
-    include/measurement_kit/common/poller.hpp
+    include/measurement_kit/common/poller.hpp \
+    include/measurement_kit/common/var.hpp

--- a/src/dns/query.cpp
+++ b/src/dns/query.cpp
@@ -6,8 +6,8 @@
 #include <measurement_kit/dns/query.hpp>
 
 #include <measurement_kit/common/libs.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/poller.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <functional>
 #include <iosfwd>
@@ -35,7 +35,7 @@ Query::Query(QueryClass dns_class, QueryType dns_type, std::string name,
     if (libs == nullptr) {
         libs = Libs::global();
     }
-    cancelled = SharedPointer<bool>(new bool());
+    cancelled = Var<bool>(new bool());
     *cancelled = false;
     QueryImpl::issue(dns_class, dns_type, name, func, lp,
                      dnsb, libs, cancelled);

--- a/src/dns/query_impl.hpp
+++ b/src/dns/query_impl.hpp
@@ -11,7 +11,7 @@
 
 #include <measurement_kit/common/libs.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/pointer.hpp>
+#include <measurement_kit/common/var.hpp>
 #include <measurement_kit/common/utils.hpp>
 
 #include <event2/dns.h>
@@ -56,7 +56,7 @@ class QueryImpl {
     std::function<void(Error, Response)> callback;
     double ticks = 0.0; // just to initialize to something
     Libs *libs;         // should not be nullptr (this is asserted below)
-    SharedPointer<bool> cancelled;
+    Var<bool> cancelled;
     Logger *logger = Logger::global();
 
     static void handle_resolve(int code, char type, int count, int ttl,
@@ -112,7 +112,7 @@ class QueryImpl {
     // Private to enforce usage through issue()
     QueryImpl(QueryClass dns_class, QueryType dns_type, std::string name,
               std::function<void(Error, Response)> f, Logger *lp,
-              evdns_base *base, Libs *lev, SharedPointer<bool> cancd)
+              evdns_base *base, Libs *lev, Var<bool> cancd)
         : callback(f), libs(lev), cancelled(cancd), logger(lp) {
 
         assert(base != nullptr && lev != nullptr);
@@ -172,7 +172,7 @@ class QueryImpl {
     static void issue(QueryClass dns_class, QueryType dns_type,
                       std::string name, std::function<void(Error, Response)> f,
                       Logger *logger, evdns_base *base, Libs *lev,
-                      SharedPointer<bool> cancd) {
+                      Var<bool> cancd) {
         try {
             new QueryImpl(dns_class, dns_type, name, f, logger,
                           base, lev, cancd);

--- a/src/dns/resolver.cpp
+++ b/src/dns/resolver.cpp
@@ -9,10 +9,10 @@
 
 #include <measurement_kit/common/libs.hpp>
 #include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/pointer.hpp>
 #include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/utils.hpp>
+#include <measurement_kit/common/var.hpp>
 
 #include <event2/dns.h>
 
@@ -113,7 +113,7 @@ void Resolver::query(QueryClass dns_class, QueryType dns_type,
     // or because of an error, or because the resolver is destroyed (this
     // is guaranteed by the destructor's impl).
     //
-    auto cancelled = SharedPointer<bool>(new bool());
+    auto cancelled = Var<bool>(new bool());
     *cancelled = false;
     QueryImpl::issue(dns_class, dns_type, name, f, logger,
                      get_evdns_base(), libs, cancelled);

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -18,7 +18,7 @@ using namespace measurement_kit::common;
 using namespace measurement_kit::ooni;
 
 static void run_http_invalid_request_line(Async &async) {
-    auto test = SharedPointer<HTTPInvalidRequestLine>(
+    auto test = Var<HTTPInvalidRequestLine>(
         new HTTPInvalidRequestLine(Settings{
             {"backend", "http://nexa.polito.it/"},
         })
@@ -28,13 +28,13 @@ static void run_http_invalid_request_line(Async &async) {
         (void) fprintf(stderr, "test #1: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());
-    async.run_test(test, [](SharedPointer<common::NetTest> test) {
+    async.run_test(test, [](Var<common::NetTest> test) {
         measurement_kit::debug("test complete: %llu", test->identifier());
     });
 }
 
 static void run_dns_injection(Async& async) {
-    auto test = SharedPointer<DNSInjection>(
+    auto test = Var<DNSInjection>(
         new DNSInjection("test/fixtures/hosts.txt", Settings{
             {"nameserver", "8.8.8.8:53"},
         })
@@ -44,13 +44,13 @@ static void run_dns_injection(Async& async) {
         (void) fprintf(stderr, "test #3: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());
-    async.run_test(test, [](SharedPointer<common::NetTest> test) {
+    async.run_test(test, [](Var<common::NetTest> test) {
         measurement_kit::debug("test complete: %llu", test->identifier());
     });
 }
 
 static void run_tcp_connect(Async& async) {
-    auto test = SharedPointer<TCPConnect>(
+    auto test = Var<TCPConnect>(
         new TCPConnect("test/fixtures/hosts.txt", Settings{
             {"port", "80"},
         })
@@ -60,7 +60,7 @@ static void run_tcp_connect(Async& async) {
         (void) fprintf(stderr, "test #4: %s\n", s);
     });
     measurement_kit::debug("test created: %llu", test->identifier());
-    async.run_test(test, [](SharedPointer<common::NetTest> test) {
+    async.run_test(test, [](Var<common::NetTest> test) {
         measurement_kit::debug("test complete: %llu", test->identifier());
     });
 }

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -63,7 +63,7 @@ TEST_CASE("Destructor cancels delayed calls") {
     // at any time by peer.
     //
     struct X {
-      SharedPointer<DelayedCall> d;
+      Var<DelayedCall> d;
     };
 
     auto called = false;

--- a/test/common/var.cpp
+++ b/test/common/var.cpp
@@ -20,23 +20,23 @@ struct Foo {
     void mascetti() {}
 };
 
-TEST_CASE("SharedPointer raises an exception when the pointee is nullptr") {
-    SharedPointer<Foo> foo;
+TEST_CASE("Var raises an exception when the pointee is nullptr") {
+    Var<Foo> foo;
     REQUIRE_THROWS(auto k = foo->elem);
     REQUIRE_THROWS(*foo);
     REQUIRE_THROWS(foo.get());
 }
 
-TEST_CASE("We can safely assign to SharedPointer an empty shared_ptr") {
+TEST_CASE("We can safely assign to Var an empty shared_ptr") {
     std::shared_ptr<Foo> antani;
-    SharedPointer<Foo> necchi = antani;
+    Var<Foo> necchi = antani;
     REQUIRE_THROWS(auto k = necchi->elem);
     REQUIRE_THROWS(*necchi);
     REQUIRE_THROWS(necchi.get());
 }
 
-TEST_CASE("We can assign to SharedPointer the result of make_shared") {
-    SharedPointer<Foo> necchi = std::make_shared<Foo>(6.28);
+TEST_CASE("We can assign to Var the result of make_shared") {
+    Var<Foo> necchi = std::make_shared<Foo>(6.28);
     REQUIRE(necchi->elem == 6.28);
     auto foo = *necchi;
     REQUIRE(foo.elem == 6.28);
@@ -44,7 +44,7 @@ TEST_CASE("We can assign to SharedPointer the result of make_shared") {
 
 TEST_CASE("The smart pointer works as expected") {
     auto pnecchi = new Foo(6.28);
-    SharedPointer<Foo> necchi(pnecchi);
+    Var<Foo> necchi(pnecchi);
     REQUIRE(necchi->elem == 6.28);
     REQUIRE((*necchi).elem == 6.28);
     REQUIRE(necchi.get() == pnecchi);
@@ -52,16 +52,16 @@ TEST_CASE("The smart pointer works as expected") {
 }
 
 TEST_CASE("Operator->() throws when nullptr") {
-    SharedPointer<Foo> necchi;
+    Var<Foo> necchi;
     REQUIRE_THROWS(necchi->mascetti());
 }
 
 TEST_CASE("Operator->* throws when nullptr") {
-    SharedPointer<Foo> sassaroli;
+    Var<Foo> sassaroli;
     REQUIRE_THROWS(*sassaroli);
 }
 
 TEST_CASE("Get() throws when nullptr") {
-    SharedPointer<Foo> il_melandri;
+    Var<Foo> il_melandri;
     REQUIRE_THROWS(il_melandri.get());
 }

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -198,7 +198,7 @@ TEST_CASE("Query::cancel() is safe when a request is pending") {
 struct TransparentQuery : public Query {
     using Query::Query;
 
-    SharedPointer<bool> get_cancelled_() { return cancelled; }
+    Var<bool> get_cancelled_() { return cancelled; }
 };
 
 TEST_CASE("Move semantic works for request") {

--- a/test/include.am
+++ b/test/include.am
@@ -37,11 +37,11 @@ test_common_poller_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/common/poller
 TESTS += test/common/poller
 
-test_common_pointer_SOURCES = test/common/pointer.cpp
-test_common_pointer_LDADD = libmeasurement_kit.la
-test_common_pointer_LDFLAGS = -lyaml-cpp
-check_PROGRAMS += test/common/pointer
-TESTS += test/common/pointer
+test_common_var_SOURCES = test/common/var.cpp
+test_common_var_LDADD = libmeasurement_kit.la
+test_common_var_LDFLAGS = -lyaml-cpp
+check_PROGRAMS += test/common/var
+TESTS += test/common/var
 
 test_common_socket_valid_SOURCES = test/common/socket_valid.cpp
 test_common_socket_valid_LDADD = libmeasurement_kit.la


### PR DESCRIPTION
The latter is more concise and conveys the meaning that Var<T> has a semantic similar to `var foo` in JavaScript.