### PR TITLE
Teach OONI tests to run themselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,9 +79,12 @@ test/net/buffer
 test/net/connection
 test/net/connection_check_fds
 test/ooni/dns_injection
+test/ooni/dns_injection_test
 test/ooni/net_test
 test/ooni/http_invalid_request_line
+test/ooni/http_invalid_request_line_test
 test/ooni/tcp_connect
+test/ooni/tcp_connect_test
 test/ooni/tcp_test
 test/dns/defines
 test/dns/error

--- a/doc/api/c++/ooni/dns_injection_test.md
+++ b/doc/api/c++/ooni/dns_injection_test.md
@@ -1,0 +1,76 @@
+# NAME
+ooni::DnsInjectionTest -- OONI dns-injection test
+
+# LIBRARY
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/ooni.hpp>
+
+using namespace measurement_kit;
+
+// Run sync test
+ooni::DnsInjectionTest()
+    .set_backend("127.0.0.1")
+    .set_input_file_path("test/fixtures/hosts.txt")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run();
+
+// Run async test
+ooni::DnsInjectionTest()
+    .set_backend("127.0.0.1")
+    .set_input_file_path("test/fixtures/hosts.txt")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run([]() {
+        // If needed, acquire the proper locks
+        // Handle test completion
+    });
+
+```
+
+# DESCRIPTION
+
+The `DnsInjectionTest` class allows to run OONI dns-injection test. After
+instantiating the class, you can configure it using these methods:
+
+- *set_backend*: set address (and optionally port) of the host to be
+  used as backend for the test. To specify the port append a colon followed
+  by the port to the IPv4/IPv6 address. Note that the test assumes that no
+  DNS server is running on the backend and its results rely on that.
+
+- *set_input_file_path*: set the path to the input file, i.e., a file
+  that contains the domain names to be tested, one for each line.
+
+- *set_verbose*: if called, this method tells the test to run in verbose
+  mode, i.e., to produce more detailed logs of its operations. The default
+  is for the test to be quiet.
+
+- *on_log*: sets the callback called each time a log line is generated
+  by the test. The default is to print logs on the stderr.
+
+Note that you MUST call *set_backend* and *set_input_file_path* because
+they provide parameters required by the test.
+
+Once you are satisfied with the test configuration, call the *run* method
+to start the test. If you do not pass any argument to *run*, the test is
+run synchronously and *run* only returns when the test is complete. If you
+provide a callback as the first argument, the test is run in a background
+thread, and the callback is called when the test is complete.
+
+# CAVEATS
+
+Callbacks MAY be called from a background thread. It is your responsibility
+to acquire the proper locks before manipulating shared objects.
+
+# HISTORY
+
+The `DnsInjectionTest` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/ooni/http_invalid_request_line_test.md
+++ b/doc/api/c++/ooni/http_invalid_request_line_test.md
@@ -1,0 +1,69 @@
+# NAME
+ooni::HttpInvalidRequestLineTest -- OONI http-invalid-request-line test
+
+# LIBRARY
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/ooni.hpp>
+
+using namespace measurement_kit;
+
+// Run sync test
+ooni::HttpInvalidRequestLineTest()
+    .set_backend("http://127.0.0.1/")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run();
+
+// Run async test
+ooni::HttpInvalidRequestLineTest()
+    .set_backend("http://127.0.0.1/")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run([]() {
+        // If needed, acquire the proper locks
+        // Handle test completion
+    });
+```
+
+# DESCRIPTION
+
+The `HttpInvalidRequestLineTest` class allows to run OONI
+http-invalid-request-line test. After instantiating the class,
+you can configure it using these methods:
+
+- *set_backend*: set URL of the backend, i.e., of the helper server where
+  an echo server, required by the test, is running.
+
+- *set_verbose*: if called, this method tells the test to run in verbose
+  mode, i.e., to produce more detailed logs of its operations. The default
+  is for the test to be quiet.
+
+- *on_log*: sets the callback called each time a log line is generated
+  by the test. The default is to print logs on the stderr.
+
+Note that you MUST call *set_backend* because it provides parameters required
+by the test.
+
+Once you are satisfied with the test configuration, call the *run* method
+to start the test. If you do not pass any argument to *run*, the test is
+run synchronously and *run* only returns when the test is complete. If you
+provide a callback as the first argument, the test is run in a background
+thread, and the callback is called when the test is complete.
+
+# CAVEATS
+
+Callbacks MAY be called from a background thread. It is your responsibility
+to acquire the proper locks before manipulating shared objects.
+
+# HISTORY
+
+The `HttpInvalidRequestLine` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/ooni/tcp_connect_test.md
+++ b/doc/api/c++/ooni/tcp_connect_test.md
@@ -1,0 +1,72 @@
+# NAME
+ooni::TcpConnectTest -- OONI tcp-connect test
+
+# LIBRARY
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/ooni.hpp>
+
+using namespace measurement_kit;
+
+// Run sync test
+ooni::TcpConnectTest()
+    .set_port("80")
+    .set_input_file_path("test/fixtures/hosts.txt")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run();
+
+// Run async test
+ooni::TcpConnectTest()
+    .set_port("80")
+    .set_input_file_path("test/fixtures/hosts.txt")
+    .set_verbose()
+    .on_log([](const char *s) {
+        // If needed, acquire the proper locks
+        // Process incoming log line
+    })
+    .run([]() {
+        // If needed, acquire the proper locks
+        // Handle test completion
+    });
+```
+
+# DESCRIPTION
+
+The `TcpConnectTest` class allows to run OONI tcp-connect test. After
+instantiating the class, you can configure it using these methods:
+
+- *set_port*: set port to connect to during the test.
+
+- *set_input_file_path*: set the path to the input file, i.e., a file
+  that contains the domain names to be tested, one for each line.
+
+- *set_verbose*: if called, this method tells the test to run in verbose
+  mode, i.e., to produce more detailed logs of its operations. The default
+  is for the test to be quiet.
+
+- *on_log*: sets the callback called each time a log line is generated
+  by the test. The default is to print logs on the stderr.
+
+Note that you MUST call *set_port* and *set_input_file_path* because
+they provide parameters required by the test.
+
+Once you are satisfied with the test configuration, call the *run* method
+to start the test. If you do not pass any argument to *run*, the test is
+run synchronously and *run* only returns when the test is complete. If you
+provide a callback as the first argument, the test is run in a background
+thread, and the callback is called when the test is complete.
+
+# CAVEATS
+
+Callbacks MAY be called from a background thread. It is your responsibility
+to acquire the proper locks before manipulating shared objects.
+
+# HISTORY
+
+The `TcpConnect` class appeared in MeasurementKit 0.1.0.

--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -34,6 +34,8 @@ class Async {
     /// Returns true when no async jobs are running
     bool empty();
 
+    static Async *global(); ///< Returns global async
+
   private:
     Var<AsyncState> state;
     static void loop_thread(Var<AsyncState>);

--- a/include/measurement_kit/ooni.hpp
+++ b/include/measurement_kit/ooni.hpp
@@ -5,6 +5,7 @@
 #ifndef MEASUREMENT_KIT_OONI_HPP
 #define MEASUREMENT_KIT_OONI_HPP
 
+#include <measurement_kit/ooni/base_test.hpp>
 #include <measurement_kit/ooni/dns_injection_test.hpp>
 #include <measurement_kit/ooni/http_invalid_request_line_test.hpp>
 #include <measurement_kit/ooni/tcp_connect_test.hpp>

--- a/include/measurement_kit/ooni/base_test.hpp
+++ b/include/measurement_kit/ooni/base_test.hpp
@@ -1,0 +1,39 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#ifndef MEASUREMENT_KIT_OONI_BASE_TEST_HPP
+#define MEASUREMENT_KIT_OONI_BASE_TEST_HPP
+
+#include <measurement_kit/common/var.hpp>
+#include <functional>
+
+namespace measurement_kit {
+
+namespace common {
+class NetTest;
+}
+
+namespace ooni {
+
+/// Base class for network tests
+class BaseTest {
+  public:
+    BaseTest() {}          ///< Default constructor
+    virtual ~BaseTest() {} ///< Default destructor
+
+    /// Create instance of the test
+    virtual common::Var<common::NetTest> create_test_() {
+        return common::Var<common::NetTest>();
+    }
+
+    /// Run synchronous test
+    void run();
+
+    /// Run asynchronous test
+    void run(std::function<void()> callback);
+};
+
+} // namespace ooni
+} // namespace measurement_kit
+#endif

--- a/include/measurement_kit/ooni/dns_injection_test.hpp
+++ b/include/measurement_kit/ooni/dns_injection_test.hpp
@@ -8,20 +8,21 @@
 #include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/var.hpp>
+#include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
 namespace measurement_kit {
 namespace ooni {
 
 /// Parameters of dns-injection test
-class DnsInjectionTest {
+class DnsInjectionTest : public BaseTest {
   public:
     /// Default constructor
     DnsInjectionTest() {}
 
     /// Set backend used to perform the test
-    DnsInjectionTest &set_nameserver(std::string nameserver) {
-        settings["nameserver"] = nameserver;
+    DnsInjectionTest &set_backend(std::string backend) {
+        settings["nameserver"] = backend;
         return *this;
     }
 
@@ -44,7 +45,7 @@ class DnsInjectionTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test();
+    common::Var<common::NetTest> create_test_() override;
 
     common::Settings settings;
     bool is_verbose = false;

--- a/include/measurement_kit/ooni/http_invalid_request_line_test.hpp
+++ b/include/measurement_kit/ooni/http_invalid_request_line_test.hpp
@@ -8,13 +8,14 @@
 #include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/var.hpp>
+#include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
 namespace measurement_kit {
 namespace ooni {
 
 /// Parameters of http-invalid-request-line test
-class HttpInvalidRequestLineTest {
+class HttpInvalidRequestLineTest : public BaseTest {
   public:
     /// Default constructor
     HttpInvalidRequestLineTest() {}
@@ -38,7 +39,7 @@ class HttpInvalidRequestLineTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test();
+    common::Var<common::NetTest> create_test_() override;
 
     common::Settings settings;
     bool is_verbose = false;

--- a/include/measurement_kit/ooni/tcp_connect_test.hpp
+++ b/include/measurement_kit/ooni/tcp_connect_test.hpp
@@ -8,13 +8,14 @@
 #include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/var.hpp>
+#include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
 namespace measurement_kit {
 namespace ooni {
 
 /// Parameters of tcp-connect test
-class TcpConnectTest {
+class TcpConnectTest : public BaseTest {
   public:
     /// Default constructor
     TcpConnectTest() {}
@@ -44,7 +45,7 @@ class TcpConnectTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test();
+    common::Var<common::NetTest> create_test_() override;
 
     common::Settings settings;
     bool is_verbose = false;

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -146,5 +146,10 @@ void Async::break_loop() {
 
 bool Async::empty() { return !state->thread_running; }
 
+Async *Async::global() {
+    static Async singleton;
+    return &singleton;
+}
+
 } // namespace common
 } // namespace measurement_kit

--- a/src/ooni/base_test.cpp
+++ b/src/ooni/base_test.cpp
@@ -1,0 +1,38 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include <chrono>                              // for seconds
+#include <functional>                          // for function
+#include <measurement_kit/common/async.hpp>    // for Async
+#include <measurement_kit/ooni/base_test.hpp>  // for BaseTest
+#include <measurement_kit/common/var.hpp>      // for Var
+#include <ratio>                               // for ratio
+#include <thread>                              // for sleep_for
+
+namespace measurement_kit {
+
+namespace common {
+class NetTest;
+}
+
+namespace ooni {
+using namespace measurement_kit::common;
+
+void BaseTest::run() {
+    // XXX Ideally it would be best to run this in the current thread with
+    // a dedicated poller, but the code is not yet ready for that.
+    bool done = false;
+    run([&done]() { done = true; });
+    do {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    } while (!done);
+}
+
+void BaseTest::run(std::function<void()> callback) {
+    Async::global()->run_test(create_test_(),
+                              [=](Var<NetTest>) { callback(); });
+}
+
+} // namespace ooni
+} // namespace measurement_kit

--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -28,7 +28,7 @@ void DNSInjection::main(std::string input, Settings options,
     });
 }
 
-Var<common::NetTest> DnsInjectionTest::create_test() {
+Var<common::NetTest> DnsInjectionTest::create_test_() {
     common::NetTest *test = new DNSInjection(input_path, settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/http_invalid_request_line.cpp
+++ b/src/ooni/http_invalid_request_line.cpp
@@ -62,7 +62,7 @@ void HTTPInvalidRequestLine::main(Settings options,
         headers, "", handle_response);
 }
 
-Var<common::NetTest> HttpInvalidRequestLineTest::create_test() {
+Var<common::NetTest> HttpInvalidRequestLineTest::create_test_() {
     common::NetTest *test = new HTTPInvalidRequestLine(settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/include.am
+++ b/src/ooni/include.am
@@ -1,6 +1,7 @@
 noinst_LTLIBRARIES += src/ooni/libooni.la
 
 src_ooni_libooni_la_SOURCES = \
+	src/ooni/base_test.cpp \
 	src/ooni/net_test.cpp \
 	src/ooni/dns_test.cpp \
 	src/ooni/http_invalid_request_line.cpp \
@@ -12,6 +13,7 @@ libmeasurement_kit_la_LIBADD += src/ooni/libooni.la
 
 ooniincludedir = $(includedir)/measurement_kit/ooni
 ooniinclude_HEADERS = \
+   include/measurement_kit/ooni/base_test.hpp \
    include/measurement_kit/ooni/dns_injection_test.hpp \
    include/measurement_kit/ooni/http_invalid_request_line_test.hpp \
    include/measurement_kit/ooni/tcp_connect_test.hpp

--- a/src/ooni/tcp_connect.cpp
+++ b/src/ooni/tcp_connect.cpp
@@ -21,7 +21,7 @@ void TCPConnect::main(std::string input, Settings options,
     });
 }
 
-Var<common::NetTest> TcpConnectTest::create_test() {
+Var<common::NetTest> TcpConnectTest::create_test_() {
     common::NetTest *test = new TCPConnect(input_path, settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -24,7 +24,7 @@ static void run_http_invalid_request_line(Async &async) {
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #1: %s\n", s);
                        })
-                       .create_test(),
+                       .create_test_(),
                    [](Var<NetTest> test) {
                        measurement_kit::debug("test complete: %llu",
                                               test->identifier());
@@ -33,13 +33,13 @@ static void run_http_invalid_request_line(Async &async) {
 
 static void run_dns_injection(Async &async) {
     async.run_test(DnsInjectionTest()
-                       .set_nameserver("8.8.8.8:53")
+                       .set_backend("8.8.8.8:53")
                        .set_input_file_path("test/fixtures/hosts.txt")
                        .set_verbose()
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #3: %s\n", s);
                        })
-                       .create_test(),
+                       .create_test_(),
                    [](Var<NetTest> test) {
                        measurement_kit::debug("test complete: %llu",
                                               test->identifier());
@@ -54,7 +54,7 @@ static void run_tcp_connect(Async &async) {
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #4: %s\n", s);
                        })
-                       .create_test(),
+                       .create_test_(),
                    [](Var<NetTest> test) {
                        measurement_kit::debug("test complete: %llu",
                                               test->identifier());

--- a/test/include.am
+++ b/test/include.am
@@ -91,11 +91,23 @@ test_ooni_dns_injection_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/dns_injection
 TESTS += test/ooni/dns_injection
 
+test_ooni_dns_injection_test_SOURCES = test/ooni/dns_injection_test.cpp
+test_ooni_dns_injection_test_LDADD = libmeasurement_kit.la
+test_ooni_dns_injection_test_LDFLAGS = -lyaml-cpp
+check_PROGRAMS += test/ooni/dns_injection_test
+TESTS += test/ooni/dns_injection_test
+
 test_ooni_http_invalid_request_line_SOURCES = test/ooni/http_invalid_request_line.cpp
 test_ooni_http_invalid_request_line_LDADD = libmeasurement_kit.la
 test_ooni_http_invalid_request_line_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/http_invalid_request_line
 TESTS += test/ooni/http_invalid_request_line
+
+test_ooni_http_invalid_request_line_test_SOURCES = test/ooni/http_invalid_request_line_test.cpp
+test_ooni_http_invalid_request_line_test_LDADD = libmeasurement_kit.la
+test_ooni_http_invalid_request_line_test_LDFLAGS = -lyaml-cpp
+check_PROGRAMS += test/ooni/http_invalid_request_line_test
+TESTS += test/ooni/http_invalid_request_line_test
 
 test_ooni_tcp_test_SOURCES = test/ooni/tcp_test.cpp
 test_ooni_tcp_test_LDADD = libmeasurement_kit.la
@@ -108,6 +120,12 @@ test_ooni_tcp_connect_LDADD = libmeasurement_kit.la
 test_ooni_tcp_connect_LDFLAGS = -lyaml-cpp
 check_PROGRAMS += test/ooni/tcp_connect
 TESTS += test/ooni/tcp_connect
+
+test_ooni_tcp_connect_test_SOURCES = test/ooni/tcp_connect_test.cpp
+test_ooni_tcp_connect_test_LDADD = libmeasurement_kit.la
+test_ooni_tcp_connect_test_LDFLAGS = -lyaml-cpp
+check_PROGRAMS += test/ooni/tcp_connect_test
+TESTS += test/ooni/tcp_connect_test
 
 test_ooni_net_test_SOURCES = test/ooni/net_test.cpp
 test_ooni_net_test_LDADD = libmeasurement_kit.la

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -1,0 +1,42 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <list>
+#include <measurement_kit/ooni.hpp>
+#include <string>
+#include <thread>
+
+using namespace measurement_kit::common;
+using namespace measurement_kit;
+
+TEST_CASE("Synchronous dns-injection test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    ooni::DnsInjectionTest()
+        .set_backend("8.8.8.8:53")
+        .set_input_file_path("test/fixtures/hosts.txt")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run();
+    for (auto &s : *logs) std::cout << s << "\n";
+}
+
+TEST_CASE("Asynchronous dns-injection test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    bool done = false;
+    ooni::DnsInjectionTest()
+        .set_backend("8.8.8.8:53")
+        .set_input_file_path("test/fixtures/hosts.txt")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run([&]() { done = true; });
+    do {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    } while (!done);
+    for (auto &s : *logs) std::cout << s << "\n";
+}

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -1,0 +1,40 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <list>
+#include <measurement_kit/ooni.hpp>
+#include <string>
+#include <thread>
+
+using namespace measurement_kit::common;
+using namespace measurement_kit;
+
+TEST_CASE("Synchronous http-invalid-request-line test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    ooni::HttpInvalidRequestLineTest()
+        .set_backend("http://nexa.polito.it/")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run();
+    for (auto &s : *logs) std::cout << s << "\n";
+}
+
+TEST_CASE("Asynchronous http-invalid-request-line test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    bool done = false;
+    ooni::HttpInvalidRequestLineTest()
+        .set_backend("http://nexa.polito.it/")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run([&done]() { done = true; });
+    do {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    } while (!done);
+    for (auto &s : *logs) std::cout << s << "\n";
+}

--- a/test/ooni/tcp_connect_test.cpp
+++ b/test/ooni/tcp_connect_test.cpp
@@ -1,0 +1,42 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <list>
+#include <measurement_kit/ooni.hpp>
+#include <string>
+#include <thread>
+
+using namespace measurement_kit::common;
+using namespace measurement_kit;
+
+TEST_CASE("Synchronous tcp-connect test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    ooni::TcpConnectTest()
+        .set_port("80")
+        .set_input_file_path("test/fixtures/hosts.txt")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run();
+    for (auto &s : *logs) std::cout << s << "\n";
+}
+
+TEST_CASE("Asynchronous tcp-connect test") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    bool done = false;
+    ooni::TcpConnectTest()
+        .set_port("80")
+        .set_input_file_path("test/fixtures/hosts.txt")
+        .set_verbose()
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run([&done]() { done = true; });
+    do {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    } while (!done);
+    for (auto &s : *logs) std::cout << s << "\n";
+}


### PR DESCRIPTION
Tested locally also with Valgrind to make sure this new set of patches does not add memory errors.

This is not enough to close #243, because improvements are needed to allow one to provide a specific poller or async to the code. However, to do so we would need to change the underlying implementation too much, and I don't want to do this before making a release.