### PR TITLE
Improve Android build process

### DIFF
--- a/mobile/android/README.md
+++ b/mobile/android/README.md
@@ -25,64 +25,53 @@ Just type the following:
 
     $ brew install android-ndk
 
-## Creating a custom toolchain
+## Cross compiling MeasurementKit for Android
 
-Next, you need to [create a custom toolchain](
-http://www.kandroid.org/ndk/docs/STANDALONE-TOOLCHAIN.html)
-for the platform and API level that you want to target
-using the `./scripts/make_toolchain.sh` command.
+The `./scripts/build.sh` script allows to create the required custom
+toolchains and to cross-compile MeasurementKit for all the architectures
+available for Android. If you run the script without arguments, it will
+print the options it accepts and the available Android architectures for
+which you can cross compile:
 
-### On Linux
+    $ ./scripts/build.sh
+    [prints usage]
 
-The following command creates a standalone
-toolchain in `./toolchain/` for ARM-based Android devices
-using API level 9 (i.e., Android 2.3).
-
-    $ ./scripts/make_toolchain.sh $HOME/Android/android-ndk-r10e/ arm-linux-androideabi 9
-
-The first argument is the path where NDK r10e is installed, the second
-argument is the cross compiler type, the third argument is the API level.
-
-### On MacOS using brew
-
-The following command creates a standalone
-toolchain in `./toolchain/` for ARM-based Android devices
-using API level 9 (i.e., Android 2.3).
-
-    $ ./scripts/make_toolchain.sh /usr/local/Cellar/android-ndk/r10e/ arm-linux-androideabi 9
-
-The first argument is the path where NDK r10e is installed, the second
-argument is the cross compiler type, the third argument is the API level.
-
-## Cross-compiling
-
-Once you created a custom toolchain, you can cross compile
-measurement-kit using that toolchain using the `./scripts/build_target.sh`
-script, which accepts as command line parameters the cross compiler
-type and the API level. For example,
-
-    $ ./scripts/build_target.sh arm-linux-androideabi 9
-
-this script cross compiles measurement-kit under `./build` and puts
-the compiled libraries and haders under `./dist`.
-
-## Putting all together
-
-You can execute both steps (creating a cross compiler and cross compiling) in
-a single command using the `./scripts/build.sh` script. For example,
-
-    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ arm-linux-androideabi 9
-
-To build for all supported architectures, just omit the architecture:
-
-    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ 9
-
-If you omit API, 21 is used by default:
+To cross-compile for all available architectures you need to tell the
+script where did you install the NDK. For example, on MacOS you can use
+the following command line:
 
     $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/
 
-## TODO next
+The above command compiles for Android with API 21. You can compile
+for another API by providing the API number as the second argument on
+the command line:
 
-What is missing to continue this work is to compile and link
-with measurement-kit and all its dependencies JNI code that can be
-accessed from Java to use measurement-kit.
+    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ 20
+
+If you want to compile only for a specific architecture, add it before
+the API number on the command line:
+
+    $ ./scripts/build.sh /usr/local/Cellar/android-ndk/r10e/ \
+                         arm-linux-androideabi 20
+
+In the above examples we have shown the path to the Android NDK on MacOS. If
+you followed the instructions for Linux, you should have written instead:
+
+    $ ./scripts/build.sh $HOME/Android/android-ndk-r10e/ [options...]
+
+This script is implemented by two helper scripts respectively called
+`./scripts/make_toolchain.sh` and `./scripts/build_arch.sh`. The former
+[creates a standalone cross-toolchain](
+http://www.kandroid.org/ndk/docs/STANDALONE-TOOLCHAIN.html)
+for a specific Android arch. The
+latter cross-compiles MeasurementKit for the selected arch.
+
+## Create the final archive
+
+Run this command to create the final archive:
+
+    $ ./scripts/make_archive.sh
+
+Then use GPG to sign the release and publish it on GitHub:
+
+    $ gpg --sign --armor -b $tarball

--- a/mobile/android/scripts/build_target.sh
+++ b/mobile/android/scripts/build_target.sh
@@ -98,7 +98,4 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib${LIB_SUFFIX} -L${ANDROID_TOOLCHA
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/*.la
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/libevent_core.a
     rm -rf ${ROOTDIR}/jni/${DESTDIR_NAME}/libevent_extra.a
-    echo "Creating tarball of ${BASEDIR}/jni/${DESTDIR_NAME}"
-    cd ${ROOTDIR} && ./scripts/make_archive.sh jni-${DESTDIR_NAME} \
-            jni/${DESTDIR_NAME}
 )

--- a/mobile/android/scripts/make_archive.sh
+++ b/mobile/android/scripts/make_archive.sh
@@ -1,9 +1,3 @@
 #!/bin/sh -e
-if [ $# -ne 2 ]; then
-    echo "usage: $0 flavour srcdir" 1>&2
-    exit 1
-fi
-flavour=$1
-srcdir=$2
 version=`git describe --tags`
-tar -cjf measurement_kit-$flavour-$version.tar.bz2 $srcdir/
+tar -cjf measurement_kit-jni-$version.tar.bz2 jni/


### PR DESCRIPTION
This is same as #278 except that bikeshedding is removed :-)

- - -

- simplify README.md

- document creation of the tarball

- simplify make_archive.sh

- do not call make_archive.sh from build_target.sh

The rationale of these changes is that:

- the compiled libraries are small (around 7 MiB so we can put everything into a single compressed tarball)

- if we do that, it's simpler to sign the tarball and also given how github releases work it's simpler to download a release