### PR TITLE
Create tarballs of the Android build

### DIFF
--- a/mobile/android/.gitignore
+++ b/mobile/android/.gitignore
@@ -1,0 +1,1 @@
+measurement_kit-jni-*.tar.bz2

--- a/mobile/android/scripts/build_target.sh
+++ b/mobile/android/scripts/build_target.sh
@@ -98,4 +98,7 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib${LIB_SUFFIX} -L${ANDROID_TOOLCHA
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/*.la
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/libevent_core.a
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/libevent_extra.a
+    echo "Creating tarball of ${BASEDIR}/jni/${DESTDIR_NAME}"
+    cd ${ROOTDIR} && ./scripts/make_archive.sh jni-${DESTDIR_NAME} \
+            jni/${DESTDIR_NAME}
 )

--- a/mobile/android/scripts/make_archive.sh
+++ b/mobile/android/scripts/make_archive.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+if [ $# -ne 2 ]; then
+    echo "usage: $0 flavour srcdir" 1>&2
+    exit 1
+fi
+flavour=$1
+srcdir=$2
+version=`git describe --tags`
+tar -cjf measurement_kit-$flavour-$version.tar.bz2 $srcdir/


### PR DESCRIPTION
This should be merged after #274. It creates compressed tarballs of the build. I have plans to publish these tarballs along with the release so that Apps can integrate them.

Closes #268.