### PR TITLE
Partial fix for issue 101

### DIFF
--- a/test/fixtures/hosts.txt
+++ b/test/fixtures/hosts.txt
@@ -1,3 +1,10 @@
 torproject.org
 ooni.nu
 neubot.org
+archive.org
+creativecommons.org
+cyber.law.harvard.edu
+duckduckgo.com
+netflix.com
+nmap.org
+www.emule.com

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -15,7 +15,7 @@ TEST_CASE(
     "The DNS Injection test should run with an input file of DNS hostnames") {
     measurement_kit::set_verbose(1);
     Settings options;
-    options["nameserver"] = "8.8.8.8:53";
+    options["nameserver"] = "8.8.8.1:53";
     DNSInjection dns_injection("test/fixtures/hosts.txt", options);
     dns_injection.begin(
         [&]() { dns_injection.end([]() { measurement_kit::break_loop(); }); });
@@ -26,7 +26,7 @@ TEST_CASE("The DNS Injection test should throw an exception if an invalid file "
           "path is given") {
     measurement_kit::set_verbose(1);
     Settings options;
-    options["nameserver"] = "8.8.8.8:53";
+    options["nameserver"] = "8.8.8.1:53";
     REQUIRE_THROWS_AS(DNSInjection dns_injection(
                           "/tmp/this-file-does-not-exist.txt", options),
                       InputFileDoesNotExist);
@@ -36,7 +36,7 @@ TEST_CASE("The DNS Injection test should throw an exception if no file path is "
           "given") {
     measurement_kit::set_verbose(1);
     Settings options;
-    options["nameserver"] = "8.8.8.8:53";
+    options["nameserver"] = "8.8.8.1:53";
     REQUIRE_THROWS_AS(DNSInjection dns_injection("", options),
                       InputFileRequired);
 }

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -18,7 +18,7 @@ using namespace measurement_kit;
 TEST_CASE("Synchronous dns-injection test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     ooni::DnsInjectionTest()
-        .set_backend("8.8.8.8:53")
+        .set_backend("8.8.8.1:53")
         .set_input_file_path("test/fixtures/hosts.txt")
         .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
@@ -30,7 +30,7 @@ TEST_CASE("Asynchronous dns-injection test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     bool done = false;
     ooni::DnsInjectionTest()
-        .set_backend("8.8.8.8:53")
+        .set_backend("8.8.8.1:53")
         .set_input_file_path("test/fixtures/hosts.txt")
         .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })


### PR DESCRIPTION
This goes as far as possible in fixing #101 without triggering travis-ci errors. While working on this we discovered, in fact, that the http-invalid-request-line test required more massaging to deal with a backend that does not speak http. Further changes to deal with this breakage and finally make sure that all the regress tests use the correct address are in #253.