### PR TITLE
android: only install MK headers

### DIFF
--- a/mobile/android/scripts/build_target.sh
+++ b/mobile/android/scripts/build_target.sh
@@ -87,5 +87,6 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib${LIB_SUFFIX} -L${ANDROID_TOOLCHA
       --with-jansson=builtin
     make V=0
     echo "Installing library in ${BASEDIR}/build/${ANDROID_TOOLCHAIN}"
-    make install-strip DESTDIR=${ROOTDIR}/jni/${DESTDIR_NAME}
+    make install-data-am DESTDIR=${ROOTDIR}/jni/${DESTDIR_NAME}
+    make install-exec DESTDIR=${ROOTDIR}/jni/${DESTDIR_NAME}
 )


### PR DESCRIPTION
Now that MK does not pull dependencies headers from its headers, we do not need anymore to install such headers.