### PR TITLE
fix for http-invalid-request-line

### DIFF
--- a/include/measurement_kit/http/error.hpp
+++ b/include/measurement_kit/http/error.hpp
@@ -1,0 +1,27 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#ifndef MEASUREMENT_KIT_HTTP_ERROR_HPP
+#define MEASUREMENT_KIT_HTTP_ERROR_HPP
+
+#include <measurement_kit/common/error.hpp>
+
+namespace measurement_kit {
+namespace http {
+
+/// Received UPGRADE request error
+class UpgradeError : public common::Error {
+  public:
+    UpgradeError (): Error(3000, "unknown_error 3000") {};
+};
+
+/// Parse error occurred
+class ParserError : public common::Error {
+  public:
+    ParserError() : Error(3001, "unknown_error 3001") {};
+};
+
+} // namespace http
+} // namespace measurement_kit
+#endif

--- a/src/http/response_parser.cpp
+++ b/src/http/response_parser.cpp
@@ -5,7 +5,7 @@
 #include <measurement_kit/common/logger.hpp>
 #include "src/http/response_parser.hpp"
 #include <measurement_kit/net/buffer.hpp>
-
+#include <measurement_kit/http/error.hpp>
 #include "ext/http-parser/http_parser.h"
 
 #include <functional>
@@ -150,10 +150,10 @@ class ResponseParserImpl {
                                            (const char *)base, count);
             parsing = false;
             if (parser.upgrade) {
-                throw UpgradeError("Unexpected UPGRADE");
+                throw UpgradeError();
             }
             if (n != count) {
-                throw ParserError("Parser error");
+                throw ParserError();
             }
             total += count;
             return true;
@@ -279,10 +279,10 @@ class ResponseParserImpl {
         size_t n = http_parser_execute(&parser, &settings, NULL, 0);
         parsing = false;
         if (parser.upgrade) {
-            throw UpgradeError("Unexpected UPGRADE");
+            throw UpgradeError();
         }
         if (n != 0) {
-            throw ParserError("Parser error");
+            throw ParserError();
         }
         if (closing) {
             delete this;

--- a/src/http/response_parser.hpp
+++ b/src/http/response_parser.hpp
@@ -6,6 +6,7 @@
 #define MEASUREMENT_KIT_HTTP_RESPONSE_PARSER_HPP
 
 #include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/http/error.hpp>
 
 #include <functional>
 #include <iosfwd>
@@ -22,28 +23,6 @@ namespace http {
 
 using namespace measurement_kit::common;
 using namespace measurement_kit::net;
-
-/*!
- * \brief Raised when the parser receives the UPGRADE method.
- * \remark This should not happen.
- */
-struct UpgradeError : public std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
-
-/*!
- * \brief Raised when readline() fails because the line is too long.
- */
-struct ReadlineError : public std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
-
-/*!
- * \brief Raised when a parse error is detected.
- */
-struct ParserError : public std::runtime_error {
-    using std::runtime_error::runtime_error;
-};
 
 class ResponseParserImpl; // See http.cpp
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -28,8 +28,6 @@ void Connection::handle_read(bufferevent *bev, void *opaque) {
         self->emit_data(buff);
     } catch (Error &error) {
         self->emit_error(error);
-    } catch (std::runtime_error &) {
-        self->emit_error(GenericError());  // XXX
     }
 }
 
@@ -40,8 +38,6 @@ void Connection::handle_write(bufferevent *bev, void *opaque) {
         self->emit_flush();
     } catch (Error &error) {
         self->emit_error(error);
-    } catch (std::runtime_error &) {
-        self->emit_error(GenericError()); // XXX
     }
 }
 

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -24,13 +24,25 @@ void Connection::handle_read(bufferevent *bev, void *opaque) {
     auto self = (Connection *)opaque;
     (void)bev; // Suppress warning about unused variable
     Buffer buff(bufferevent_get_input(self->bev));
-    self->emit_data(buff);
+    try {
+        self->emit_data(buff);
+    } catch (Error &error) {
+        self->emit_error(error);
+    } catch (std::runtime_error &) {
+        self->emit_error(GenericError());  // XXX
+    }
 }
 
 void Connection::handle_write(bufferevent *bev, void *opaque) {
     auto self = (Connection *)opaque;
     (void)bev; // Suppress warning about unused variable
-    self->emit_flush();
+    try {
+        self->emit_flush();
+    } catch (Error &error) {
+        self->emit_error(error);
+    } catch (std::runtime_error &) {
+        self->emit_error(GenericError()); // XXX
+    }
 }
 
 void Connection::handle_event(bufferevent *bev, short what, void *opaque) {

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -13,7 +13,7 @@ using namespace measurement_kit::ooni;
 
 TEST_CASE("The HTTP Invalid Request Line test should run") {
     Settings options;
-    options["backend"] = "http://google.com/";
+    options["backend"] = "http://213.138.109.232/";
     HTTPInvalidRequestLine http_invalid_request_line(options);
     http_invalid_request_line.begin([&]() {
         http_invalid_request_line.end([]() { measurement_kit::break_loop(); });

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -24,6 +24,15 @@ TEST_CASE("Synchronous http-invalid-request-line test") {
     for (auto &s : *logs) std::cout << s << "\n";
 }
 
+TEST_CASE("Synchronous http-invalid-request-line test with HTTP backend") {
+    Var<std::list<std::string>> logs(new std::list<std::string>);
+    ooni::HttpInvalidRequestLineTest()
+        .set_backend("http://data.neubot.org/") // Let's troll Davide!
+        .on_log([=](const char *s) { logs->push_back(s); })
+        .run();
+    for (auto &s : *logs) std::cout << s << "\n";
+}
+
 TEST_CASE("Asynchronous http-invalid-request-line test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     bool done = false;

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -18,7 +18,7 @@ using namespace measurement_kit;
 TEST_CASE("Synchronous http-invalid-request-line test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     ooni::HttpInvalidRequestLineTest()
-        .set_backend("http://nexa.polito.it/")
+        .set_backend("http://213.138.109.232/")
         .on_log([=](const char *s) { logs->push_back(s); })
         .run();
     for (auto &s : *logs) std::cout << s << "\n";
@@ -28,7 +28,7 @@ TEST_CASE("Asynchronous http-invalid-request-line test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     bool done = false;
     ooni::HttpInvalidRequestLineTest()
-        .set_backend("http://nexa.polito.it/")
+        .set_backend("http://213.138.109.232/")
         .on_log([=](const char *s) { logs->push_back(s); })
         .run([&done]() { done = true; });
     do {


### PR DESCRIPTION
This diff is the starting point to fix http-invalid-request-line test when the backend used is an echo server rather than a properly working HTTP server.

So far, I've changed the backend address according to what is indicated in #101. Then, I've added code to route errors in the read and write callbacks of the stream. I think this is a better approach than the other branch that I opened, in which I was rewriting too much of HTTP too close to the release.

The diff works (meaning that routing exceptions prevent the exception thrown by the http-parser to terminate the test). However, I think more is needed to have something mergeable.

Specifically:

1. two new errors should be added to `include/measurement_kit/common/error.hpp`: one should represent a runtime exception received when reading, the other should represent a runtime exception received when writing

2. the code in this pull request should be modified to throw the two exceptions defined in step 1 respectively in the reading and in the writing case (this removing the need to XXX the code)

3. a new file should be added to the `include/measurement_kit/http` folder and should be called `error.hpp` for symmetry with other parts of measurement-kit

4. inside this file we shall move the errors currently defined in `src/http/response_parser.hpp` and furthermore such errors should inherit from `measurement_kit::common::Error` rather than from `std::runtime_error`, i.e. this `error.hpp` file should be similar to `net/error.hpp` or `dns/error.hpp`

5. we should make sure that all the errors that were defined by the parsing code are actually used and unused errors should be removed from `http/error.hpp`

6. we should use Valgrind to make sure that there are no memory errors introduced by the code that routes the exceptions (http code is still fragile); to this end it would probably suffice to test with Valgrind the http-invalid-request-line test because it triggers that behavior, but to be safe I'd also check other http-related regress tests

7. make sure that (and possibly add regress tests) the http-invalid-request-line test reports success if the response is exactly what was sent (this brings the question of how to get the content of the buffer that caused the http parser to freak out, which can probably be done through the http stream and the related transport) and failure otherwise

Closes #101.