### PR TITLE
allow to set std::function<> from a lambda stored inside such function

### DIFF
--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -1,11 +1,11 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
 #ifndef MEASUREMENT_KIT_COMMON_LOGGER_HPP
 #define MEASUREMENT_KIT_COMMON_LOGGER_HPP
 
 #include <measurement_kit/common/constraints.hpp>
+#include <measurement_kit/common/funcs.hpp>
 
 #include <functional>
 #include <stdarg.h>
@@ -64,7 +64,7 @@ class Logger : public NonCopyable, public NonMovable {
     }
 
   private:
-    std::function<void(const char *)> consumer_;
+    SafelyOverridableFunc<void(const char *)> consumer_;
     int verbose_ = 0;
     char buffer_[32768];
 };

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -6,6 +6,7 @@
 #define MEASUREMENT_KIT_COMMON_POLLER_HPP
 
 #include <measurement_kit/common/constraints.hpp>
+#include <measurement_kit/common/funcs.hpp>
 #include <measurement_kit/common/libs.hpp>
 
 #include <functional>
@@ -76,7 +77,7 @@ class Poller : public NonCopyable, public NonMovable {
     event_base *base_;
     evdns_base *dnsbase_;
     Libs *libs_ = get_global_libs();
-    std::function<void(Poller *)> periodic_cb_;
+    SafelyOverridableFunc<void(Poller *)> periodic_cb_;
 };
 
 /*

--- a/include/measurement_kit/traceroute/android.hpp
+++ b/include/measurement_kit/traceroute/android.hpp
@@ -37,9 +37,7 @@
 // This is meant to run on Android but can run on all Linux systems
 #ifdef __linux__
 
-#include <measurement_kit/common/constraints.hpp>
-#include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/poller.hpp>
+#include <measurement_kit/common.hpp>
 #include <measurement_kit/traceroute/interface.hpp>
 
 #include <functional>
@@ -101,9 +99,9 @@ class AndroidProber : public NonCopyable,
     int port_ = 0;                 ///< socket port
     Logger *logger = Logger::global();///< logger
 
-    std::function<void(ProbeResult)> result_cb_;  ///< on result callback
-    std::function<void()> timeout_cb_;            ///< on timeout callback
-    std::function<void(Error)> error_cb_; ///< on error callback
+    SafelyOverridableFunc<void(ProbeResult)> result_cb_;  ///< on result callback
+    SafelyOverridableFunc<void()> timeout_cb_;            ///< on timeout callback
+    SafelyOverridableFunc<void(Error)> error_cb_;         ///< on error callback
 
     /// Call this when you don't receive a response within timeout
     void on_timeout() { probe_pending_ = false; }


### PR DESCRIPTION
Closes #111.

Not ready yet. Started working on this with @AntonioLangiu and created a template function that provides syntactic sugar for calling std::functions as demonstrated in #111. More work to be done before we can actually merge this into master. Specifically:

- need to check existing code

- need to use safe_call() in all the places in which a std::function is bound to an object that allows with another method to set the value of the std::function itself

- verify with valgrind

- possibly write more regress tests