### PR TITLE
Allowed creation of empty maybe.

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -53,6 +53,12 @@ class GenericError : public Error {
     GenericError() : Error(1, "unknown_failure 1") {} ///< Default constructor
 };
 
+/// Maybe not initialized error
+class MaybeNotInitializedError : public Error {
+  public:
+    MaybeNotInitializedError() : Error(2, "unknown_failure 2") {}
+};
+
 } // namespace common
 } // namespace measurement_kit
 #endif

--- a/include/measurement_kit/common/maybe.hpp
+++ b/include/measurement_kit/common/maybe.hpp
@@ -13,6 +13,9 @@ namespace common {
 /// Maybe contains a value of type T
 template <typename T> class Maybe {
   public:
+    /// Empty constructor
+    Maybe() :  error_(MaybeNotInitializedError()) {}
+
     /// Constructor with value
     Maybe(T value) : Maybe(NoError(), value) {}
 

--- a/test/common/maybe.cpp
+++ b/test/common/maybe.cpp
@@ -22,3 +22,10 @@ TEST_CASE("The maybe template works as expected when there is an error") {
     REQUIRE(maybe.as_error() == GenericError());
     REQUIRE_THROWS_AS(maybe.as_value(), Error);
 }
+
+TEST_CASE("The maybe template works as expected when the empty constructor is called") {
+    Maybe<int> maybe;
+    REQUIRE(static_cast<bool>(maybe) == false);
+    REQUIRE(maybe.as_error() == MaybeNotInitializedError());
+    REQUIRE_THROWS_AS(maybe.as_value(), Error);
+}


### PR DESCRIPTION
`Maybe<type> maybe`  now can be called.

MaybeNotInitializedError() is called when accessing the variable without initialization.

Closes #242 