### PR TITLE
Repair coveralls and improve build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,17 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y --force-yes gcc-4.8 g++-4.8
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 90
   - sudo apt-get install tor
   - pip install --user cpp-coveralls
 
 install: autoreconf -i
 
+# Only measure coverage with clang for now because I cannot manage to
+# convince coveralls to find all sources when using gcc-4.8 and gcov-4.8
+# (For more context see measurement-kit/measurement-kit#255)
 script:
   - if [ "$CXX" = "clang++" ]; then
       ./configure -q CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage;
@@ -21,7 +26,7 @@ script:
 
 after_success:
   - if [ "$CXX" = "clang++" ]; then
-      coveralls --exclude src/ext;
+      coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext;
     fi
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ script:
   - make -j2 V=0
   - make -j2 check-am V=0
 
+# Silence gcov standard output since it produces way too much output
 after_success:
   - if [ "$CXX" = "clang++" ]; then
-      coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext;
+      coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext > /dev/null;
     fi
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
@@ -6,13 +7,23 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo apt-get install tor
   - pip install --user cpp-coveralls
+
 install: autoreconf -i
+
 script:
-  - ./configure -q CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage
+  - if [ "$CXX" = "clang++" ]; then
+      ./configure -q CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage;
+    else
+      ./configure -q;
+    fi
   - make -j2 V=0
   - make -j2 check-am V=0
+
 after_success:
-  - coveralls --exclude src/ext
+  - if [ "$CXX" = "clang++" ]; then
+      coveralls --exclude src/ext;
+    fi
+
 compiler:
   - clang
   - g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ before_install:
   - sudo apt-get install tor
   - pip install --user cpp-coveralls
 install: autoreconf -i
-script: ./configure CFLAGS=--coverage CPPFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage && make -j2 V=0 && make -j2 check-am V=0
+script:
+  - ./configure -q CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage
+  - make -j2 V=0
+  - make -j2 check-am V=0
 after_success:
-  - if [ "$CXX" == "g++" ]; then coveralls --exclude src/ext; fi
+  - coveralls --exclude src/ext
 compiler:
   - clang
   - g++

--- a/configure.ac
+++ b/configure.ac
@@ -202,8 +202,6 @@ if test "$measurement_kit_boost_path"x = "builtin"x; then
     CPPFLAGS="$CPPFLAGS -I \$(top_srcdir)/src/ext/boost/utility/include"
 fi
 
-
-
 # Step 1: process --with-yaml-cpp and set measurement_kit_yamlcpp_path accordingly
 measurement_kit_yamlcpp_path=
 AC_ARG_WITH([yaml-cpp],
@@ -261,8 +259,6 @@ if test "$measurement_kit_yamlcpp_path"x = "builtin"x; then
 fi
 AM_CONDITIONAL([USE_BUILTIN_YAMLCPP],
     [test "$measurement_kit_yamlcpp_path"x = "builtin"x])
-
-
 
 # checks for header files
 # checks for types
@@ -324,24 +320,13 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <functional>],
 CXXFLAGS="$measurement_kit_saved_cxxflags $measurement_kit_cxx_stdlib_flags"
 AC_LANG_POP([C++])
 
-measurement_kit_saved_cxxflags="$CXXFLAGS"
-CXXFLAGS="-Werror -Wmissing-prototypes"
-measurement_kit_cxx_stdlib_flags=""
-AC_MSG_CHECKING([whether the C++ compiler supports -Wmissing-prototypes])
-AC_LANG_PUSH([C++])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <string>]
-                                    [std::string s;]])],
-    [
-     AC_MSG_RESULT([yes])
-     measurement_kit_cxx_missing_prototypes="-Wmissing-prototypes"
-    ]
-    [],
-    [
-     AC_MSG_RESULT([no])
-    ]
-)
-CXXFLAGS="$measurement_kit_saved_cxxflags $measurement_kit_cxx_missing_prototypes"
-AC_LANG_POP([C++])
+AC_MSG_CHECKING([whether the C++ compiler is clang++])
+if test echo | $CXX -dM -E - | grep __clang__ > /dev/null; then
+    AC_MSG_RESULT([yes])
+    CXXFLAGS="$CXXFLAGS -Wmissing-prototypes"
+else
+    AC_MSG_RESULT([yes])
+fi
 
 # checks for library functions
 # checks for system services
@@ -349,3 +334,11 @@ AC_LANG_POP([C++])
 AC_CONFIG_FILES([Makefile])
 
 AC_OUTPUT
+
+echo "==== configured variables ==="
+echo "CC       : $CC"
+echo "CXX      : $CXX"
+echo "CFLAGS   : $CFLAGS"
+echo "CPPFLAGS : $CPPFLAGS"
+echo "CXXFLAGS : $CXXFLAGS"
+echo "LDFLAGS  : $LDFLAGS"

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -33,7 +33,7 @@ if USE_BUILTIN_YAMLCPP
     lib_LTLIBRARIES += src/ext/libyaml-cpp.la
 
     # Adapt CXXFLAGS to yaml-cpp:
-    src_ext_libyaml_cpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations -Wno-missing-prototypes
+    src_ext_libyaml_cpp_la_CXXFLAGS = $(AM_CXXFLAGS) -Wno-deprecated-declarations
 
     src_ext_libyaml_cpp_la_SOURCES = \
 	src/ext/yaml-cpp/src/stream.cpp \

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -20,7 +20,6 @@ using namespace measurement_kit::ooni;
 static void run_http_invalid_request_line(Async &async) {
     async.run_test(HttpInvalidRequestLineTest()
                        .set_backend("http://nexa.polito.it/")
-                       .set_verbose()
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #1: %s\n", s);
                        })
@@ -35,7 +34,6 @@ static void run_dns_injection(Async &async) {
     async.run_test(DnsInjectionTest()
                        .set_backend("8.8.8.8:53")
                        .set_input_file_path("test/fixtures/hosts.txt")
-                       .set_verbose()
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #3: %s\n", s);
                        })
@@ -50,7 +48,6 @@ static void run_tcp_connect(Async &async) {
     async.run_test(TcpConnectTest()
                        .set_port("80")
                        .set_input_file_path("test/fixtures/hosts.txt")
-                       .set_verbose()
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #4: %s\n", s);
                        })
@@ -63,7 +60,6 @@ static void run_tcp_connect(Async &async) {
 
 TEST_CASE("The async engine works as expected") {
 
-    measurement_kit::set_verbose(1);
     Async async;
 
     for (int i = 0; i < 4; ++i) {

--- a/test/http/client.cpp
+++ b/test/http/client.cpp
@@ -17,7 +17,6 @@ using namespace measurement_kit::net;
 using namespace measurement_kit::http;
 
 TEST_CASE("HTTP Client works as expected") {
-    // measurement_kit::set_verbose(1);
     auto client = Client();
     auto count = 0;
 
@@ -78,7 +77,6 @@ TEST_CASE("HTTP Client works as expected") {
 }
 
 TEST_CASE("HTTP Client works as expected over Tor") {
-    measurement_kit::set_verbose(1);
     auto client = Client();
     auto count = 0;
 
@@ -145,7 +143,6 @@ TEST_CASE("HTTP Client works as expected over Tor") {
 }
 
 TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
-    measurement_kit::set_verbose(1);
     auto client = Client();
 
     client.request(
@@ -168,7 +165,6 @@ TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
 }
 
 TEST_CASE("Make sure that settings are not modified") {
-    measurement_kit::set_verbose(1);
     auto client = Client();
 
     Settings settings{

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -19,7 +19,6 @@ using namespace measurement_kit::net;
 using namespace measurement_kit::http;
 
 TEST_CASE("HTTP Request works as expected") {
-    // measurement_kit::set_verbose(1);
     Request r(
         {
          {"url", "http://www.google.com/robots.txt"},
@@ -50,7 +49,6 @@ TEST_CASE("HTTP Request works as expected") {
 }
 
 TEST_CASE("HTTP request behaves correctly when EOF indicates body END") {
-    // measurement_kit::set_verbose(1);
 
     auto called = 0;
 
@@ -90,7 +88,6 @@ TEST_CASE("HTTP request behaves correctly when EOF indicates body END") {
 }
 
 TEST_CASE("HTTP Request correctly receives errors") {
-    measurement_kit::set_verbose(1);
     Request r(
         {
          {"url", "http://nexa.polito.it:81/robots.txt"},
@@ -122,7 +119,6 @@ TEST_CASE("HTTP Request correctly receives errors") {
 }
 
 TEST_CASE("HTTP Request works as expected over Tor") {
-    measurement_kit::set_verbose(1);
     Request r(
         {
          {"url", "http://www.google.com/robots.txt"},
@@ -154,7 +150,6 @@ TEST_CASE("HTTP Request works as expected over Tor") {
 }
 
 TEST_CASE("Behavior is correct when only tor_socks_port is specified") {
-    // measurement_kit::set_verbose(1);
 
     Settings settings{
         {"method", "POST"},
@@ -189,7 +184,6 @@ TEST_CASE("Behavior is correct when only tor_socks_port is specified") {
 }
 
 TEST_CASE("Behavior is correct with both tor_socks_port and socks5_proxy") {
-    // measurement_kit::set_verbose(1);
 
     Settings settings{
         {"method", "POST"},
@@ -225,7 +219,6 @@ TEST_CASE("Behavior is correct with both tor_socks_port and socks5_proxy") {
 }
 
 TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
-    // measurement_kit::set_verbose(1);
 
     Settings settings{
         {"method", "POST"},
@@ -260,7 +253,6 @@ TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
 }
 
 TEST_CASE("Behavior is OK w/o tor_socks_port and socks5_proxy") {
-    // measurement_kit::set_verbose(1);
 
     Settings settings{
         {"method", "POST"}, {"http_version", "HTTP/1.1"},

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -16,8 +16,6 @@ using namespace measurement_kit::http;
 
 TEST_CASE("We don't leak when we receive an invalid message") {
 
-    // measurement_kit::set_verbose(1);
-
     ResponseParser parser;
     std::string data;
 
@@ -40,8 +38,6 @@ TEST_CASE("We don't leak when we receive an invalid message") {
 }
 
 TEST_CASE("We don't leak when we receive a UPGRADE") {
-
-    // measurement_kit::set_verbose(1);
 
     ResponseParser parser;
     std::string data;
@@ -68,8 +64,6 @@ TEST_CASE("The HTTP response parser works as expected") {
     auto data = std::string();
     auto parser = ResponseParser();
     auto body = std::string();
-
-    /*measurement_kit::set_verbose(1);*/
 
     //
     // Request #1
@@ -156,8 +150,6 @@ TEST_CASE("Response parser eof() does not trigger immediate distruction") {
     // not trigger a crash because the real parser should understand
     // that it is parsing and should delay its destruction.
     //
-
-    // measurement_kit::set_verbose(1);
 
     auto parser = new ResponseParser();
     std::string data;

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -23,7 +23,6 @@ TEST_CASE("HTTP stream works as expected") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    // measurement_kit::set_verbose(1);
     auto stream = std::make_shared<Stream>(Settings{
         {"address", "www.google.com"}, {"port", "80"},
     });
@@ -59,8 +58,6 @@ TEST_CASE("HTTP stream works as expected") {
 }
 
 TEST_CASE("HTTP stream is robust to EOF") {
-
-    // measurement_kit::set_verbose(1);
 
     // We simulate the receipt of a message terminated by EOF followed by
     // an EOF so that stream emits in sequence "end" followed by "error(0)"
@@ -98,7 +95,6 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    measurement_kit::set_verbose(1);
     auto stream = std::make_shared<Stream>(Settings{
         {"address", "www.google.com"},
         {"port", "80"},
@@ -145,7 +141,6 @@ TEST_CASE("HTTP stream receives connection errors") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    // measurement_kit::set_verbose(1);
     auto stream = std::make_shared<Stream>(Settings{
         {"address", "nexa.polito.it"}, {"port", "81"},
     });

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -62,7 +62,6 @@ TEST_CASE("It is safe to close Connection while resolve is in progress") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    measurement_kit::set_verbose(1);
     Connection s("PF_INET", "nexa.polito.it", "80");
     DelayedCall unsched(0.001, [&s]() { s.close(); });
     DelayedCall bail_out(2.0, []() { measurement_kit::break_loop(); });
@@ -73,7 +72,6 @@ TEST_CASE("connect() iterates over all the available addresses") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    measurement_kit::set_verbose(1);
     Connection s("PF_UNSPEC", "www.youtube.com", "81");
     s.set_timeout(5);
     s.on_error([](Error error) {
@@ -89,7 +87,6 @@ TEST_CASE("It is possible to use Connection with a custom poller") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    measurement_kit::set_verbose(1);
     Poller poller;
     Connection s("PF_UNSPEC", "nexa.polito.it", "22", Logger::global(),
                  &poller);

--- a/test/net/transport.cpp
+++ b/test/net/transport.cpp
@@ -18,7 +18,6 @@ TEST_CASE("It is possible to use Transport with a custom poller") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    //measurement_kit::set_verbose(1);
     Poller poller;
     Maybe<Var<Transport>> maybe_s = measurement_kit::net::connect({
         {"family", "PF_UNSPEC"},

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -13,7 +13,6 @@ using namespace measurement_kit::ooni;
 
 TEST_CASE(
     "The DNS Injection test should run with an input file of DNS hostnames") {
-    measurement_kit::set_verbose(1);
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
     DNSInjection dns_injection("test/fixtures/hosts.txt", options);
@@ -24,7 +23,6 @@ TEST_CASE(
 
 TEST_CASE("The DNS Injection test should throw an exception if an invalid file "
           "path is given") {
-    measurement_kit::set_verbose(1);
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
     REQUIRE_THROWS_AS(DNSInjection dns_injection(
@@ -34,7 +32,6 @@ TEST_CASE("The DNS Injection test should throw an exception if an invalid file "
 
 TEST_CASE("The DNS Injection test should throw an exception if no file path is "
           "given") {
-    measurement_kit::set_verbose(1);
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
     REQUIRE_THROWS_AS(DNSInjection dns_injection("", options),

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -20,7 +20,6 @@ TEST_CASE("Synchronous dns-injection test") {
     ooni::DnsInjectionTest()
         .set_backend("8.8.8.1:53")
         .set_input_file_path("test/fixtures/hosts.txt")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run();
     for (auto &s : *logs) std::cout << s << "\n";
@@ -32,7 +31,6 @@ TEST_CASE("Asynchronous dns-injection test") {
     ooni::DnsInjectionTest()
         .set_backend("8.8.8.1:53")
         .set_input_file_path("test/fixtures/hosts.txt")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run([&]() { done = true; });
     do {

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -12,7 +12,6 @@ using namespace measurement_kit::common;
 using namespace measurement_kit::ooni;
 
 TEST_CASE("The HTTP Invalid Request Line test should run") {
-    measurement_kit::set_verbose(1);
     Settings options;
     options["backend"] = "http://google.com/";
     HTTPInvalidRequestLine http_invalid_request_line(options);

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -19,7 +19,6 @@ TEST_CASE("Synchronous http-invalid-request-line test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     ooni::HttpInvalidRequestLineTest()
         .set_backend("http://nexa.polito.it/")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run();
     for (auto &s : *logs) std::cout << s << "\n";
@@ -30,7 +29,6 @@ TEST_CASE("Asynchronous http-invalid-request-line test") {
     bool done = false;
     ooni::HttpInvalidRequestLineTest()
         .set_backend("http://nexa.polito.it/")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run([&done]() { done = true; });
     do {

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -13,7 +13,6 @@ using namespace measurement_kit::ooni;
 
 TEST_CASE(
     "The TCP connect test should run with an input file of DNS hostnames") {
-    measurement_kit::set_verbose(1);
     TCPConnect tcp_connect("test/fixtures/hosts.txt", {
                                                        {"port", "80"},
                                                       });
@@ -31,6 +30,5 @@ TEST_CASE("The TCP connect test should throw an exception if an invalid file "
 
 TEST_CASE(
     "The TCP connect test should throw an exception if no file path is given") {
-    measurement_kit::set_verbose(1);
     REQUIRE_THROWS_AS(TCPConnect("", Settings()), InputFileRequired);
 }

--- a/test/ooni/tcp_connect_test.cpp
+++ b/test/ooni/tcp_connect_test.cpp
@@ -20,7 +20,6 @@ TEST_CASE("Synchronous tcp-connect test") {
     ooni::TcpConnectTest()
         .set_port("80")
         .set_input_file_path("test/fixtures/hosts.txt")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run();
     for (auto &s : *logs) std::cout << s << "\n";
@@ -32,7 +31,6 @@ TEST_CASE("Asynchronous tcp-connect test") {
     ooni::TcpConnectTest()
         .set_port("80")
         .set_input_file_path("test/fixtures/hosts.txt")
-        .set_verbose()
         .on_log([=](const char *s) { logs->push_back(s); })
         .run([&done]() { done = true; });
     do {

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -15,7 +15,6 @@ using namespace measurement_kit::ooni;
 
 TEST_CASE("TCPTest test should run") {
 #if 0
-    measurement_kit::set_verbose(1);
 
     auto client = TCPClient("www.torproject.org", "80");
 
@@ -50,7 +49,6 @@ TEST_CASE("TCPTest test should run") {
 }
 
 TEST_CASE("TCPTest works as expected in a common case") {
-    measurement_kit::set_verbose(1);
 
     auto count = 0;
     TCPTest tcp_test("", Settings());


### PR DESCRIPTION
Start to repair coveralls and improve the build process. Work done so far:

- travis: split build command on multiple lines

- configure.ac: recognize clang++

- yaml-cpp: zap -Wno-missing-prototypes flag

- run quiet configure with summary at the end

- revert "Teach travis to send one time the coverage reports"  (712602c5da)

- reduce verbosity of all tests

Work to do before we can merge this pull request:

- apparently coveralls segfaults for gcc builds because of a version mismatch between the compiler (v4.8) and some other unspecified utility (v4.6): find a fix for that

- find a way to teach coveralls to produce less output than this, because this is too much