### PR TITLE
Rename and simplify namespaces (issue #284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,9 @@ of the same thread that called *run*).
 
 ```C++
 #include <measurement_kit/ooni.hpp>
-using namespace measurement_kit;
 
 // Run sync test
-ooni::HttpInvalidRequestLineTest()
+mk::ooni::HttpInvalidRequestLineTest()
     .set_backend("http://127.0.0.1/")
     .set_verbose()
     .on_log([](const char *s) {
@@ -216,7 +215,7 @@ the callback passed as argument to *run* is invoked when the test completed.
 
 ```C++
 // Run async test
-ooni::HttpInvalidRequestLineTest()
+mk::ooni::HttpInvalidRequestLineTest()
     .set_backend("http://127.0.0.1/")
     .set_verbose()
     .on_log([](const char *s) {

--- a/doc/api/c++/common/async.md
+++ b/doc/api/c++/common/async.md
@@ -9,13 +9,10 @@ MeasurementKit (libmeasurement\_kit, -lmeasurement\_kit).
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/foo.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::foo;
-
-Async *async = new Async;
+mk::Async *async = new mk::Async;
 
 void on_run_test() {
-    SharedPointer<FooTest> test = std::make_shared<FooTest>(
+    SharedPointer<mk::FooTest> test = std::make_shared<mk::FooTest>(
         // Test configuration params
     );
     test->set_verbose(1);
@@ -24,7 +21,7 @@ void on_run_test() {
         // its content if you plan to use it at a later time
         // Caution: this callback is called from a background thread
     });
-    async->run_test(test, [](SharedPointer<NetTest> test) {
+    async->run_test(test, [](SharedPointer<mk::NetTest> test) {
         // Do something with the terminated test
         // Caution: this callback is called from a background thread
     });

--- a/doc/api/c++/common/async.md
+++ b/doc/api/c++/common/async.md
@@ -12,7 +12,7 @@ MeasurementKit (libmeasurement\_kit, -lmeasurement\_kit).
 mk::Async *async = new mk::Async;
 
 void on_run_test() {
-    SharedPointer<mk::FooTest> test = std::make_shared<mk::FooTest>(
+    SharedPointer<mk::Foo::Test> test = std::make_shared<mk::Foo::Test>(
         // Test configuration params
     );
     test->set_verbose(1);
@@ -70,4 +70,4 @@ hence the moment in which the background thread is stopped).
 
 # HISTORY
 
-The `Async` class appeared in MeasurementKit 0.1.
+The `Async` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/constraints.md
+++ b/doc/api/c++/common/constraints.md
@@ -2,21 +2,20 @@
 Constraints -- Constraints on copyability and movability
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace foobar {
 
-class Foo : public common::NonCopyable {};
+class Foo : public NonCopyable {};
 
-class Bar : public common::NonMovable {};
+class Bar : public NonMovable {};
 
-class FooBar : public common::NonCopyable,
-               public common::NonMovable {};
+class FooBar : public NonCopyable, public NonMovable {};
 
 }}
 ```

--- a/doc/api/c++/common/constraints.md
+++ b/doc/api/c++/common/constraints.md
@@ -17,7 +17,8 @@ class Bar : public NonMovable {};
 
 class FooBar : public NonCopyable, public NonMovable {};
 
-}}
+}
+}
 ```
 
 # DESCRIPTION
@@ -31,4 +32,4 @@ the specific value of `this` to the registered low-level callback.
 
 # HISTORY
 
-`NonCopyable` and `NonMovable` appeared in MeasurementKit 0.1.
+`NonCopyable` and `NonMovable` appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/error.md
+++ b/doc/api/c++/common/error.md
@@ -22,4 +22,4 @@ and uses exceptions only to report unrecoverable errors.
 
 # HISTORY
 
-The `Error` class appeared in MeasurementKit 0.1.
+The `Error` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/error.md
+++ b/doc/api/c++/common/error.md
@@ -2,19 +2,17 @@
 Error -- Represents an error.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
-Error err = GenericError(); // Assign to error class
-Error err = 17;             // Assign error code
-int code = (int) err;       // Convert error to int
-bool x = (error != 17);     // Implicit conversion here
-bool y = (error == 17);     // Also here
+mk::Error err = mk::GenericError(); // Assign to error class
+mk::Error err = 17;                 // Assign error code
+int code = (int) err;               // Convert error to int
+bool x = (error != 17);             // Implicit conversion here
+bool y = (error == 17);             // Also here
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/common/evbuffer.md
+++ b/doc/api/c++/common/evbuffer.md
@@ -2,15 +2,13 @@
 Evbuffer -- RAII wrapper for libevent evbuffer
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
-Evbuffer evbuf;
+mk::Evbuffer evbuf;
 evbuffer *p = evbuf; // Conversion done automatically
 ```
 

--- a/doc/api/c++/common/evbuffer.md
+++ b/doc/api/c++/common/evbuffer.md
@@ -22,4 +22,4 @@ automatically frees the underlying evbuffer when it goes out of scope.
 
 # HISTORY
 
-The `Evbuffer` class appeared in MeasurementKit 0.1.
+The `Evbuffer` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/libs.md
+++ b/doc/api/c++/common/libs.md
@@ -2,20 +2,18 @@
 Libs -- Wrappers for C libraries functions.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
-
-using namespace measurement_kit::common;
 
 class Foo {
   public:
     // ...
 
   private:
-    Libs *libs_ = get_global_libs();
+    Libs *libs_ = mk::get_global_libs();
 }
 
 ```

--- a/doc/api/c++/common/libs.md
+++ b/doc/api/c++/common/libs.md
@@ -28,4 +28,4 @@ allow to access the default implementation.
 
 # HISTORY
 
-The `Libs` class appeared in MeasurementKit 0.1.
+The `Libs` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/logger.md
+++ b/doc/api/c++/common/logger.md
@@ -37,4 +37,4 @@ a logger specific of each network test.
 
 # HISTORY
 
-The `Logger` class appeared in MeasurementKit 0.1.
+The `Logger` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/logger.md
+++ b/doc/api/c++/common/logger.md
@@ -2,15 +2,13 @@
 Logger -- Log messages processor
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
-Logger logger;              // Log on stderr warn messages only
+mk::Logger logger;          // Log on stderr warn messages only
 
 logger.set_verbose(-1);     // Same as above
 logger.set_verbose(0);      // Only log warning messages
@@ -26,7 +24,7 @@ logger.debug("Format string: %s", "but also arguments");
 logger.info("Just like printf");
 logger.warn("Use this for important messages");
 
-Logger *root = Logger::default();
+mk::Logger *root = mk::Logger::default();
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/common/net_test.md
+++ b/doc/api/c++/common/net_test.md
@@ -8,7 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/common.hpp>
 
-mk::NetTest *test = new foo::SomeNetTest();  // NetTest is abstract
+mk::NetTest *test = new mk::foo::Test();  // NetTest is abstract
 
 // Configure the logger contained by NetTest
 test->on_log([](const char *s) {
@@ -45,4 +45,4 @@ but mentioning it here to warn people using this interface.)
 
 # HISTORY
 
-The `NetTest` class appeared in MeasurementKit 0.1.
+The `NetTest` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/net_test.md
+++ b/doc/api/c++/common/net_test.md
@@ -2,15 +2,13 @@
 NetTest -- Base network test class
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
-NetTest *test = new SomeNetTest();  // NetTest is abstract
+mk::NetTest *test = new foo::SomeNetTest();  // NetTest is abstract
 
 // Configure the logger contained by NetTest
 test->on_log([](const char *s) {

--- a/doc/api/c++/common/poller.md
+++ b/doc/api/c++/common/poller.md
@@ -34,4 +34,4 @@ thread (which is what you typically want for apps).
 
 # HISTORY
 
-The `Poller` class appeared in MeasurementKit 0.1.
+The `Poller` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/poller.md
+++ b/doc/api/c++/common/poller.md
@@ -2,15 +2,13 @@
 Poller -- Dispatcher of I/O events
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
-Poller poller;
+mk::Poller poller;
 event_base *p = poller.get_event_base();
 evdns_base *dp = poller.get_evdns_base();
 
@@ -18,7 +16,7 @@ poller.loop();                    // Blocking method to run the event loop
 poller.break_loop();              // Break out of event loop
 poller.loop_once();               // Just one iteration of event loop
 
-Poller *root = Poller::global();
+mk::Poller *root = mk::Poller::global();
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/common/settings.md
+++ b/doc/api/c++/common/settings.md
@@ -2,14 +2,13 @@
 Settings -- Map from string to string
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
-namespace measurement_kit {
-namespace common {
+namespace mk {
 typedef std::map<std::string, std::string> Settings;
-}}
+}
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/common/settings.md
+++ b/doc/api/c++/common/settings.md
@@ -17,4 +17,4 @@ typedef std::map<std::string, std::string> Settings;
 
 # HISTORY
 
-The `Settings` class appeared in MeasurementKit 0.1.
+The `Settings` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/var.md
+++ b/doc/api/c++/common/var.md
@@ -52,4 +52,4 @@ does not result in object slicing (i.e. in the construction of a
 
 # HISTORY
 
-The `Var` class appeared in MeasurementKit 0.1.
+The `Var` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/common/var.md
+++ b/doc/api/c++/common/var.md
@@ -2,18 +2,16 @@
 Var -- Shared-pointer with JavaScript-var-like semantic
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-
 // Construct as a shared_ptr<T>
 
-Var<T> p;                         // pointer is nullptr
-Var<T> p(new T());                // construct from raw pointer
+mk::Var<T> p;                         // pointer is nullptr
+mk::Var<T> p(new T());                // construct from raw pointer
 
 // The three overriden operations
 
@@ -46,7 +44,7 @@ remember not to add attributes to `Var<T>` implementation. This
 guarantees that the following:
 
 ```C++
-Var<T> p = std::make_shared<T>();
+mk::Var<T> p = std::make_shared<T>();
 ```
 
 does not result in object slicing (i.e. in the construction of a

--- a/doc/api/c++/dns/defines.md
+++ b/doc/api/c++/dns/defines.md
@@ -2,13 +2,13 @@
 Defines -- Define DNS query classes and types
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/dns.hpp>
 
-using namespace measurement_kit::dns;
+using namespace mk::dns;
 
 QueryClassId::IN;           // internet class
 

--- a/doc/api/c++/dns/defines.md
+++ b/doc/api/c++/dns/defines.md
@@ -8,29 +8,27 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/dns.hpp>
 
-using namespace mk::dns;
+mk::dns::QueryClassId::IN;           // internet class
 
-QueryClassId::IN;           // internet class
+mk::dns::QueryTypeId:A;              // name to IPv4 addresses
+mk::dns::QueryTypeId:REVERSE_A;      // IPv4 address to one or more names
+mk::dns::QueryTypeId:AAAA;           // name to IPv6 addresses
+mk::dns::QueryTypeId:REVERSE_AAAA;   // IPv6 address to one or more names
+mk::dns::QueryTypeId:PTR;            // `.arpa` name to name
 
-QueryTypeId:A;              // name to IPv4 addresses
-QueryTypeId:REVERSE_A;      // IPv4 address to one or more names
-QueryTypeId:AAAA;           // name to IPv6 addresses
-QueryTypeId:REVERSE_AAAA;   // IPv6 address to one or more names
-QueryTypeId:PTR;            // `.arpa` name to name
-
-QueryClass c(queryClassId::IN);  // construct from id
-QueryClass cc("IN");             // construct from string
+mk::dns::QueryClass c(mk::dns::queryClassId::IN);  // construct from id
+mk::dns::QueryClass cc("IN");             // construct from string
 assert(c == cc);
-c == QueryClassId::IN;           // equality
-c != QueryClassId::CH;           // unequality
-QueryClassId x = cc;             // automatic cast
+c == mk::dns::QueryClassId::IN;           // equality
+c != mk::dns::QueryClassId::CH;           // unequality
+mk::dns::QueryClassId x = cc;             // automatic cast
 
-QueryType q(QueryTypeId::A);     // construct from id
-QueryType qq("A");               // construct from string
+mk::dns::QueryType q(mk::dns::QueryTypeId::A);     // construct from id
+mk::dns::QueryType qq("A");               // construct from string
 assert(q == qq);
-q == QueryTypeId:A;              // equality
-q != QueryTypeId:MX;             // unequality
-QueryTypeId x = cc;              // automatic cast
+q == mk::dns::QueryTypeId:A;              // equality
+q != mk::dns::QueryTypeId:MX;             // unequality
+mk::dns::QueryTypeId x = cc;              // automatic cast
 
 ```
 
@@ -55,4 +53,4 @@ in the `.in-addr.arpa` or `ip6.arpa` namespaces.
 # HISTORY
 
 The `QueryTypeId`, `QueryType`, `QueryClassId`, and `QueryClass` classes
-appeared in MeasurementKit 0.1.
+appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/dns/error.md
+++ b/doc/api/c++/dns/error.md
@@ -2,13 +2,13 @@
 Error -- DNS library specific errors
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/dns.hpp>
 
-using namespace measurement_kit::dns;
+using namespace mk::dns;
 
 FormatError;               // invalid response format
 ServerFailedError;         // server failure
@@ -23,7 +23,7 @@ CancelError;               // user cancelled query
 NoDataError;               // no data in the response
 
 // Map evdns error code to a DNS error
-common::Error dns_error(int code);
+Error mk::dns::dns_error(int code);
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/dns/error.md
+++ b/doc/api/c++/dns/error.md
@@ -8,22 +8,20 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/dns.hpp>
 
-using namespace mk::dns;
-
-FormatError;               // invalid response format
-ServerFailedError;         // server failure
-NotExistError;             // the name does not exist
-NotImplementedError;       // query not implemented
-RefusedError;              // the server refuses to reply
-TruncatedError;            // response truncated
-UknownError;               // internal evnds error
-TimeoutError;              // query timed out
-ShutdownError;             // evdns library was shut down
-CancelError;               // user cancelled query
-NoDataError;               // no data in the response
+mk::dns::FormatError;               // invalid response format
+mk::dns::ServerFailedError;         // server failure
+mk::dns::NotExistError;             // the name does not exist
+mk::dns::NotImplementedError;       // query not implemented
+mk::dns::RefusedError;              // the server refuses to reply
+mk::dns::TruncatedError;            // response truncated
+mk::dns::UknownError;               // internal evnds error
+mk::dns::TimeoutError;              // query timed out
+mk::dns::ShutdownError;             // evdns library was shut down
+mk::dns::CancelError;               // user cancelled query
+mk::dns::NoDataError;               // no data in the response
 
 // Map evdns error code to a DNS error
-Error mk::dns::dns_error(int code);
+mk::Error mk::dns::dns_error(int err_code);
 ```
 
 # DESCRIPTION
@@ -32,4 +30,4 @@ These are the errors triggered by MeasurementKit DNS library.
 
 # HISTORY
 
-DNS error classes appeared in MeasurementKit 0.1.
+DNS error classes appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/dns/resolver.md
+++ b/doc/api/c++/dns/resolver.md
@@ -2,14 +2,13 @@
 Resolver -- DNS resolver
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
-#include <event2/event.h>
 #include <measurement_kit/dns.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 // Constructs resolver with default settings
 dns::Resolver resolver;
@@ -28,9 +27,7 @@ reso.query(
         "AAAA",                                 // Type of query
         "nexa.polito.it",                       // Name to resolve
         [](Error error, Response response) {    // Callback
-            if (error) {
-                return;
-            }
+            if (error) throw error;
             /* handle successful response */
         });
 ```

--- a/doc/api/c++/dns/resolver.md
+++ b/doc/api/c++/dns/resolver.md
@@ -8,13 +8,11 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/dns.hpp>
 
-using namespace mk;
-
 // Constructs resolver with default settings
-dns::Resolver resolver;
+mk::dns::Resolver resolver;
 
 // Constructs resolver with specific settings
-dns::Resolver reso({
+mk::dns::Resolver reso({
     {"nameserver", "8.8.8.8:53"},  // Set the name server IP
     {"attempts", "1"},             // How many attempts before erroring out
     {"timeout", "3.1415"},         // How many seconds before timeout
@@ -23,12 +21,12 @@ dns::Resolver reso({
 
 // Issue an async DNS query
 reso.query(
-        "IN",                                   // Domain of the query
-        "AAAA",                                 // Type of query
-        "nexa.polito.it",                       // Name to resolve
-        [](Error error, Response response) {    // Callback
+        "IN",                                             // Domain of the query
+        "AAAA",                                           // Type of query
+        "nexa.polito.it",                                 // Name to resolve
+        [](mk::Error error, mk::dns::Response response) { // Callback
             if (error) throw error;
-            /* handle successful response */
+            // handle successful response
         });
 ```
 
@@ -85,4 +83,4 @@ to be either string or numbers, depending on their semantic.
 
 # HISTORY
 
-The `Resolver` class appeared in MeasurementKit 1.0.0.
+The `Resolver` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/dns/response.md
+++ b/doc/api/c++/dns/response.md
@@ -2,14 +2,14 @@
 Response -- DNS response message
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <event2/dns.h>
 #include <measurement_kit/dns.hpp>
 
-using namespace measurement_kit::dns;
+using namespace mk::dns;
 
 Response response;        // by default evdns status is DNS_ERR_UNKNOWN
 

--- a/doc/api/c++/dns/response.md
+++ b/doc/api/c++/dns/response.md
@@ -6,14 +6,11 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
-#include <event2/dns.h>
 #include <measurement_kit/dns.hpp>
 
-using namespace mk::dns;
+mk::dns::Response response; // by default evdns status is DNS_ERR_UNKNOWN
 
-Response response;        // by default evdns status is DNS_ERR_UNKNOWN
-
-Response resp(
+mk::dns::Response resp(
         DNS_ERR_NONE,     // evdns status code
         DNS_TYPE_IPv4,    // evdns type
         n_records,        // number of returned records
@@ -38,10 +35,12 @@ int ttl = resp.get_ttl();
 // Get round trip time
 double rtt = resp.get_rtt();
 
+#include <event2/dns.h> // for DNS_IPv4_A
+
 // Get evdns type
 char type = resp.get_type();
 if (type == DNS_IPv4_A) {
-    /* do something if request was for IPv4 */
+    // do something if request was for IPv4
 }
 ```
 
@@ -63,4 +62,4 @@ to the [evdns implementation](https://github.com/libevent/libevent/blob/master/i
 
 # HISTORY
 
-The `Response` class appeared in MeasurementKit 0.1.
+The `Response` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/http/client.md
+++ b/doc/api/c++/http/client.md
@@ -8,20 +8,18 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace mk;
-
-http::Client client;
+mk::http::Client client;
 
 client.request(
     { 
       "follow_redirects" : "yes",       // default is no
-      "url" : "http://nexa.polito.it/",
+      "url" : "http://nexa.polito.it/", // must be specified
       "method" : "PUT",                 // default is GET
       "path" : "/robots.txt",           // default is to use URL
       "http_version" : "HTTP/1.0"       // default is HTTP/1.1
     },
     {{"Content-Type", "text/plain"}, {"User-Agent", "Antani/1.0"}},
-    "THIS IS THE BODY", [](Error err, http::Response resp) {
+    "THIS IS THE BODY", [](mk::Error err, mk::http::Response resp) {
         if (err) throw err;
         // Process the response
     });
@@ -63,15 +61,6 @@ receives the following arguments:
 Beware that, in case of early error, the callback MAY be called
 immediately by the `request()` method.
 
-# BUGS
-
-In the current implementation, the parser throws an exception that
-is not catched if there is a parse error. Ideally that exception has
-to be properly routed, but the parser code is messy and I think
-the best thing to do is to rewrite the parser. This is to be fixed
-in a successive point release, as the objective of this first release
-was to have a good API.
-
 # HISTORY
 
-The `Response` class appeared in MeasurementKit 1.0.0.
+The `Response` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/http/client.md
+++ b/doc/api/c++/http/client.md
@@ -2,14 +2,13 @@
 Client -- HTTP client.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit;
+using namespace mk;
 
 http::Client client;
 

--- a/doc/api/c++/http/headers.md
+++ b/doc/api/c++/http/headers.md
@@ -8,9 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace mk;
-
-http::Headers headers;
+mk::http::Headers headers;
 ```
 
 # DESCRIPTION
@@ -20,4 +18,4 @@ actually a typedef for `std::map<std::string, std::string>`.
 
 # HISTORY
 
-The `Headers` class appeared in MeasurementKit 0.1.
+The `Headers` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/http/headers.md
+++ b/doc/api/c++/http/headers.md
@@ -2,13 +2,13 @@
 Headers -- HTTP headers.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 http::Headers headers;
 ```
@@ -20,4 +20,4 @@ actually a typedef for `std::map<std::string, std::string>`.
 
 # HISTORY
 
-The `Headers` class appeared in MeasurementKit 1.0.0.
+The `Headers` class appeared in MeasurementKit 0.1.

--- a/doc/api/c++/http/response.md
+++ b/doc/api/c++/http/response.md
@@ -8,15 +8,13 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace mk;
-
-http::Response response;
+mk::http::Response response;
 
 std::string s = response.response_line;
 unsigned short mjr = response.http_major;
 unsigned short mnr = response.http_minor;
 unsigned int sc = response.status_code;
-http::Headers hh = response.headers;
+mk::http::Headers hh = response.headers;
 std::string b = response.body;
 ```
 
@@ -27,4 +25,4 @@ including response line, headers, and body.
 
 # HISTORY
 
-The `Response` class appeared in MeasurementKit 0.1.
+The `Response` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/http/response.md
+++ b/doc/api/c++/http/response.md
@@ -2,13 +2,13 @@
 Response -- HTTP reponse.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/http.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 http::Response response;
 
@@ -27,4 +27,4 @@ including response line, headers, and body.
 
 # HISTORY
 
-The `Response` class appeared in MeasurementKit 1.0.0.
+The `Response` class appeared in MeasurementKit 0.1.

--- a/doc/api/c++/net/buffer.md
+++ b/doc/api/c++/net/buffer.md
@@ -2,15 +2,14 @@
 Buffer - Buffer containing data.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+using namespace mk::net;
 
 // Constructor
 

--- a/doc/api/c++/net/buffer.md
+++ b/doc/api/c++/net/buffer.md
@@ -9,14 +9,12 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace mk::net;
-
 // Constructor
 
-Buffer buf;
+mk::net::Buffer buf;
 
 evbuffer *evbuf = /* something */ ;
-Buffer buf(evbuf);  // Move content from (evbuffer *) evbuf
+mk::net::Buffer buf(evbuf);  // Move content from (evbuffer *) evbuf
 
 // Move data from/to other buffers (this does not entail copies)
 
@@ -33,7 +31,7 @@ size_t n = buf.length();
 
 // Walk over data and decide when to stop by returning false
 buf.for_each([](const char *p, size_t n) -> bool {
-    /* Do something with `p` and `n` */
+    // Do something with `p` and `n`
     return true;
 });
 
@@ -49,13 +47,13 @@ std::string s = buf.peek();
 
 std::string s = buf.readn(1024);
 if (s == "") {
-    /* less than 1024 bytes buffered */
+    // less than 1024 bytes buffered
     return;
 }
 
-Maybe<std::string> res = buf.readline(1024);
+mk::Maybe<std::string> res = buf.readline(1024);
 if (!res) {
-    /* readline failed, check error */
+    // readline failed, check error
     auto error = res.as_error();
     return;
 }
@@ -102,4 +100,4 @@ that is internally used to implement a `Buffer`).
 
 # HISTORY
 
-The `Buffer` class appeared in MeasurementKit 0.1.
+The `Buffer` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/net/error.md
+++ b/doc/api/c++/net/error.md
@@ -2,15 +2,15 @@
 Error -- A network error.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
-common::Error error = net::EOFError();
+Error error = net::EOFError();
 ```
 
 # DESCRIPTION

--- a/doc/api/c++/net/error.md
+++ b/doc/api/c++/net/error.md
@@ -8,9 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace mk;
-
-Error error = net::EOFError();
+mk::Error error = mk::net::EOFError();
 ```
 
 # DESCRIPTION
@@ -19,4 +17,4 @@ Errors that occurr in the `net` library of MeasurementKit.
 
 # HISTORY
 
-Net specific errors appeared in MeasurementKit 0.1.
+Net specific errors appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/net/transport.md
+++ b/doc/api/c++/net/transport.md
@@ -8,30 +8,31 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace mk;
-
-Var<net::Transport> transport = net::connect({
+mk::Maybe<mk::Var<mk::net::Transport>> mt = net::connect({
     {"address", "www.google.com"},
     {"port", "80"}
 });
+if (!mt) throw mt.as_error();
+mk::Var<mk::net::Transport> transport = mt.as_value();
+// Use transport...
 
 transport->on_connect([]() {
     /* connection established */
 });
-transport->on_data([](net::Buffer buff) {
+transport->on_data([](mk::net::Buffer buff) {
     /* data received */
 });
 transport->on_flush([]() {
     /* all queued data was sent */
 });
-transport->on_error([](Error error) {
+transport->on_error([](mk::Error error) {
     /* handle error that occurred */
 });
 
 transport->set_timeout(7.14);
 transport->clear_timeout();
 
-net::Buffer buff;
+mk::net::Buffer buff;
 transport->send("sassaroli", 5);
 transport->send(std::string("sassaroli"));
 transport->send(buff);
@@ -42,11 +43,11 @@ std::string s = transport->socks5_address();  // empty string if no proxy
 std::string s = transport->socks5_port();     // ditto
 
 /* event emitters: */
-net::Buffer buffer;
+mk::net::Buffer buffer;
 transport->emit_connect();
 transport->emit_data(buffer);
 transport->emit_flush();
-transport->emit_error(net::EOFError());
+transport->emit_error(mk::net::EOFError());
 ```
 
 # DESCRIPTION
@@ -84,6 +85,11 @@ address and port separated by a colon (default: unspecified)
 Options can only be specified as strings. It would be nice to allow for them
 to be either string or numbers, depending on their semantic.
 
+The return value of `connect()` is ugly because it is made of two templates,
+i.e. `Maybe<>` and `Var<>`. It is possible that for this and other reasons we
+will consider making `Transport` movable and copyable such that `connect()`
+will return just the more readable and manageable `Maybe<Transport`>.
+
 # HISTORY
 
-The `Transport` class appeared in MeasurementKit 0.1.
+The `Transport` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/net/transport.md
+++ b/doc/api/c++/net/transport.md
@@ -2,14 +2,13 @@
 Transport -- TCP-like connection
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/net.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit;
+using namespace mk;
 
 Var<net::Transport> transport = net::connect({
     {"address", "www.google.com"},

--- a/doc/api/c++/ooni/dns_injection_test.md
+++ b/doc/api/c++/ooni/dns_injection_test.md
@@ -8,7 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 // Run sync test
 ooni::DnsInjectionTest()

--- a/doc/api/c++/ooni/dns_injection_test.md
+++ b/doc/api/c++/ooni/dns_injection_test.md
@@ -8,10 +8,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace mk;
-
 // Run sync test
-ooni::DnsInjectionTest()
+mk::ooni::DnsInjectionTest()
     .set_backend("127.0.0.1")
     .set_input_file_path("test/fixtures/hosts.txt")
     .set_verbose()
@@ -22,7 +20,7 @@ ooni::DnsInjectionTest()
     .run();
 
 // Run async test
-ooni::DnsInjectionTest()
+mk::ooni::DnsInjectionTest()
     .set_backend("127.0.0.1")
     .set_input_file_path("test/fixtures/hosts.txt")
     .set_verbose()

--- a/doc/api/c++/ooni/http_invalid_request_line_test.md
+++ b/doc/api/c++/ooni/http_invalid_request_line_test.md
@@ -8,10 +8,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace mk;
-
 // Run sync test
-ooni::HttpInvalidRequestLineTest()
+mk::ooni::HttpInvalidRequestLineTest()
     .set_backend("http://127.0.0.1/")
     .set_verbose()
     .on_log([](const char *s) {
@@ -21,7 +19,7 @@ ooni::HttpInvalidRequestLineTest()
     .run();
 
 // Run async test
-ooni::HttpInvalidRequestLineTest()
+mk::ooni::HttpInvalidRequestLineTest()
     .set_backend("http://127.0.0.1/")
     .set_verbose()
     .on_log([](const char *s) {

--- a/doc/api/c++/ooni/http_invalid_request_line_test.md
+++ b/doc/api/c++/ooni/http_invalid_request_line_test.md
@@ -8,7 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 // Run sync test
 ooni::HttpInvalidRequestLineTest()

--- a/doc/api/c++/ooni/tcp_connect_test.md
+++ b/doc/api/c++/ooni/tcp_connect_test.md
@@ -8,7 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace measurement_kit;
+using namespace mk;
 
 // Run sync test
 ooni::TcpConnectTest()

--- a/doc/api/c++/ooni/tcp_connect_test.md
+++ b/doc/api/c++/ooni/tcp_connect_test.md
@@ -8,10 +8,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-using namespace mk;
-
 // Run sync test
-ooni::TcpConnectTest()
+mk::ooni::TcpConnectTest()
     .set_port("80")
     .set_input_file_path("test/fixtures/hosts.txt")
     .set_verbose()
@@ -22,7 +20,7 @@ ooni::TcpConnectTest()
     .run();
 
 // Run async test
-ooni::TcpConnectTest()
+mk::ooni::TcpConnectTest()
     .set_port("80")
     .set_input_file_path("test/fixtures/hosts.txt")
     .set_verbose()

--- a/doc/api/c++/tor/controller.md
+++ b/doc/api/c++/tor/controller.md
@@ -8,19 +8,17 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/tor.hpp>
 
-using namespace mk::tor;
-
 // Default constructor using 127.0.0.1:9050
-Controller controller([]() {
+mk::tor::Controller controller([]() {
     // Here you must actually start Tor using CPAProxy
 });
 
 // Constructor with custom address and port
-Controller controller("127.0.0.1", 9051, []() {
+mk::tor::Controller controller("127.0.0.1", 9051, []() {
     // Here you must actually start Tor using CPAProxy
 });
 
-controller.on_complete([](common::Error error) {
+controller.on_complete([](mk::Error error) {
     // Check error to see whether Tor started successfully or not
 });
 
@@ -50,4 +48,4 @@ lifecycle of a measurement-kit App.
 
 # HISTORY
 
-The `Contoller` class appeared in MeasurementKit 0.1.
+The `Contoller` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/c++/tor/controller.md
+++ b/doc/api/c++/tor/controller.md
@@ -2,13 +2,13 @@
 Controller -- Tor controller.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include <measurement_kit/tor.hpp>
 
-using namespace measurement_kit::tor;
+using namespace mk::tor;
 
 // Default constructor using 127.0.0.1:9050
 Controller controller([]() {

--- a/doc/private/c++/common/libs.md
+++ b/doc/private/c++/common/libs.md
@@ -8,16 +8,14 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include "src/measurement_kit/common/libs_impl.hpp"
 
-using namespace mk;
-
 // Suppose you want to check whether the Poller constructor deals
 // well with `event_base_new()` returning `nullptr`, then:
 
-Libs libs;
+mk::Libs libs;
 libs.event_base_new = []() { return nullptr; };
 bool exc = false;
 try {
-    Poller poller(&libs);
+    mk::Poller poller(&libs);
 } catch (std::bad_alloc &) {
     exc = true;
 }
@@ -40,4 +38,4 @@ simulate API failure in regress tests as shown above.
 
 # HISTORY
 
-The `Libs` class appeared in MeasurementKit 0.1.
+The `Libs` class appeared in MeasurementKit 0.1.0.

--- a/doc/private/c++/common/libs.md
+++ b/doc/private/c++/common/libs.md
@@ -2,13 +2,13 @@
 Libs -- Wrappers for C libraries functions.
 
 # LIBRARY
-MeasurementKit (libmeasurement-kit, -lmeasurement-kit).
+MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 
 # SYNOPSIS
 ```C++
 #include "src/measurement_kit/common/libs_impl.hpp"
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 // Suppose you want to check whether the Poller constructor deals
 // well with `event_base_new()` returning `nullptr`, then:

--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -10,8 +10,7 @@
 #include <functional>
 #include <string>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 class NetTest;
 struct AsyncState;
@@ -41,6 +40,5 @@ class Async {
     static void loop_thread(Var<AsyncState>);
 };
 
-} // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/constraints.hpp
+++ b/include/measurement_kit/common/constraints.hpp
@@ -5,8 +5,7 @@
 #ifndef MEASUREMENT_KIT_COMMON_CONSTRAINTS_HPP
 #define MEASUREMENT_KIT_COMMON_CONSTRAINTS_HPP
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 struct NonMovable {
     NonMovable(NonMovable &&) = delete;
@@ -19,6 +18,6 @@ struct NonCopyable {
     NonCopyable &operator=(NonCopyable &) = delete;
     NonCopyable() {}
 };
-}
-}
+
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -9,8 +9,7 @@
 #include <iosfwd>
 #include <string>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// An error that occurred
 class Error : public std::exception {
@@ -59,6 +58,5 @@ class MaybeNotInitializedError : public Error {
     MaybeNotInitializedError() : Error(2, "unknown_failure 2") {}
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/evbuffer.hpp
+++ b/include/measurement_kit/common/evbuffer.hpp
@@ -9,8 +9,7 @@
 #include <measurement_kit/common/libs.hpp>
 struct evbuffer;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// RAII wrapper for evbuffer
 class Evbuffer : public NonCopyable, public NonMovable {
@@ -32,6 +31,5 @@ class Evbuffer : public NonCopyable, public NonMovable {
     evbuffer *evbuf_ = nullptr;
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/libs.hpp
+++ b/include/measurement_kit/common/libs.hpp
@@ -5,14 +5,11 @@
 #ifndef MEASUREMENT_KIT_COMMON_LIBS_HPP
 #define MEASUREMENT_KIT_COMMON_LIBS_HPP
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 struct Libs;
 
-} // namespace common
+Libs *get_global_libs();  /// Access global libs object
 
-common::Libs *get_global_libs();  /// Access global libs object
-
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -10,8 +10,7 @@
 #include <functional>
 #include <stdarg.h>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// Object used to log messages
 class Logger : public NonCopyable, public NonMovable {
@@ -70,14 +69,12 @@ class Logger : public NonCopyable, public NonMovable {
     char buffer_[32768];
 };
 
-} // namespace common
-
 inline void warn(const char *, ...) __attribute__((format(printf, 1, 2)));
 inline void debug(const char *, ...) __attribute__((format(printf, 1, 2)));
 inline void info(const char *, ...) __attribute__((format(printf, 1, 2)));
 
 inline void warn(const char *fmt, ...) {
-    auto logger = common::Logger::global();
+    auto logger = Logger::global();
     if (logger->get_verbose() >= 0) {
         va_list ap;
         va_start(ap, fmt);
@@ -87,7 +84,7 @@ inline void warn(const char *fmt, ...) {
 }
 
 inline void info(const char *fmt, ...) {
-    auto logger = common::Logger::global();
+    auto logger = Logger::global();
     if (logger->get_verbose() > 0) {
         va_list ap;
         va_start(ap, fmt);
@@ -97,7 +94,7 @@ inline void info(const char *fmt, ...) {
 }
 
 inline void debug(const char *fmt, ...) {
-    auto logger = common::Logger::global();
+    auto logger = Logger::global();
     if (logger->get_verbose() > 0) {
         va_list ap;
         va_start(ap, fmt);
@@ -106,11 +103,11 @@ inline void debug(const char *fmt, ...) {
     }
 }
 
-inline void set_verbose(int v) { common::Logger::global()->set_verbose(v); }
+inline void set_verbose(int v) { Logger::global()->set_verbose(v); }
 
 inline void on_log(std::function<void(const char *)> fn) {
-    common::Logger::global()->on_log(fn);
+    Logger::global()->on_log(fn);
 }
 
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/maybe.hpp
+++ b/include/measurement_kit/common/maybe.hpp
@@ -7,8 +7,7 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// Maybe contains a value of type T
 template <typename T> class Maybe {
@@ -39,6 +38,5 @@ template <typename T> class Maybe {
     T value_;
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/net_test.hpp
+++ b/include/measurement_kit/common/net_test.hpp
@@ -10,8 +10,7 @@
 
 #include <functional>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// The generic network test
 class NetTest : public NonCopyable, public NonMovable {
@@ -42,6 +41,5 @@ class NetTest : public NonCopyable, public NonMovable {
     Logger logger;
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -11,8 +11,7 @@
 struct evdns_base;
 struct event_base;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 class Poller : public NonCopyable, public NonMovable {
   public:
@@ -40,29 +39,27 @@ class Poller : public NonCopyable, public NonMovable {
     Libs *libs_ = get_global_libs();
 };
 
-} // namespace common
-
 /*
  * Syntactic sugar:
  */
 
-inline common::Poller *get_global_poller(void) {
-    return (common::Poller::global());
+inline Poller *get_global_poller(void) {
+    return (Poller::global());
 }
 
 inline event_base *get_global_event_base(void) {
-    return (common::Poller::global()->get_event_base());
+    return (Poller::global()->get_event_base());
 }
 
 inline evdns_base *get_global_evdns_base(void) {
-    return (common::Poller::global()->get_evdns_base());
+    return (Poller::global()->get_evdns_base());
 }
 
-inline void loop(void) { common::Poller::global()->loop(); }
+inline void loop(void) { Poller::global()->loop(); }
 
-inline void loop_once(void) { common::Poller::global()->loop_once(); }
+inline void loop_once(void) { Poller::global()->loop_once(); }
 
-inline void break_loop(void) { common::Poller::global()->break_loop(); }
+inline void break_loop(void) { Poller::global()->break_loop(); }
 
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/common/settings.hpp
+++ b/include/measurement_kit/common/settings.hpp
@@ -7,10 +7,9 @@
 
 #include <map>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 typedef std::map<std::string, std::string> Settings;
-}
+
 }
 #endif

--- a/include/measurement_kit/common/var.hpp
+++ b/include/measurement_kit/common/var.hpp
@@ -8,8 +8,7 @@
 #include <memory>
 #include <stdexcept>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// Improved std::shared_ptr<T> with null pointer checks
 template <typename T> class Var : public std::shared_ptr<T> {
@@ -40,6 +39,5 @@ template <typename T> class Var : public std::shared_ptr<T> {
     // DOING THAT CREATES THE RISK OF OBJECT SLICING.
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/dns/defines.hpp
+++ b/include/measurement_kit/dns/defines.hpp
@@ -9,7 +9,7 @@
 #ifndef MEASUREMENT_KIT_DNS_DEFINES_HPP
 #define MEASUREMENT_KIT_DNS_DEFINES_HPP
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
 
 /// Available query classes id
@@ -137,5 +137,5 @@ class QueryType {
 };
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/dns/error.hpp
+++ b/include/measurement_kit/dns/error.hpp
@@ -7,119 +7,119 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
 
 /// Format error
-class FormatError : public common::Error {
+class FormatError : public Error {
   public:
     /// Default constructor
     FormatError() : Error(2000, "dns_lookup_error") {}
 };
 
 /// Server failed error
-class ServerFailedError : public common::Error {
+class ServerFailedError : public Error {
   public:
     /// Default constructor
     ServerFailedError() : Error(2001, "dns_lookup_error") {}
 };
 
 /// Not exist error
-class NotExistError : public common::Error {
+class NotExistError : public Error {
   public:
     /// Default constructor
     NotExistError() : Error(2002, "dns_lookup_error") {}
 };
 
 /// Not implemented error
-class NotImplementedError : public common::Error {
+class NotImplementedError : public Error {
   public:
     /// Default constructor
     NotImplementedError() : Error(2003, "dns_lookup_error") {}
 };
 
 /// Refused error
-class RefusedError : public common::Error {
+class RefusedError : public Error {
   public:
     /// Default constructor
     RefusedError() : Error(2004, "dns_lookup_error") {}
 };
 
 /// Truncated error
-class TruncatedError : public common::Error {
+class TruncatedError : public Error {
   public:
     /// Default constructor
     TruncatedError() : Error(2005, "dns_lookup_error") {}
 };
 
 /// Uknown error
-class UnknownError : public common::Error {
+class UnknownError : public Error {
   public:
     UnknownError() : Error(2006, "unknown_failure 2006") {}
 };
 
 /// Timeout error
-class TimeoutError : public common::Error {
+class TimeoutError : public Error {
   public:
     TimeoutError() : Error(2007, "generic_timeout_error") {}
 };
 
 /// Shutdown error
-class ShutdownError : public common::Error {
+class ShutdownError : public Error {
   public:
     ShutdownError() : Error(2008, "unknown_failure 2008") {}
 };
 
 /// Cancel error
-class CancelError : public common::Error {
+class CancelError : public Error {
   public:
     CancelError() : Error(2009, "unknown_failure 2009") {}
 };
 
 /// No data error
-class NoDataError : public common::Error {
+class NoDataError : public Error {
   public:
     NoDataError() : Error(2010, "dns_lookup_error") {}
 };
 
 /// Invalid IPv4 error
-class InvalidIPv4AddressError : public common::Error {
+class InvalidIPv4AddressError : public Error {
   public:
     InvalidIPv4AddressError() : Error(2011, "unknown_failure 2011") {}
 };
 
 /// Invalid IPv6 error
-class InvalidIPv6AddressError : public common::Error {
+class InvalidIPv6AddressError : public Error {
   public:
     InvalidIPv6AddressError() : Error(2012, "unknown_failure 2012") {}
 };
 
 /// Unsupported class error
-class UnsupportedClassError : public common::Error {
+class UnsupportedClassError : public Error {
   public:
     UnsupportedClassError() : Error(2013, "unknown_failure 2013") {}
 };
 
 /// Invalid name for PTR query error
-class InvalidNameForPTRError : public common::Error {
+class InvalidNameForPTRError : public Error {
   public:
     InvalidNameForPTRError() : Error(2014, "unknown_failure 2014") {}
 };
 
 /// Resolver error
-class ResolverError : public common::Error {
+class ResolverError : public Error {
   public:
     ResolverError() : Error(2015, "unknown_failure 2015") {}
 };
 
 /// Unsupported type error
-class UnsupportedTypeError : public common::Error {
+class UnsupportedTypeError : public Error {
   public:
     UnsupportedTypeError() : Error(2016, "unknown_failure 2016") {}
 };
 
-common::Error dns_error(int code); ///< Map evdns code to proper error
+Error dns_error(int code); ///< Map evdns code to proper error
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/dns/resolver.hpp
+++ b/include/measurement_kit/dns/resolver.hpp
@@ -21,12 +21,10 @@
 
 struct evdns_base; // Internally we use evdns
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
 
 class Response;
-
-using namespace measurement_kit::common;
 
 /// DNS Resolver object.
 class Resolver : public NonCopyable, public NonMovable {
@@ -37,7 +35,7 @@ class Resolver : public NonCopyable, public NonMovable {
   protected:
     Settings settings;
     Libs *libs = get_global_libs();
-    Poller *poller = measurement_kit::get_global_poller();
+    Poller *poller = mk::get_global_poller();
     evdns_base *base = nullptr;
     Logger *logger = Logger::global();
 
@@ -70,5 +68,5 @@ class Resolver : public NonCopyable, public NonMovable {
 };
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/dns/response.hpp
+++ b/include/measurement_kit/dns/response.hpp
@@ -11,13 +11,11 @@
 #include <string>
 #include <vector>
 
-namespace measurement_kit {
-namespace common {
-struct Libs;
-}
-namespace dns {
+namespace mk {
 
-using namespace measurement_kit::common;
+struct Libs;
+
+namespace dns {
 
 /// DNS response.
 class Response {
@@ -64,5 +62,5 @@ class Response {
 };
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/http/client.hpp
+++ b/include/measurement_kit/http/client.hpp
@@ -15,10 +15,11 @@
 #include <string>
 #include <type_traits>
 
-namespace measurement_kit {
-namespace http {
+namespace mk {
 
-using namespace measurement_kit::common;
+class Error;
+
+namespace http {
 
 class Request;
 
@@ -49,5 +50,5 @@ class Client {
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/http/error.hpp
+++ b/include/measurement_kit/http/error.hpp
@@ -7,21 +7,21 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
 
 /// Received UPGRADE request error
-class UpgradeError : public common::Error {
+class UpgradeError : public Error {
   public:
     UpgradeError (): Error(3000, "unknown_error 3000") {};
 };
 
 /// Parse error occurred
-class ParserError : public common::Error {
+class ParserError : public Error {
   public:
     ParserError() : Error(3001, "unknown_error 3001") {};
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/http/headers.hpp
+++ b/include/measurement_kit/http/headers.hpp
@@ -9,11 +9,11 @@
 #include <map>
 #include <string>
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
 
 typedef std::map<std::string, std::string> Headers;
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/http/response.hpp
+++ b/include/measurement_kit/http/response.hpp
@@ -5,18 +5,13 @@
 #ifndef MEASUREMENT_KIT_HTTP_RESPONSE_HPP
 #define MEASUREMENT_KIT_HTTP_RESPONSE_HPP
 
-#include <measurement_kit/net/buffer.hpp>
-
 #include <measurement_kit/http/headers.hpp>
 
 #include <iosfwd>
 #include <string>
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
 
 /*!
  * \brief HTTP response.
@@ -32,5 +27,5 @@ struct Response {
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/net/buffer.hpp
+++ b/include/measurement_kit/net/buffer.hpp
@@ -15,15 +15,17 @@
 #include <stdexcept>                            // for runtime_error
 #include <string>                               // for string
 #include <tuple>                                // for tuple
-namespace measurement_kit { namespace common { class Error; } }
 struct evbuffer;
 
-namespace measurement_kit {
+namespace mk {
+
+class Error;
+
 namespace net {
 
 class Buffer {
   private:
-    common::Var<common::Evbuffer> evbuf{new common::Evbuffer};
+    Var<Evbuffer> evbuf{new Evbuffer};
 
   public:
     Buffer(evbuffer *b = nullptr);
@@ -84,7 +86,7 @@ class Buffer {
         return read(n);
     }
 
-    common::Maybe<std::string> readline(size_t maxline);
+    Maybe<std::string> readline(size_t maxline);
 
     /*
      * Wrappers for write, including a handy wrapper for sending
@@ -122,5 +124,5 @@ class Buffer {
 };
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -7,81 +7,81 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
 
 /// EOF error
-class EOFError : public common::Error {
+class EOFError : public Error {
   public:
     /// Default constructor
     EOFError() : Error(1000, "unknown_failure 1000") {}
 };
 
 /// Timeout error
-class TimeoutError : public common::Error {
+class TimeoutError : public Error {
   public:
     /// Default constructor
     TimeoutError() : Error(1001, "generic_timeout_error") {}
 };
 
 /// Socket error
-class SocketError : public common::Error {
+class SocketError : public Error {
   public:
     /// Default constructor
     SocketError() : Error(1002, "unknown_failure 1002") {}
 };
 
 /// Connect failed error
-class ConnectFailedError : public common::Error {
+class ConnectFailedError : public Error {
   public:
     /// Default constructor
     ConnectFailedError() : Error(1003, "unknown_failure 1003") {}
 };
 
 /// DNS generic error
-class DNSGenericError : public common::Error {
+class DNSGenericError : public Error {
   public:
     /// Default constructor
     DNSGenericError() : Error(1004, "unknown_failure 1004") {}
 };
 
 /// Bad SOCKS version error
-class BadSocksVersionError : public common::Error {
+class BadSocksVersionError : public Error {
   public:
     /// Default constructor
     BadSocksVersionError() : Error(1005, "socks_error") {}
 };
 
 /// SOCKS address too long
-class SocksAddressTooLongError : public common::Error {
+class SocksAddressTooLongError : public Error {
   public:
     SocksAddressTooLongError() : Error(1006, "unknown_failure 1006") {}
 };
 
 /// SOCKS invalid port
-class SocksInvalidPortError : public common::Error {
+class SocksInvalidPortError : public Error {
   public:
     SocksInvalidPortError() : Error(1007, "unknown_failure 1007") {}
 };
 
 /// SOCKS generic error
-class SocksGenericError : public common::Error {
+class SocksGenericError : public Error {
   public:
     SocksGenericError() : Error(1008, "socks_error") {}
 };
 
 /// EOL not found error
-class EOLNotFoundError : public common::Error {
+class EOLNotFoundError : public Error {
   public:
     EOLNotFoundError() : Error(1009, "unknown_failure 1009") {}
 };
 
 /// Line too long error
-class LineTooLongError : public common::Error {
+class LineTooLongError : public Error {
   public:
     LineTooLongError() : Error(1010, "unknown_failure 1010") {}
 };
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -22,10 +22,8 @@
 
 #include <measurement_kit/net/buffer.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
-
-using namespace measurement_kit::common;
 
 class Transport {
   public:
@@ -70,5 +68,5 @@ Maybe<Var<Transport>> connect(Settings, Logger * = Logger::global(),
                               Poller * = Poller::global());
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/ooni/base_test.hpp
+++ b/include/measurement_kit/ooni/base_test.hpp
@@ -8,11 +8,9 @@
 #include <measurement_kit/common/var.hpp>
 #include <functional>
 
-namespace measurement_kit {
+namespace mk {
 
-namespace common {
 class NetTest;
-}
 
 namespace ooni {
 
@@ -23,8 +21,8 @@ class BaseTest {
     virtual ~BaseTest() {} ///< Default destructor
 
     /// Create instance of the test
-    virtual common::Var<common::NetTest> create_test_() {
-        return common::Var<common::NetTest>();
+    virtual Var<NetTest> create_test_() {
+        return Var<NetTest>();
     }
 
     /// Run synchronous test
@@ -35,5 +33,5 @@ class BaseTest {
 };
 
 } // namespace ooni
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/ooni/dns_injection_test.hpp
+++ b/include/measurement_kit/ooni/dns_injection_test.hpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
 /// Parameters of dns-injection test
@@ -45,14 +45,14 @@ class DnsInjectionTest : public BaseTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test_() override;
+    Var<NetTest> create_test_() override;
 
-    common::Settings settings;
+    Settings settings;
     bool is_verbose = false;
     std::function<void(const char *)> log_handler;
     std::string input_path;
 };
 
 } // namespace ooni
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/ooni/http_invalid_request_line_test.hpp
+++ b/include/measurement_kit/ooni/http_invalid_request_line_test.hpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
 /// Parameters of http-invalid-request-line test
@@ -39,13 +39,13 @@ class HttpInvalidRequestLineTest : public BaseTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test_() override;
+    Var<NetTest> create_test_() override;
 
-    common::Settings settings;
+    Settings settings;
     bool is_verbose = false;
     std::function<void(const char *)> log_handler;
 };
 
 } // namespace ooni
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/ooni/tcp_connect_test.hpp
+++ b/include/measurement_kit/ooni/tcp_connect_test.hpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni/base_test.hpp>
 #include <string>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
 /// Parameters of tcp-connect test
@@ -45,14 +45,14 @@ class TcpConnectTest : public BaseTest {
     }
 
     /// Create instance of the test
-    common::Var<common::NetTest> create_test_() override;
+    Var<NetTest> create_test_() override;
 
-    common::Settings settings;
+    Settings settings;
     bool is_verbose = false;
     std::function<void(const char *)> log_handler;
     std::string input_path;
 };
 
 } // namespace ooni
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/tor/controller.hpp
+++ b/include/measurement_kit/tor/controller.hpp
@@ -11,7 +11,7 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace tor {
 
 /// Tor controller class
@@ -27,7 +27,7 @@ class Controller {
         : Controller("127.0.0.1", 9050, start_tor) {}
 
     /// Set callback called on completion
-    void on_complete(std::function<void(common::Error)> func) {
+    void on_complete(std::function<void(Error)> func) {
         complete_fn_ = func;
     }
 
@@ -40,7 +40,7 @@ class Controller {
     void start_tor() { start_tor_(); }
 
   private:
-    std::function<void(common::Error)> complete_fn_;
+    std::function<void(Error)> complete_fn_;
     std::function<void(int, std::string)> progress_fn_;
     std::string host_;
     std::function<void()> start_tor_;
@@ -48,5 +48,5 @@ class Controller {
 };
 
 } // namespace tor
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/traceroute/android.hpp
+++ b/include/measurement_kit/traceroute/android.hpp
@@ -53,16 +53,15 @@ struct sockaddr_in6;
 struct sockaddr_in;
 struct sockaddr_storage;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
+
 class Error;
-}
 
 namespace traceroute {
 
 /// Traceroute prober for Android
-class AndroidProber : public measurement_kit::common::NonCopyable,
-                      public measurement_kit::common::NonMovable,
+class AndroidProber : public NonCopyable,
+                      public NonMovable,
                       public ProberInterface {
 
   public:
@@ -72,7 +71,7 @@ class AndroidProber : public measurement_kit::common::NonCopyable,
     /// \param evbase Event base to use (optional)
     AndroidProber(
         bool use_ipv4, int port,
-        event_base *evbase = measurement_kit::get_global_event_base());
+        event_base *evbase = mk::get_global_event_base());
 
     /// Destructor
     ~AndroidProber() { cleanup(); }
@@ -86,7 +85,7 @@ class AndroidProber : public measurement_kit::common::NonCopyable,
 
     void on_timeout(std::function<void()> cb) override { timeout_cb_ = cb; }
 
-    void on_error(std::function<void(common::Error)> cb) override {
+    void on_error(std::function<void(Error)> cb) override {
         error_cb_ = cb;
     }
 
@@ -101,7 +100,7 @@ class AndroidProber : public measurement_kit::common::NonCopyable,
 
     std::function<void(ProbeResult)> result_cb_;  ///< on result callback
     std::function<void()> timeout_cb_;            ///< on timeout callback
-    std::function<void(common::Error)> error_cb_; ///< on error callback
+    std::function<void(Error)> error_cb_; ///< on error callback
 
     /// Call this when you don't receive a response within timeout
     void on_timeout() { probe_pending_ = false; }
@@ -159,6 +158,6 @@ class AndroidProber : public measurement_kit::common::NonCopyable,
 };
 
 } // namespace traceroute
-} // namespace measurement_kit
+} // namespace mk
 #endif
 #endif

--- a/include/measurement_kit/traceroute/error.hpp
+++ b/include/measurement_kit/traceroute/error.hpp
@@ -7,91 +7,91 @@
 
 #include <measurement_kit/common/error.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace traceroute {
 
 /// Socket create error
-class SocketCreateError : public common::Error {
+class SocketCreateError : public Error {
   public:
     /// Default constructor
     SocketCreateError() : Error(2000, "unknown_failure 2000") {}
 };
 
 /// Setsockopt error
-class SetsockoptError : public common::Error {
+class SetsockoptError : public Error {
   public:
     /// Default constructor
     SetsockoptError() : Error(2001, "unknown_failure 2001") {}
 };
 
 /// Probe already pending error
-class ProbeAlreadyPendingError : public common::Error {
+class ProbeAlreadyPendingError : public Error {
   public:
     /// Default constructor
     ProbeAlreadyPendingError() : Error(2002, "unknown_failure 2002") {}
 };
 
 /// Payload too long error
-class PayloadTooLongError : public common::Error {
+class PayloadTooLongError : public Error {
   public:
     /// Default constructor
     PayloadTooLongError() : Error(2003, "unknown_failure 2003") {}
 };
 
 /// Storage init error
-class StorageInitError : public common::Error {
+class StorageInitError : public Error {
   public:
     /// Default constructor
     StorageInitError() : Error(2004, "unknown_failure 2004") {}
 };
 
 /// Bind error
-class BindError : public common::Error {
+class BindError : public Error {
   public:
     /// Default constructor
     BindError() : Error(2005, "unknown_failure 2005") {}
 };
 
 /// Event new error
-class EventNewError : public common::Error {
+class EventNewError : public Error {
   public:
     /// Default constructor
     EventNewError() : Error(2006, "unknown_failure 2006") {}
 };
 
 /// Sendto error
-class SendtoError : public common::Error {
+class SendtoError : public Error {
   public:
     /// Default constructor
     SendtoError() : Error(2007, "unknown_failure 2007") {}
 };
 
 /// No probe pending error
-class NoProbePendingError : public common::Error {
+class NoProbePendingError : public Error {
   public:
     /// Default constructor
     NoProbePendingError() : Error(2008, "unknown_failure 2008") {}
 };
 
 /// Clock gettime error
-class ClockGettimeError : public common::Error {
+class ClockGettimeError : public Error {
   public:
     /// Default constructor
     ClockGettimeError() : Error(2009, "unknown_failure 2009") {}
 };
 
-class EventAddError : public common::Error {
+class EventAddError : public Error {
   public:
     /// Default constructor
     EventAddError() : Error(2010, "unknown_failure 2010") {}
 };
 
-class SocketAlreadyClosedError : public common::Error {
+class SocketAlreadyClosedError : public Error {
   public:
     /// Default constructor
     SocketAlreadyClosedError() : Error(2011, "unknown_failure 2011") {}
 };
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/include/measurement_kit/traceroute/interface.hpp
+++ b/include/measurement_kit/traceroute/interface.hpp
@@ -49,10 +49,9 @@
 // Forward declarations
 struct event_base;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
+
 class Error;
-}
 
 namespace traceroute {
 
@@ -109,7 +108,7 @@ class ProberInterface {
     virtual void on_timeout(std::function<void()> cb) = 0;
 
     /// Set callback called when there is an error
-    virtual void on_error(std::function<void(common::Error)> cb) = 0;
+    virtual void on_error(std::function<void(Error)> cb) = 0;
 
     /// Default copy constructor
     ProberInterface(ProberInterface &) = default;
@@ -137,7 +136,7 @@ template <class Impl> class Prober : public ProberInterface {
     /// \param evbase Event base to use (optional)
     /// \throws Exception on error
     Prober(bool use_ipv4, int port,
-           event_base *evbase = measurement_kit::get_global_event_base()) {
+           event_base *evbase = mk::get_global_event_base()) {
         impl_.reset(new Impl(use_ipv4, port, evbase));
     }
 
@@ -154,7 +153,7 @@ template <class Impl> class Prober : public ProberInterface {
         impl_->on_timeout(cb);
     }
 
-    void on_error(std::function<void(common::Error)> cb) override {
+    void on_error(std::function<void(Error)> cb) override {
         impl_->on_error(cb);
     }
 
@@ -163,6 +162,6 @@ template <class Impl> class Prober : public ProberInterface {
 };
 
 } // namespace traceroute
-} // namespace measurement_kit
+} // namespace mk
 #endif
 #endif

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -13,8 +13,7 @@
 
 #include <event2/thread.h>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 // Shared state between foreground and background threads
 struct AsyncState {
@@ -151,5 +150,4 @@ Async *Async::global() {
     return &singleton;
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/bufferevent.hpp
+++ b/src/common/bufferevent.hpp
@@ -16,8 +16,7 @@
 struct bufferevent;
 struct event_base;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// RAII wrapper for bufferevent socket
 class Bufferevent : public NonCopyable, public NonMovable {
@@ -65,6 +64,5 @@ class Bufferevent : public NonCopyable, public NonMovable {
     bufferevent *bev_ = nullptr;
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/common/check_connectivity.cpp
+++ b/src/common/check_connectivity.cpp
@@ -11,8 +11,7 @@
 #include "src/common/check_connectivity.hpp"
 #include <measurement_kit/common/logger.hpp>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 void CheckConnectivity::cleanup() // Idempotent cleanup function
 {
@@ -79,5 +78,4 @@ CheckConnectivity::CheckConnectivity() {
     }
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/check_connectivity.hpp
+++ b/src/common/check_connectivity.hpp
@@ -11,8 +11,7 @@
 struct event_base;
 struct evdns_base;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 /// Check whether the network is up
 class CheckConnectivity : public NonCopyable, public NonMovable {
@@ -42,6 +41,5 @@ class CheckConnectivity : public NonCopyable, public NonMovable {
     ~CheckConnectivity() { cleanup(); }
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/common/delayed_call.cpp
+++ b/src/common/delayed_call.cpp
@@ -15,8 +15,7 @@
 
 #include <sys/select.h> // for struct timeval
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 DelayedCallState::DelayedCallState(double t, std::function<void()> f,
                                    Libs *libs, event_base *evbase) {
@@ -45,5 +44,4 @@ DelayedCallState::~DelayedCallState() {
     evp_ = nullptr;
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/delayed_call.hpp
+++ b/src/common/delayed_call.hpp
@@ -15,8 +15,7 @@
 struct event;
 struct event_base;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 // TODO: after MeasurementKit 0.1 move this class inside the .cpp file
 class DelayedCallState : public NonCopyable, public NonMovable {
@@ -46,6 +45,5 @@ class DelayedCall {
     Var<DelayedCallState> state_;
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/common/evbuffer.cpp
+++ b/src/common/evbuffer.cpp
@@ -8,8 +8,7 @@
 #include <new>                              // for bad_alloc
 #include "src/common/libs_impl.hpp"
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 Evbuffer::~Evbuffer() {
     if (evbuf_ != nullptr) libs_->evbuffer_free(evbuf_);
@@ -21,5 +20,4 @@ Evbuffer::operator evbuffer *() {
     return (evbuf_);
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/libs.cpp
+++ b/src/common/libs.cpp
@@ -5,8 +5,8 @@
 #include <measurement_kit/common/libs.hpp>
 #include "src/common/libs_impl.hpp"
 
-namespace measurement_kit {
+namespace mk {
 
-common::Libs *get_global_libs() { return common::Libs::global(); }
+Libs *get_global_libs() { return Libs::global(); }
 
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/libs_impl.hpp
+++ b/src/common/libs_impl.hpp
@@ -23,8 +23,7 @@ struct event;
 struct event_base;
 struct timeval;
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 struct Libs {
 
@@ -123,6 +122,5 @@ struct Libs {
     }
 };
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -6,8 +6,7 @@
 
 #include <stdio.h>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 Logger::Logger() {
     consumer_ = [](const char *s) { fprintf(stderr, "%s\n", s); };
@@ -23,5 +22,4 @@ void Logger::logv(const char *fmt, va_list ap) {
     consumer_(buffer_);
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/net_test.cpp
+++ b/src/common/net_test.cpp
@@ -4,10 +4,8 @@
 
 #include <measurement_kit/common/net_test.hpp>
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 NetTest::~NetTest() {}
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -7,8 +7,7 @@
 #include <stdexcept>
 #include "src/common/libs_impl.hpp"
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
 
 Poller::Poller(Libs *libs) {
     if (libs != nullptr) libs_ = libs;
@@ -41,5 +40,4 @@ void Poller::loop_once() {
     if (result == 1) warn("loop: no pending and/or active events");
 }
 
-} // namespace common
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -25,7 +25,7 @@
 
 #include <event2/util.h>
 
-namespace measurement_kit {
+namespace mk {
 
 void timeval_now(timeval *tv) {
     if (gettimeofday(tv, nullptr) != 0) {
@@ -308,4 +308,4 @@ std::string unreverse_ipv4(std::string s) {
     return std::string(r.begin(), r.end());
 }
 
-} // namespace measurement_kit
+} // namespace mk

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -17,7 +17,7 @@
 struct sockaddr_storage;
 struct timeval;
 
-namespace measurement_kit {
+namespace mk {
 
 /*
  * Macros and functions useful to check whether sockets are valid. We
@@ -139,5 +139,5 @@ std::string unreverse_ipv6(std::string s);
 
 std::string unreverse_ipv4(std::string s);
 
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/dns/error.cpp
+++ b/src/dns/error.cpp
@@ -7,11 +7,11 @@
 
 #include <event2/dns.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
 
-common::Error dns_error(int code) {
-    common::Error err;
+Error dns_error(int code) {
+    Error err;
 
     //
     // Here we map evdns error codes to specific Errors.
@@ -20,7 +20,7 @@ common::Error dns_error(int code) {
     //
 
     if (code == DNS_ERR_NONE) {
-        err = common::NoError();
+        err = NoError();
 
     } else if (code == DNS_ERR_FORMAT) {
         // The name server was unable to interpret the query
@@ -76,11 +76,11 @@ common::Error dns_error(int code) {
 
     } else {
         // Safery net - should really not happen
-        err = common::GenericError();
+        err = GenericError();
     }
 
     return err;
 }
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk

--- a/src/dns/query.cpp
+++ b/src/dns/query.cpp
@@ -18,19 +18,17 @@
 
 struct evdns_base;
 
-namespace measurement_kit {
-namespace common {
-class Logger;
-}
-namespace dns {
+namespace mk {
 
-using namespace measurement_kit::common;
+class Logger;
+
+namespace dns {
 
 Query::Query(QueryClass dns_class, QueryType dns_type, std::string name,
              std::function<void(Error, Response)> func, Logger *lp,
              evdns_base *dnsb, Libs *libs) {
     if (dnsb == nullptr) {
-        dnsb = measurement_kit::get_global_evdns_base();
+        dnsb = mk::get_global_evdns_base();
     }
     if (libs == nullptr) {
         libs = Libs::global();
@@ -48,4 +46,4 @@ void Query::cancel(void) {
 }
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk

--- a/src/dns/query.hpp
+++ b/src/dns/query.hpp
@@ -16,15 +16,13 @@
 
 struct evdns_base; // Internally we use evdns
 
-namespace measurement_kit {
-namespace common {
+namespace mk {
+
 struct Libs;
-}
+
 namespace dns {
 
 class Response;
-
-using namespace measurement_kit::common;
 
 /// Async DNS request.
 class Query {
@@ -75,5 +73,5 @@ class Query {
 };
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/dns/query_impl.hpp
+++ b/src/dns/query_impl.hpp
@@ -28,10 +28,8 @@
 
 struct evdns_base;
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
-
-using namespace measurement_kit::common;
 
 /// Implementation of Query.
 class QueryImpl {
@@ -84,10 +82,9 @@ class QueryImpl {
         Response resp(code, type, count, ttl, impl->ticks, addresses,
                       impl->logger);
         if (resp.get_evdns_status() != DNS_ERR_NONE) {
-            impl->callback(
-                measurement_kit::dns::dns_error(resp.get_evdns_status()), resp);
+            impl->callback(mk::dns::dns_error(resp.get_evdns_status()), resp);
         } else
-            impl->callback(common::NoError(), resp);
+            impl->callback(NoError(), resp);
 
         delete impl;
     }
@@ -121,10 +118,10 @@ class QueryImpl {
         // Allow PTR queries
         if (dns_type == QueryTypeId::PTR) {
             std::string s;
-            if ((s = measurement_kit::unreverse_ipv4(name)) != "") {
+            if ((s = mk::unreverse_ipv4(name)) != "") {
                 dns_type = QueryTypeId::REVERSE_A;
                 name = s;
-            } else if ((s = measurement_kit::unreverse_ipv6(name)) != "") {
+            } else if ((s = mk::unreverse_ipv6(name)) != "") {
                 dns_type = QueryTypeId::REVERSE_AAAA;
                 name = s;
             } else
@@ -165,7 +162,7 @@ class QueryImpl {
             throw UnsupportedTypeError();
         }
 
-        ticks = measurement_kit::time_now();
+        ticks = mk::time_now();
     }
 
   public:
@@ -176,14 +173,14 @@ class QueryImpl {
         try {
             new QueryImpl(dns_class, dns_type, name, f, logger, base, lev,
                           cancd);
-        } catch (common::Error &error) {
+        } catch (Error &error) {
             f(error, Response());
         } catch (...) {
-            f(common::GenericError(), Response());
+            f(GenericError(), Response());
         }
     }
 };
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/dns/resolver.cpp
+++ b/src/dns/resolver.cpp
@@ -31,10 +31,8 @@
 
 struct evdns_base;
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
-
-using namespace measurement_kit::common;
 
 void Resolver::cleanup(void) {
     if (base != nullptr) {
@@ -119,4 +117,4 @@ void Resolver::query(QueryClass dns_class, QueryType dns_type, std::string name,
 }
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk

--- a/src/dns/response.cpp
+++ b/src/dns/response.cpp
@@ -17,10 +17,8 @@
 #include <limits.h>
 #include <stddef.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace dns {
-
-using namespace measurement_kit::common;
 
 Response::Response(int code_, char type_, int count, int ttl_, double started,
                    void *addresses, Logger *logger, Libs *libs, int start_from)
@@ -41,7 +39,7 @@ Response::Response(int code_, char type_, int count, int ttl_, double started,
     case DNS_ERR_REFUSED:
     case DNS_ERR_TRUNCATED:
     case DNS_ERR_NODATA:
-        rtt = measurement_kit::time_now() - started;
+        rtt = mk::time_now() - started;
         break;
     default:
         rtt = 0.0;
@@ -104,4 +102,4 @@ Response::Response(int code_, char type_, int count, int ttl_, double started,
 }
 
 } // namespace dns
-} // namespace measurement_kit
+} // namespace mk

--- a/src/http/client.cpp
+++ b/src/http/client.cpp
@@ -5,7 +5,7 @@
 #include <measurement_kit/http/client.hpp>
 #include "src/http/request.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
 
 void Client::request(Settings settings, Headers headers, std::string body,
@@ -29,4 +29,4 @@ Client::~Client() {
 }
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -28,11 +28,8 @@
 #include <string>
 #include <type_traits>
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
 
 /*!
  * \brief HTTP request.
@@ -106,7 +103,7 @@ class Request : public NonCopyable, public NonMovable {
         }
         stream = std::make_shared<Stream>(settings, logger);
         stream->on_error([this](Error err) {
-            if (err != EOFError()) {
+            if (err != net::EOFError()) {
                 emit_end(err, std::move(response));
             } else {
                 // When EOF is received, on_end() is called, therefore we
@@ -116,7 +113,7 @@ class Request : public NonCopyable, public NonMovable {
         stream->on_connect([this](void) {
             // TODO: improve the way in which we serialize the request
             //       to reduce unnecessary copies
-            Buffer buf;
+            net::Buffer buf;
             serializer.serialize(buf);
             *stream << buf.read();
 
@@ -164,5 +161,5 @@ class Request : public NonCopyable, public NonMovable {
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/http/request_serializer.cpp
+++ b/src/http/request_serializer.cpp
@@ -15,10 +15,7 @@
 #include <stdexcept>
 #include <string>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-
-namespace measurement_kit {
+namespace mk {
 namespace http {
 
 RequestSerializer::RequestSerializer(Settings settings, Headers headers_,
@@ -68,4 +65,4 @@ RequestSerializer::RequestSerializer(Settings settings, Headers headers_,
 }
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk

--- a/src/http/request_serializer.hpp
+++ b/src/http/request_serializer.hpp
@@ -15,11 +15,8 @@
 #include <string>
 #include <utility>
 
-namespace measurement_kit {
+namespace mk {
 namespace http {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
 
 /*!
  * \brief HTTP request serializer.
@@ -60,7 +57,7 @@ struct RequestSerializer {
      * \brief Serialize request.
      * \param buff Buffer where to serialize request.
      */
-    void serialize(Buffer &buff) {
+    void serialize(net::Buffer &buff) {
         buff << method << " " << pathquery << " " << protocol << "\r\n";
         for (auto &kv : headers) {
             buff << kv.first << ": " << kv.second << "\r\n";
@@ -87,5 +84,5 @@ struct RequestSerializer {
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/http/response_parser.cpp
+++ b/src/http/response_parser.cpp
@@ -20,10 +20,7 @@
 
 #define MAXLINE 4096
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-
-namespace measurement_kit {
+namespace mk {
 namespace http {
 
 /*!
@@ -35,7 +32,7 @@ class ResponseParserImpl {
     Logger *logger = Logger::global();
     http_parser parser;
     http_parser_settings settings;
-    Buffer buffer;
+    net::Buffer buffer;
 
 // Header parsing states (see do_header_internal)
 #define S_NOTHING 0
@@ -240,7 +237,7 @@ class ResponseParserImpl {
      * \throws std::runtime_error This method throws std::runtime_error (or
      *         a class derived from it) on several error conditions.
      */
-    void feed(Buffer &data) {
+    void feed(net::Buffer &data) {
         buffer << data;
         parse();
     }
@@ -339,7 +336,7 @@ void ResponseParser::on_end(std::function<void(void)> &&fn) {
     impl->end_fn = std::move(fn);
 }
 
-void ResponseParser::feed(Buffer &data) { impl->feed(data); }
+void ResponseParser::feed(net::Buffer &data) { impl->feed(data); }
 
 void ResponseParser::feed(std::string data) { impl->feed(data); }
 
@@ -348,4 +345,4 @@ void ResponseParser::feed(char c) { impl->feed(c); }
 void ResponseParser::eof() { impl->eof(); }
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk

--- a/src/http/response_parser.hpp
+++ b/src/http/response_parser.hpp
@@ -15,14 +15,11 @@
 #include <string>
 #include <type_traits>
 
-namespace measurement_kit {
-namespace net {
-class Buffer;
-}
-namespace http {
+namespace mk {
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+namespace net { class Buffer; }
+
+namespace http {
 
 class ResponseParserImpl; // See http.cpp
 
@@ -152,7 +149,7 @@ class ResponseParser {
      * \throws std::runtime_error This method throws std::runtime_error (or
      *         a class derived from it) on several error conditions.
      */
-    void feed(Buffer &data);
+    void feed(net::Buffer &data);
 
     /*!
      * \brief Feed the parser.
@@ -181,5 +178,5 @@ class ResponseParser {
 };
 
 } // namespace http
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/http/stream.hpp
+++ b/src/http/stream.hpp
@@ -21,14 +21,11 @@
 #include <string>
 #include <type_traits>
 
-namespace measurement_kit {
-namespace net {
-class Buffer;
-}
-namespace http {
+namespace mk {
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+namespace net { class Buffer; }
+
+namespace http {
 
 /*!
  * \brief HTTP stream. This class implements a HTTP stream, i.e., a
@@ -40,19 +37,19 @@ using namespace measurement_kit::net;
  * degree of control is needed over the HTTP protocol.
  */
 class Stream {
-    Var<Transport> connection;
+    Var<net::Transport> connection;
     Var<ResponseParser> parser;
     std::function<void(Error)> error_handler;
     std::function<void()> connect_handler;
 
     void connection_ready(void) {
-        connection->on_data([&](Buffer data) { parser->feed(data); });
+        connection->on_data([&](net::Buffer data) { parser->feed(data); });
         //
         // Intercept EOF error to implement body-ends-at-EOF semantic.
         //
         connection->on_error([&](Error error) {
             auto safe_eh = error_handler;
-            if (error == EOFError()) {
+            if (error == net::EOFError()) {
                 parser->eof();
             }
             // parser->eof() may cause this object to go out of
@@ -72,7 +69,7 @@ class Stream {
      */
     Var<ResponseParser> get_parser() { return parser; }
 
-    Var<Transport> get_transport() { return connection; }
+    Var<net::Transport> get_transport() { return connection; }
 
     /*!
      * \brief Deleted copy constructor.
@@ -121,7 +118,7 @@ class Stream {
         // the connect() function failed in some way. This is to be fixed once
         // release v0.1.0 is rolled out, when we'll deal with all the errors
         // that can happen in the implementation of HTTP.
-        connection = connect(settings, lp).as_value();
+        connection = net::connect(settings, lp).as_value();
         //
         // While the connection is in progress, just forward the
         // error if needed, we'll deal with body-terminated-by-EOF
@@ -244,6 +241,7 @@ class Stream {
 
     std::string socks5_port() { return connection->socks5_port(); }
 };
-}
-}
+
+} // namespace http
+} // namespace mk
 #endif

--- a/src/net/buffer.cpp
+++ b/src/net/buffer.cpp
@@ -15,7 +15,7 @@
 #include <stdexcept>                           // for runtime_error
 #include <string>                              // for string, basic_string
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
 
 Buffer::Buffer(evbuffer *b) {
@@ -76,16 +76,16 @@ std::string Buffer::readpeek(bool ispeek, size_t upto) {
     return out;
 }
 
-common::Maybe<std::string> Buffer::readline(size_t maxline) {
+Maybe<std::string> Buffer::readline(size_t maxline) {
 
     size_t eol_length = 0;
     auto search_result =
         evbuffer_search_eol(*evbuf, nullptr, &eol_length, EVBUFFER_EOL_CRLF);
     if (search_result.pos < 0) {
         if (length() > maxline) {
-            return common::Maybe<std::string>(EOLNotFoundError(), "");
+            return Maybe<std::string>(EOLNotFoundError(), "");
         }
-        return common::Maybe<std::string>("");
+        return Maybe<std::string>("");
     }
 
     /*
@@ -96,9 +96,9 @@ common::Maybe<std::string> Buffer::readline(size_t maxline) {
         throw std::runtime_error("unexpected error");
     auto len = (size_t)search_result.pos + eol_length;
     if (len > maxline) {
-        return common::Maybe<std::string>(LineTooLongError(), "");
+        return Maybe<std::string>(LineTooLongError(), "");
     }
-    return common::Maybe<std::string>(read(len));
+    return Maybe<std::string>(read(len));
 }
 
 void Buffer::write(const void *buf, size_t count) {
@@ -150,4 +150,4 @@ void Buffer::write(size_t count, std::function<size_t(void *, size_t)> func) {
 }
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -28,11 +28,8 @@
 
 #include <string.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
 
 class Connection : public Dumb {
   private:
@@ -55,18 +52,18 @@ class Connection : public Dumb {
 
     // Functions used when connecting
     void connect_next();
-    void handle_resolve(common::Error, char, std::vector<std::string>);
+    void handle_resolve(Error, char, std::vector<std::string>);
     void resolve();
     bool resolve_internal(char);
 
   public:
     Connection(evutil_socket_t fd, Logger *lp = Logger::global(),
-               Poller *poller = measurement_kit::get_global_poller())
+               Poller *poller = mk::get_global_poller())
         : Connection("PF_UNSPEC", "0.0.0.0", "0", poller, lp, fd) {}
 
     Connection(const char *af, const char *a, const char *p,
                Logger *lp = Logger::global(),
-               Poller *poller = measurement_kit::get_global_poller())
+               Poller *poller = mk::get_global_poller())
         : Connection(af, a, p, poller, lp, -1) {}
 
     Connection(const char *, const char *, const char *, Poller *, Logger *,
@@ -83,7 +80,7 @@ class Connection : public Dumb {
 
     void set_timeout(double timeout) override {
         struct timeval tv, *tvp;
-        tvp = measurement_kit::timeval_init(&tv, timeout);
+        tvp = mk::timeval_init(&tv, timeout);
         if (bufferevent_set_timeouts(this->bev, tvp, tvp) != 0) {
             throw std::runtime_error("cannot set timeout");
         }
@@ -122,6 +119,7 @@ class Connection : public Dumb {
 
     void close() override;
 };
-}
-}
+
+} // namespace net
+} // namespace mk
 #endif

--- a/src/net/dumb.hpp
+++ b/src/net/dumb.hpp
@@ -12,10 +12,8 @@
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/net/transport.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
-
-using namespace measurement_kit::common;
 
 class Dumb : public Transport {
   private:
@@ -106,5 +104,5 @@ class Dumb : public Transport {
 };
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -5,7 +5,7 @@
 #include <measurement_kit/net/error.hpp>
 #include "src/net/socks5.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
 
 Socks5::Socks5(Settings s, Logger *lp, Poller *poller)
@@ -165,4 +165,4 @@ Socks5::Socks5(Settings s, Logger *lp, Poller *poller)
 }
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -13,10 +13,8 @@
 #include "src/net/dumb.hpp"
 #include <measurement_kit/net/transport.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
-
-using namespace measurement_kit::common;
 
 class Socks5 : public Dumb {
   protected:
@@ -53,5 +51,5 @@ class Socks5 : public Dumb {
 };
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -7,10 +7,8 @@
 #include "src/net/socks5.hpp"
 #include <measurement_kit/net/transport.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace net {
-
-using namespace measurement_kit::common;
 
 static Var<Transport> connect_internal(Settings settings, Logger *logger,
                                        Poller *poller) {
@@ -66,4 +64,4 @@ Maybe<Var<Transport>> connect(Settings settings, Logger *lp, Poller *poller) {
 }
 
 } // namespace net
-} // namespace measurement_kit
+} // namespace mk

--- a/src/ooni/base_test.cpp
+++ b/src/ooni/base_test.cpp
@@ -10,14 +10,11 @@
 #include <ratio>                               // for ratio
 #include <thread>                              // for sleep_for
 
-namespace measurement_kit {
+namespace mk {
 
-namespace common {
 class NetTest;
-}
 
 namespace ooni {
-using namespace measurement_kit::common;
 
 void BaseTest::run() {
     // XXX Ideally it would be best to run this in the current thread with
@@ -35,4 +32,4 @@ void BaseTest::run(std::function<void()> callback) {
 }
 
 } // namespace ooni
-} // namespace measurement_kit
+} // namespace mk

--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -7,17 +7,15 @@
 #include "src/ooni/dns_injection.hpp"
 #include <sys/stat.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
 
 void DNSInjection::main(std::string input, Settings options,
                         std::function<void(report::Entry)> &&cb) {
     entry["injected"] = NULL;
     have_entry = cb;
-    query("A", "IN", input, options["nameserver"], [this](Response response) {
+    query("A", "IN", input, options["nameserver"],
+            [this](dns::Response response) {
         logger.debug("dns_injection: got response");
         if (response.get_evdns_status() == DNS_ERR_NONE) {
             entry["injected"] = true;
@@ -28,11 +26,12 @@ void DNSInjection::main(std::string input, Settings options,
     });
 }
 
-Var<common::NetTest> DnsInjectionTest::create_test_() {
-    common::NetTest *test = new DNSInjection(input_path, settings);
+Var<mk::NetTest> DnsInjectionTest::create_test_() {
+    mk::NetTest *test = new DNSInjection(input_path, settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
-    return Var<common::NetTest>(test);
+    return Var<mk::NetTest>(test);
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/dns_injection.hpp
+++ b/src/ooni/dns_injection.hpp
@@ -11,11 +11,8 @@
 #include "src/ooni/dns_test.hpp"
 #include <sys/stat.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::report;
 
 class DNSInjection : public DNSTest {
     using DNSTest::DNSTest;
@@ -41,6 +38,7 @@ class DNSInjection : public DNSTest {
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb);
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/dns_test.cpp
+++ b/src/ooni/dns_test.cpp
@@ -5,16 +5,13 @@
 #include <measurement_kit/dns/error.hpp>
 #include "src/ooni/dns_test.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
-using namespace measurement_kit::dns;
-using namespace measurement_kit::common;
-
-void DNSTest::query(QueryType query_type, QueryClass query_class,
+void DNSTest::query(dns::QueryType query_type, dns::QueryClass query_class,
                     std::string query_name, std::string nameserver,
-                    std::function<void(Response)> cb) {
-    resolver = std::make_shared<Resolver>(
+                    std::function<void(dns::Response)> cb) {
+    resolver = std::make_shared<dns::Resolver>(
         Settings{
             {"nameserver", nameserver}, {"attempts", "1"},
         },
@@ -29,17 +26,17 @@ void DNSTest::query(QueryType query_type, QueryClass query_class,
 
     resolver->query(
         query_class, query_type, query_name,
-        [=](Error error, Response response) {
+        [=](Error error, dns::Response response) {
             logger.debug("dns_test: got response!");
             YAML::Node query_entry;
-            if (query_type == QueryTypeId::A) {
+            if (query_type == dns::QueryTypeId::A) {
                 query_entry["query_type"] = "A";
                 query_entry["query"] = "[Query('" + query_name + ", 1, 1')]";
             }
             if (!error) {
                 int idx = 0;
                 for (auto result : response.get_results()) {
-                    if (query_type == QueryTypeId::A) {
+                    if (query_type == dns::QueryTypeId::A) {
                         std::string rr;
                         rr = "<RR name=" + query_name + " ";
                         rr += "type=A class=IN ";
@@ -64,5 +61,6 @@ void DNSTest::query(QueryType query_type, QueryClass query_class,
             logger.debug("dns_test: callback called");
         });
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/dns_test.hpp
+++ b/src/ooni/dns_test.hpp
@@ -10,16 +10,13 @@
 #include <measurement_kit/dns.hpp>
 #include "src/ooni/net_test.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
 
 class DNSTest : public ooni::NetTest {
     using ooni::NetTest::NetTest;
 
-    Var<Resolver> resolver;
+    Var<dns::Resolver> resolver;
 
   public:
     DNSTest(std::string input_filepath_, Settings options_)
@@ -28,10 +25,11 @@ class DNSTest : public ooni::NetTest {
         test_version = "0.0.1";
     };
 
-    void query(QueryType query_type, QueryClass query_class,
+    void query(dns::QueryType query_type, dns::QueryClass query_class,
                std::string query_name, std::string nameserver,
-               std::function<void(Response)> cb);
+               std::function<void(dns::Response)> cb);
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/errors.hpp
+++ b/src/ooni/errors.hpp
@@ -7,7 +7,7 @@
 
 #include <stdexcept>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
 class InputFileDoesNotExist : public std::runtime_error {
@@ -17,6 +17,7 @@ class InputFileDoesNotExist : public std::runtime_error {
 class InputFileRequired : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
-}
-}
+
+} // namespace mk
+} // namespace ooni
 #endif

--- a/src/ooni/http_invalid_request_line.cpp
+++ b/src/ooni/http_invalid_request_line.cpp
@@ -7,10 +7,8 @@
 #include "src/ooni/http_invalid_request_line.hpp"
 #include <sys/stat.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
 
 void HTTPInvalidRequestLine::main(Settings options,
                                   std::function<void(report::Entry)> &&cb) {
@@ -32,7 +30,7 @@ void HTTPInvalidRequestLine::main(Settings options,
     request(
         {
          {"url", options["backend"]},
-         {"method", measurement_kit::random_str_uppercase(4)},
+         {"method", mk::random_str_uppercase(4)},
          {"http_version", "HTTP/1.1"},
         },
         headers, "", handle_response);
@@ -46,7 +44,7 @@ void HTTPInvalidRequestLine::main(Settings options,
     request(
         {
          {"url", options["backend"]},
-         {"method", measurement_kit::random_str_uppercase(1024)},
+         {"method", mk::random_str_uppercase(1024)},
          {"http_version", "HTTP/1.1"},
         },
         headers, "", handle_response);
@@ -57,16 +55,17 @@ void HTTPInvalidRequestLine::main(Settings options,
         {
          {"url", options["backend"]},
          {"method", "GET"},
-         {"http_version", "HTTP/" + measurement_kit::random_str(3)},
+         {"http_version", "HTTP/" + mk::random_str(3)},
         },
         headers, "", handle_response);
 }
 
-Var<common::NetTest> HttpInvalidRequestLineTest::create_test_() {
-    common::NetTest *test = new HTTPInvalidRequestLine(settings);
+Var<mk::NetTest> HttpInvalidRequestLineTest::create_test_() {
+    mk::NetTest *test = new HTTPInvalidRequestLine(settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
-    return Var<common::NetTest>(test);
+    return Var<mk::NetTest>(test);
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/http_invalid_request_line.hpp
+++ b/src/ooni/http_invalid_request_line.hpp
@@ -11,11 +11,8 @@
 #include "src/ooni/http_test.hpp"
 #include <sys/stat.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::report;
 
 class HTTPInvalidRequestLine : public HTTPTest {
     using HTTPTest::HTTPTest;
@@ -32,6 +29,7 @@ class HTTPInvalidRequestLine : public HTTPTest {
 
     void main(Settings options, std::function<void(report::Entry)> &&cb);
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/http_test.hpp
+++ b/src/ooni/http_test.hpp
@@ -9,11 +9,8 @@
 #include <measurement_kit/http/client.hpp>
 #include "src/ooni/net_test.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit;
 
 class HTTPTest : public ooni::NetTest {
     using ooni::NetTest::NetTest;
@@ -66,6 +63,7 @@ class HTTPTest : public ooni::NetTest {
             }, &logger);
     };
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/net_test.cpp
+++ b/src/ooni/net_test.cpp
@@ -6,9 +6,7 @@
 #include "src/ooni/net_test.hpp"
 #include <ctime>
 
-using namespace measurement_kit::common;
-
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
 
 NetTest::NetTest(std::string input_filepath_, Settings options_)
@@ -143,5 +141,6 @@ void NetTest::main(std::string, Settings,
         cb(entry);
     });
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/net_test.hpp
+++ b/src/ooni/net_test.hpp
@@ -17,11 +17,8 @@
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/net_test.hpp>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::report;
 
 class InputGenerator {
 
@@ -67,9 +64,9 @@ class InputFileGenerator : public InputGenerator {
     Logger *logger = Logger::global();
 };
 
-class NetTest : public measurement_kit::common::NetTest {
+class NetTest : public mk::NetTest {
     std::string input_filepath;
-    FileReporter file_report;
+    report::FileReporter file_report;
 
     DelayedCall delayed_call;
 
@@ -135,6 +132,7 @@ class NetTest : public measurement_kit::common::NetTest {
      */
     virtual void end(std::function<void()> cb) override;
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/tcp_connect.cpp
+++ b/src/ooni/tcp_connect.cpp
@@ -6,10 +6,8 @@
 
 #include "src/ooni/tcp_connect.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
 
 void TCPConnect::main(std::string input, Settings options,
                       std::function<void(report::Entry)> &&cb) {
@@ -21,11 +19,12 @@ void TCPConnect::main(std::string input, Settings options,
     });
 }
 
-Var<common::NetTest> TcpConnectTest::create_test_() {
-    common::NetTest *test = new TCPConnect(input_path, settings);
+Var<mk::NetTest> TcpConnectTest::create_test_() {
+    mk::NetTest *test = new TCPConnect(input_path, settings);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
-    return Var<common::NetTest>(test);
+    return Var<mk::NetTest>(test);
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/tcp_connect.hpp
+++ b/src/ooni/tcp_connect.hpp
@@ -9,11 +9,8 @@
 #include "src/ooni/tcp_test.hpp"
 #include <sys/stat.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
-using namespace measurement_kit::report;
 
 class TCPConnect : public TCPTest {
     using TCPTest::TCPTest;
@@ -41,6 +38,7 @@ class TCPConnect : public TCPTest {
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb);
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/ooni/tcp_test.cpp
+++ b/src/ooni/tcp_test.cpp
@@ -5,10 +5,8 @@
 #include "src/ooni/tcp_test.hpp"
 #include "src/net/connection.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace ooni {
-
-using namespace measurement_kit::common;
 
 TCPClient TCPTest::connect(Settings options, std::function<void()> &&cb) {
     if (options["port"] == "") {
@@ -18,7 +16,7 @@ TCPClient TCPTest::connect(Settings options, std::function<void()> &&cb) {
         options["host"] = "localhost";
     }
 
-    auto connection = std::make_shared<Connection>(
+    auto connection = std::make_shared<net::Connection>(
         "PF_UNSPEC", options["host"].c_str(), options["port"].c_str());
 
     //
@@ -39,5 +37,6 @@ TCPClient TCPTest::connect(Settings options, std::function<void()> &&cb) {
 
     return connection;
 }
-}
-}
+
+} // namespace ooni
+} // namespace mk

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -13,16 +13,13 @@
 
 #include "src/ooni/net_test.hpp"
 
-namespace measurement_kit {
-namespace net {
-class Connection;
-}
+namespace mk {
+
+namespace net { class Connection; }
+
 namespace ooni {
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-
-typedef Var<Connection> TCPClient; /* XXX */
+typedef Var<net::Connection> TCPClient; /* XXX */
 
 class TCPTest : public ooni::NetTest {
     using ooni::NetTest::NetTest;
@@ -36,6 +33,7 @@ class TCPTest : public ooni::NetTest {
 
     TCPClient connect(Settings options, std::function<void()> &&cb);
 };
-}
-}
+
+} // namespace ooni
+} // namespace mk
 #endif

--- a/src/report/base_reporter.cpp
+++ b/src/report/base_reporter.cpp
@@ -4,7 +4,7 @@
 
 #include "src/report/base_reporter.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace report {
 
 std::string BaseReporter::getHeader() {
@@ -43,4 +43,4 @@ void BaseReporter::close() {
 }
 
 } // namespace report
-} // namespace measurement_kit
+} // namespace mk

--- a/src/report/base_reporter.hpp
+++ b/src/report/base_reporter.hpp
@@ -10,7 +10,7 @@
 #include <measurement_kit/common/version.hpp>
 #include "src/report/entry.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace report {
 
 class BaseReporter {
@@ -24,7 +24,7 @@ class BaseReporter {
 
     time_t start_time;
 
-    common::Settings options;
+    Settings options;
 
     BaseReporter(){};
 
@@ -38,15 +38,15 @@ class BaseReporter {
 
     virtual void close();
 
-    void on_error(std::function<void(common::Error)> func) { error_fn_ = func; }
+    void on_error(std::function<void(Error)> func) { error_fn_ = func; }
 
-    void emit_error(common::Error err) {
+    void emit_error(Error err) {
         if (!error_fn_) throw err;
         error_fn_(err);
     }
 
   private:
-    std::function<void(common::Error)> error_fn_;
+    std::function<void(Error)> error_fn_;
     bool closed = false;
     bool openned = false;
 
@@ -56,5 +56,5 @@ class BaseReporter {
 };
 
 } // namespace report
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/report/entry.hpp
+++ b/src/report/entry.hpp
@@ -8,7 +8,7 @@
 #include <yaml-cpp/yaml.h>
 #include <ctime>
 
-namespace measurement_kit {
+namespace mk {
 namespace report {
 
 class Entry {
@@ -38,5 +38,5 @@ class Entry {
 };
 
 } // namespace report
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/report/file_reporter.cpp
+++ b/src/report/file_reporter.cpp
@@ -4,7 +4,7 @@
 
 #include "src/report/file_reporter.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace report {
 
 void FileReporter::open() {
@@ -13,7 +13,7 @@ void FileReporter::open() {
         file.open(filename);
         file << getHeader();
     } catch (...) {
-        emit_error(common::GenericError());
+        emit_error(GenericError());
     }
 }
 
@@ -22,7 +22,7 @@ void FileReporter::writeEntry(Entry &entry) {
     try {
         file << entry.str();
     } catch (...) {
-        emit_error(common::GenericError());
+        emit_error(GenericError());
     }
 }
 
@@ -31,9 +31,9 @@ void FileReporter::close() {
     try {
         file.close();
     } catch (...) {
-        emit_error(common::GenericError());
+        emit_error(GenericError());
     }
 }
 
 } // namespace report
-} // namespace measurement_kit
+} // namespace mk

--- a/src/report/file_reporter.hpp
+++ b/src/report/file_reporter.hpp
@@ -10,7 +10,7 @@
 
 #include "src/report/base_reporter.hpp"
 
-namespace measurement_kit {
+namespace mk {
 namespace report {
 
 class FileReporter : public BaseReporter {
@@ -25,5 +25,5 @@ class FileReporter : public BaseReporter {
 };
 
 } // namespace report
-} // namespace measurement_kit
+} // namespace mk
 #endif

--- a/src/traceroute/interface.cpp
+++ b/src/traceroute/interface.cpp
@@ -42,7 +42,7 @@
 #include <netinet/icmp6.h>
 #include <netinet/ip_icmp.h>
 
-namespace measurement_kit {
+namespace mk {
 namespace traceroute {
 
 struct ProbeResultMapping {
@@ -73,20 +73,20 @@ static ProbeResultMapping MAPPINGv6[] = {
 
 ProbeResultMeaning ProbeResult::get_meaning() {
     if (valid_reply) {
-        measurement_kit::debug("type %d code %d meaning %d (got reply packet)",
-                               icmp_type, icmp_code, PRM_::GOT_REPLY_PACKET);
+        mk::debug("type %d code %d meaning %d (got reply packet)",
+                  icmp_type, icmp_code, PRM_::GOT_REPLY_PACKET);
         return PRM_::GOT_REPLY_PACKET;
     }
     for (auto m = is_ipv4 ? &MAPPINGv4[0] : &MAPPINGv6[0];
          m->meaning != PRM_::OTHER; ++m) {
         if (m->type == icmp_type && m->code == icmp_code) {
-            measurement_kit::debug("type %d code %d meaning %d", icmp_type,
-                                   icmp_code, m->meaning);
+            mk::debug("type %d code %d meaning %d", icmp_type,
+                      icmp_code, m->meaning);
             return m->meaning;
         }
     }
-    measurement_kit::debug("type %d code %d meaning %d (other)", icmp_type,
-                           icmp_code, PRM_::OTHER);
+    mk::debug("type %d code %d meaning %d (other)", icmp_type,
+              icmp_code, PRM_::OTHER);
     return PRM_::OTHER;
 }
 
@@ -95,6 +95,6 @@ ProberInterface::~ProberInterface() {}
 #undef PRM_
 
 } // namespace traceroute
-} // namespace measurement_kit
+} // namespace mk
 
 #endif

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -14,24 +14,22 @@
 
 #include <unistd.h>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::ooni;
+using namespace mk;
 
 static void run_http_invalid_request_line(Async &async) {
-    async.run_test(HttpInvalidRequestLineTest()
+    async.run_test(ooni::HttpInvalidRequestLineTest()
                        .set_backend("http://nexa.polito.it/")
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #1: %s\n", s);
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       measurement_kit::debug("test complete: %llu",
-                                              test->identifier());
+                       mk::debug("test complete: %llu", test->identifier());
                    });
 }
 
 static void run_dns_injection(Async &async) {
-    async.run_test(DnsInjectionTest()
+    async.run_test(ooni::DnsInjectionTest()
                        .set_backend("8.8.8.8:53")
                        .set_input_file_path("test/fixtures/hosts.txt")
                        .on_log([](const char *s) {
@@ -39,13 +37,12 @@ static void run_dns_injection(Async &async) {
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       measurement_kit::debug("test complete: %llu",
-                                              test->identifier());
+                       mk::debug("test complete: %llu", test->identifier());
                    });
 }
 
 static void run_tcp_connect(Async &async) {
-    async.run_test(TcpConnectTest()
+    async.run_test(ooni::TcpConnectTest()
                        .set_port("80")
                        .set_input_file_path("test/fixtures/hosts.txt")
                        .on_log([](const char *s) {
@@ -53,8 +50,7 @@ static void run_tcp_connect(Async &async) {
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       measurement_kit::debug("test complete: %llu",
-                                              test->identifier());
+                       mk::debug("test complete: %llu", test->identifier());
                    });
 }
 
@@ -63,7 +59,7 @@ TEST_CASE("The async engine works as expected") {
     Async async;
 
     for (int i = 0; i < 4; ++i) {
-        measurement_kit::debug("do another iteration of tests");
+        mk::debug("do another iteration of tests");
 
         // Create tests in temporary void functions to also check that we can
         // create them in functions that later return in real apps

--- a/test/common/bufferevent.cpp
+++ b/test/common/bufferevent.cpp
@@ -8,7 +8,7 @@
 #include <measurement_kit/common.hpp>
 #include "src/common/bufferevent.hpp"
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 TEST_CASE("Constructors") {
 
@@ -99,7 +99,7 @@ TEST_CASE("Bufferevent operations") {
             ::bufferevent_free(bev);
         };
 
-        Bufferevent b(measurement_kit::get_global_event_base(), -1, 0, &libs);
+        Bufferevent b(mk::get_global_event_base(), -1, 0, &libs);
 
         b.close();
 
@@ -124,9 +124,9 @@ TEST_CASE("Bufferevent operations") {
             ::bufferevent_free(bev);
         };
 
-        Bufferevent b(measurement_kit::get_global_event_base(), -1, 0, &libs);
+        Bufferevent b(mk::get_global_event_base(), -1, 0, &libs);
 
-        b.make(measurement_kit::get_global_event_base(), -1, 0);
+        b.make(mk::get_global_event_base(), -1, 0);
 
         // Ensure that close() was called before creating a new bufferevent
         REQUIRE(called == 1);
@@ -143,7 +143,7 @@ TEST_CASE("Bufferevent operations") {
 
         Bufferevent b(&libs);
 
-        b.make(measurement_kit::get_global_event_base(), -1, 0);
+        b.make(mk::get_global_event_base(), -1, 0);
 
         // Ensure that close() was not called in this case
         REQUIRE(called == 0);
@@ -161,9 +161,9 @@ TEST_CASE("Bufferevent operations") {
                 return bevp;
             };
 
-        Bufferevent b(measurement_kit::get_global_event_base(), -1, 0);
+        Bufferevent b(mk::get_global_event_base(), -1, 0);
 
-        b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
+        b.make(mk::get_global_event_base(), -1, 0, &libs);
 
         // Ensure that bufferevent_socket_new() was called
         REQUIRE(bevp == (bufferevent *)b);
@@ -187,9 +187,9 @@ TEST_CASE("Bufferevent operations") {
 
         Bufferevent b(&libs);
 
-        b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
-        b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
-        b.make(measurement_kit::get_global_event_base(), -1, 0, &libs);
+        b.make(mk::get_global_event_base(), -1, 0, &libs);
+        b.make(mk::get_global_event_base(), -1, 0, &libs);
+        b.make(mk::get_global_event_base(), -1, 0, &libs);
 
         REQUIRE(new_called == 3);
         REQUIRE(free_called == 2);
@@ -200,13 +200,13 @@ TEST_CASE("Bufferevent operations") {
 
         Bufferevent b(&libs);
 
-        b.make(measurement_kit::get_global_event_base(), -1, 0);
+        b.make(mk::get_global_event_base(), -1, 0);
 
         // Check whether the libs is changed as it ought to be
         REQUIRE(b.get_libs() == Libs::global());
 
         auto libs2 = Libs();
-        b.make(measurement_kit::get_global_event_base(), -1, 0, &libs2);
+        b.make(mk::get_global_event_base(), -1, 0, &libs2);
 
         // Check whether the libs is changed as it ought to be
         REQUIRE(b.get_libs() == &libs2);

--- a/test/common/delayed_call.cpp
+++ b/test/common/delayed_call.cpp
@@ -12,7 +12,7 @@
 #include <measurement_kit/common.hpp>
 #include "src/common/delayed_call.hpp"
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 TEST_CASE("Bad allocations triggers a failure ") {
     Libs libs;
@@ -83,8 +83,8 @@ TEST_CASE("Destructor cancels delayed calls") {
         auto called = false;
         auto d1 = new DelayedCall(0.25, [&](void) { called = true; });
         DelayedCall d2(0.249, [&](void) { delete (d1); });
-        DelayedCall d3(0.33, []() { measurement_kit::break_loop(); });
-        measurement_kit::loop();
+        DelayedCall d3(0.33, []() { mk::break_loop(); });
+        mk::loop();
         d1 = NULL; /* Clear the pointer, just in case */
         REQUIRE(called == false);
     }
@@ -106,7 +106,7 @@ TEST_CASE("Delayed call construction") {
         // callback, when we're passed an empty std::function.
         //
         DelayedCall d3(0.0, std::function<void(void)>());
-        DelayedCall d4(0.1, []() { measurement_kit::break_loop(); });
-        measurement_kit::loop();
+        DelayedCall d4(0.1, []() { mk::break_loop(); });
+        mk::loop();
     }
 }

--- a/test/common/evbuffer.cpp
+++ b/test/common/evbuffer.cpp
@@ -12,7 +12,7 @@
 #include <measurement_kit/common.hpp>
 #include "src/common/delayed_call.hpp"
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 TEST_CASE("The constructor is lazy") {
 

--- a/test/common/log.cpp
+++ b/test/common/log.cpp
@@ -16,13 +16,13 @@
 TEST_CASE("By default the logger is quiet") {
     std::string buffer;
 
-    measurement_kit::on_log([&buffer](const char *s) {
+    mk::on_log([&buffer](const char *s) {
         buffer += s;
         buffer += "\n";
     });
 
-    measurement_kit::debug("Antani");
-    measurement_kit::info("Foo");
+    mk::debug("Antani");
+    mk::info("Foo");
 
     REQUIRE(buffer == "");
 }
@@ -30,15 +30,15 @@ TEST_CASE("By default the logger is quiet") {
 TEST_CASE("It is possible to make the logger verbose") {
     std::string buffer;
 
-    measurement_kit::on_log([&buffer](const char *s) {
+    mk::on_log([&buffer](const char *s) {
         buffer += s;
         buffer += "\n";
     });
 
-    measurement_kit::set_verbose(1);
+    mk::set_verbose(1);
 
-    measurement_kit::debug("Antani");
-    measurement_kit::info("Foo");
+    mk::debug("Antani");
+    mk::info("Foo");
 
     REQUIRE(buffer == "Antani\nFoo\n");
 }

--- a/test/common/maybe.cpp
+++ b/test/common/maybe.cpp
@@ -7,7 +7,7 @@
 
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 TEST_CASE("The maybe template works as expected when there is no error") {
     Maybe<int> maybe(0xdeadbeef);

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -16,7 +16,7 @@
 #include <new>
 #include <stdexcept>
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 TEST_CASE("Constructor") {
 

--- a/test/common/socket_valid.cpp
+++ b/test/common/socket_valid.cpp
@@ -3,7 +3,7 @@
 // information on the copying conditions.
 
 //
-// Tests for src/common/utils.hpp's measurement_kit::socket_valid()
+// Tests for src/common/utils.hpp's mk::socket_valid()
 //
 
 #define CATCH_CONFIG_MAIN
@@ -17,25 +17,25 @@
  */
 
 static inline void test_valid_sockets_unix_(void) {
-    REQUIRE(measurement_kit::socket_valid_unix_(0));
-    REQUIRE(measurement_kit::socket_valid_unix_(1));
-    REQUIRE(measurement_kit::socket_valid_unix_(2));
+    REQUIRE(mk::socket_valid_unix_(0));
+    REQUIRE(mk::socket_valid_unix_(1));
+    REQUIRE(mk::socket_valid_unix_(2));
     /* ... */
-    REQUIRE(measurement_kit::socket_valid_unix_(INT_MAX));
+    REQUIRE(mk::socket_valid_unix_(INT_MAX));
 }
 
 static inline void test_invalid_sockets_unix_(void) {
-    REQUIRE(!measurement_kit::socket_valid_unix_(-1));
-    REQUIRE(!measurement_kit::socket_valid_unix_(-2));
+    REQUIRE(!mk::socket_valid_unix_(-1));
+    REQUIRE(!mk::socket_valid_unix_(-2));
     /* ... */
-    REQUIRE(!measurement_kit::socket_valid_unix_(INT_MIN));
+    REQUIRE(!mk::socket_valid_unix_(INT_MIN));
 }
 
 static inline void test_normalize_sockets_unix_(void) {
-    REQUIRE(measurement_kit::socket_normalize_if_invalid_unix_(-1) == -1);
-    REQUIRE(measurement_kit::socket_normalize_if_invalid_unix_(-2) == -1);
+    REQUIRE(mk::socket_normalize_if_invalid_unix_(-1) == -1);
+    REQUIRE(mk::socket_normalize_if_invalid_unix_(-2) == -1);
     /* ... */
-    REQUIRE(measurement_kit::socket_normalize_if_invalid_unix_(INT_MIN) == -1);
+    REQUIRE(mk::socket_normalize_if_invalid_unix_(INT_MIN) == -1);
 }
 
 TEST_CASE("Nonnegative integers are valid sockets on Unix") {
@@ -56,29 +56,29 @@ TEST_CASE("Negative integers are normalized as -1 on Unix") {
  */
 
 static inline void test_valid_sockets_win32_(void) {
-    REQUIRE(measurement_kit::socket_valid_win32_(-2));
-    REQUIRE(measurement_kit::socket_valid_win32_(-3));
-    REQUIRE(measurement_kit::socket_valid_win32_(-4));
+    REQUIRE(mk::socket_valid_win32_(-2));
+    REQUIRE(mk::socket_valid_win32_(-3));
+    REQUIRE(mk::socket_valid_win32_(-4));
     /* ... */
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MIN + 2));
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MIN + 1));
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MIN));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MIN + 2));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MIN + 1));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MIN));
     /* ... */
-    REQUIRE(measurement_kit::socket_valid_win32_(0));
-    REQUIRE(measurement_kit::socket_valid_win32_(1));
-    REQUIRE(measurement_kit::socket_valid_win32_(2));
+    REQUIRE(mk::socket_valid_win32_(0));
+    REQUIRE(mk::socket_valid_win32_(1));
+    REQUIRE(mk::socket_valid_win32_(2));
     /* ... */
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MAX - 2));
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MAX - 1));
-    REQUIRE(measurement_kit::socket_valid_win32_(INTPTR_MAX));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MAX - 2));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MAX - 1));
+    REQUIRE(mk::socket_valid_win32_(INTPTR_MAX));
 }
 
 static inline void test_invalid_sockets_win32_(void) {
-    REQUIRE(!measurement_kit::socket_valid_win32_(-1));
+    REQUIRE(!mk::socket_valid_win32_(-1));
 }
 
 static inline void test_normalize_sockets_win32_(void) {
-    REQUIRE(measurement_kit::socket_normalize_if_invalid_win32_(-1) == -1);
+    REQUIRE(mk::socket_normalize_if_invalid_win32_(-1) == -1);
 }
 
 TEST_CASE("All integers but INVALID_SOCKET are valid sockets on Win32") {

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -9,29 +9,29 @@
 #include "src/common/utils.hpp"
 
 TEST_CASE("IPv4 addresses are correctly reversed") {
-    REQUIRE(measurement_kit::unreverse_ipv4("211.91.192.130.in-addr.arpa") ==
+    REQUIRE(mk::unreverse_ipv4("211.91.192.130.in-addr.arpa") ==
             "130.192.91.211");
-    REQUIRE(measurement_kit::unreverse_ipv4("4.3.2.1.in-addr.arpa.") ==
+    REQUIRE(mk::unreverse_ipv4("4.3.2.1.in-addr.arpa.") ==
             "1.2.3.4");
-    REQUIRE(measurement_kit::unreverse_ipv4("22.177.3.149.in-addr.arpa") ==
+    REQUIRE(mk::unreverse_ipv4("22.177.3.149.in-addr.arpa") ==
             "149.3.177.22");
 }
 
 TEST_CASE("IPv4 addresses cannot contain numbers > 255") {
-    REQUIRE(measurement_kit::unreverse_ipv4("254.777.254.254.in-addr.arpa") ==
+    REQUIRE(mk::unreverse_ipv4("254.777.254.254.in-addr.arpa") ==
             "");
-    REQUIRE(measurement_kit::unreverse_ipv4("255.255.255.255.in-addr.arpa") ==
+    REQUIRE(mk::unreverse_ipv4("255.255.255.255.in-addr.arpa") ==
             "255.255.255.255");
 }
 
 TEST_CASE("IPv6 addresses are correctly reversed") {
-    REQUIRE(measurement_kit::unreverse_ipv6(
+    REQUIRE(mk::unreverse_ipv6(
                 "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0."
                 "2.ip6.arpa") == "2001:0db8:0000:0000:0000:0000:0567:89ab");
-    REQUIRE(measurement_kit::unreverse_ipv6(
+    REQUIRE(mk::unreverse_ipv6(
                 "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0."
                 "2.ip6.arpa.") == "2001:0db8:0000:0000:0000:0000:0000:0001");
-    REQUIRE(measurement_kit::unreverse_ipv6(
+    REQUIRE(mk::unreverse_ipv6(
                 "4.0.0.2.0.0.0.0.0.0.0.0.0.0.0.0.8.0.8.0.2.0.0.4.0.5.4.1.0.0.a."
                 "2.ip6.arpa") == "2a00:1450:4002:0808:0000:0000:0000:2004");
 }
@@ -39,27 +39,27 @@ TEST_CASE("IPv6 addresses are correctly reversed") {
 TEST_CASE("Verify that invalid input is rejected") {
 
     SECTION("For IPv4") {
-        REQUIRE(measurement_kit::unreverse_ipv4("") == "");
+        REQUIRE(mk::unreverse_ipv4("") == "");
         // First non number non dot character we break and search in-addr.arpa
-        REQUIRE(measurement_kit::unreverse_ipv4("foobar") == "");
+        REQUIRE(mk::unreverse_ipv4("foobar") == "");
         // We deal correctly with good address with missing suffix
-        REQUIRE(measurement_kit::unreverse_ipv4("4.3.2.1") == "");
-        REQUIRE(measurement_kit::unreverse_ipv4("4.3.2.1.") == "");
+        REQUIRE(mk::unreverse_ipv4("4.3.2.1") == "");
+        REQUIRE(mk::unreverse_ipv4("4.3.2.1.") == "");
     }
 
     SECTION("For IPv6") {
-        REQUIRE(measurement_kit::unreverse_ipv6("") == "");
+        REQUIRE(mk::unreverse_ipv6("") == "");
         // We encounter a character that is not a dot in position N + 1
-        REQUIRE(measurement_kit::unreverse_ipv6("e.2.1;d.e.a.d") == "");
+        REQUIRE(mk::unreverse_ipv6("e.2.1;d.e.a.d") == "");
         // We encounter a character that is not hex in position N
-        REQUIRE(measurement_kit::unreverse_ipv6("d.e.a.d.r.e.e.f") == "");
+        REQUIRE(mk::unreverse_ipv6("d.e.a.d.r.e.e.f") == "");
         // We deal correctly with good address with missing suffix
         REQUIRE(
-            measurement_kit::unreverse_ipv6(
+            mk::unreverse_ipv6(
                 "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0."
                 "2") == "");
         REQUIRE(
-            measurement_kit::unreverse_ipv6(
+            mk::unreverse_ipv6(
                 "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0."
                 "2.") == "");
     }

--- a/test/common/var.cpp
+++ b/test/common/var.cpp
@@ -11,7 +11,7 @@
 
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
+using namespace mk;
 
 struct Foo {
     double elem = 3.14;

--- a/test/dns/defines.cpp
+++ b/test/dns/defines.cpp
@@ -8,8 +8,8 @@
 #include <measurement_kit/dns.hpp>
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
+using namespace mk;
+using namespace mk::dns;
 
 TEST_CASE("QueryClass works as expected") {
     QueryClass qclass(QueryClassId::IN);

--- a/test/dns/error.cpp
+++ b/test/dns/error.cpp
@@ -10,42 +10,42 @@
 
 #include <event2/dns.h>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
+using namespace mk;
+using namespace mk::dns;
 
 TEST_CASE("Evdns errors are correctly mapped to OONI failures") {
 
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_NONE).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_NONE).as_ooni_error() ==
             "");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_FORMAT).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_FORMAT).as_ooni_error() ==
             "dns_lookup_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_SERVERFAILED)
+    REQUIRE(mk::dns::dns_error(DNS_ERR_SERVERFAILED)
                 .as_ooni_error() == "dns_lookup_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_NOTEXIST).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_NOTEXIST).as_ooni_error() ==
             "dns_lookup_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_NOTIMPL).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_NOTIMPL).as_ooni_error() ==
             "dns_lookup_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_REFUSED).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_REFUSED).as_ooni_error() ==
             "dns_lookup_error");
 
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_TRUNCATED)
+    REQUIRE(mk::dns::dns_error(DNS_ERR_TRUNCATED)
                 .as_ooni_error() == "dns_lookup_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_UNKNOWN).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_UNKNOWN).as_ooni_error() ==
             "unknown_failure 2006");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_TIMEOUT).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_TIMEOUT).as_ooni_error() ==
             "generic_timeout_error");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_SHUTDOWN).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_SHUTDOWN).as_ooni_error() ==
             "unknown_failure 2008");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_CANCEL).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_CANCEL).as_ooni_error() ==
             "unknown_failure 2009");
-    REQUIRE(measurement_kit::dns::dns_error(DNS_ERR_NODATA).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(DNS_ERR_NODATA).as_ooni_error() ==
             "dns_lookup_error");
 
     // Just three random numbers to increase confidence...
-    REQUIRE(measurement_kit::dns::dns_error(1024).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(1024).as_ooni_error() ==
             "unknown_failure 1");
-    REQUIRE(measurement_kit::dns::dns_error(1025).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(1025).as_ooni_error() ==
             "unknown_failure 1");
-    REQUIRE(measurement_kit::dns::dns_error(1026).as_ooni_error() ==
+    REQUIRE(mk::dns::dns_error(1026).as_ooni_error() ==
             "unknown_failure 1");
 }

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -13,8 +13,8 @@
 #include "src/common/libs_impl.hpp"
 #include "src/common/check_connectivity.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
+using namespace mk;
+using namespace mk::dns;
 
 //
 // TODO: make sure that Query() correctly handle `dnsb` and `libs`.
@@ -169,7 +169,7 @@ TEST_CASE("Query::cancel() is safe when a request is pending") {
         // the Query immediately, so we don't have a callback where
         // to report that we are done and we need to break the loop.
         //
-        measurement_kit::break_loop();
+        mk::break_loop();
     };
 
     auto failed = false;
@@ -181,12 +181,12 @@ TEST_CASE("Query::cancel() is safe when a request is pending") {
             // itself rather than calling the callback.
             //
             failed = true;
-            measurement_kit::break_loop();
+            mk::break_loop();
         }, Logger::global(), NULL, &libs);
 
     } // This kills Query, but not the underlying QueryImpl
 
-    measurement_kit::loop();
+    mk::loop();
     REQUIRE(!failed);
     REQUIRE(!bad_code);
     REQUIRE(called);
@@ -261,7 +261,7 @@ TEST_CASE("The system resolver works as expected") {
 
     DelayedCall d(10.0, [&](void) {
         failed = true;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
     auto r1 =
@@ -273,9 +273,9 @@ TEST_CASE("The system resolver works as expected") {
             REQUIRE(response.get_results()[0] == "130.192.16.172");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     auto r2 = Query(
         "IN", "REVERSE_A", "130.192.16.172", [&](Error e, Response response) {
@@ -286,9 +286,9 @@ TEST_CASE("The system resolver works as expected") {
             REQUIRE(response.get_results()[0] == "server-nexa.polito.it");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     auto r2bis =
         Query("IN", "PTR", "172.16.192.130.in-addr.arpa.",
@@ -300,9 +300,9 @@ TEST_CASE("The system resolver works as expected") {
                   REQUIRE(response.get_results()[0] == "server-nexa.polito.it");
                   REQUIRE(response.get_rtt() > 0.0);
                   REQUIRE(response.get_ttl() > 0);
-                  measurement_kit::break_loop();
+                  mk::break_loop();
               });
-    measurement_kit::loop();
+    mk::loop();
 
     auto r3 = Query(
         "IN", "AAAA", "ooni.torproject.org", [&](Error e, Response response) {
@@ -319,9 +319,9 @@ TEST_CASE("The system resolver works as expected") {
                 }
             }
             REQUIRE(found);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     auto r4 = Query(
         "IN", "REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
@@ -333,9 +333,9 @@ TEST_CASE("The system resolver works as expected") {
             REQUIRE(response.get_results()[0] == "listera.torproject.org");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     auto r4bis = Query(
         "IN", "PTR", "6.2.4.1.0.2.e.f.f.f.1.2.3.1.2.0.b.e.d.0.2.0.2.0.8.b.1.4."
@@ -348,9 +348,9 @@ TEST_CASE("The system resolver works as expected") {
             REQUIRE(response.get_results()[0] == "listera.torproject.org");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     REQUIRE(!failed);
 }
@@ -364,7 +364,7 @@ class SafeToDeleteQueryInItsOwnCallback {
             // This assignment should trigger the original request's destructor
             request =
                 Query("IN", "AAAA", "nexa.polito.it", [this](Error, Response) {
-                    measurement_kit::break_loop();
+                    mk::break_loop();
                 });
         });
     }
@@ -378,8 +378,8 @@ TEST_CASE("It is safe to clear a request in its own callback") {
     auto called = 0;
     DelayedCall watchdog(5.0, [&called]() {
         ++called;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
     REQUIRE(called == 0);
 }

--- a/test/dns/resolver.cpp
+++ b/test/dns/resolver.cpp
@@ -13,8 +13,8 @@
 #include "src/dns/query.hpp"
 #include "src/common/check_connectivity.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
+using namespace mk;
+using namespace mk::dns;
 
 //
 // Resolver unit tests.
@@ -178,7 +178,7 @@ TEST_CASE("We can override the default timeout") {
                            {"attempts", "1"},
                            {"timeout", "0.5"}});
 
-    auto ticks = measurement_kit::time_now();
+    auto ticks = mk::time_now();
     reso.query("IN", "A", "www.neubot.org", [&](Error e, Response response) {
         REQUIRE(e == TimeoutError());
         REQUIRE(response.get_reply_authoritative() == "unknown");
@@ -187,15 +187,15 @@ TEST_CASE("We can override the default timeout") {
         REQUIRE(response.get_ttl() == 0);
         REQUIRE(response.get_rtt() == 0.0);
 
-        auto elapsed = measurement_kit::time_now() - ticks;
+        auto elapsed = mk::time_now() - ticks;
         // This interval is wide so the unit tests does not fail when
         // we run it using valgrind on slow machines
         REQUIRE(elapsed > 0.3);
         REQUIRE(elapsed < 0.7);
 
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("We can override the default number of tries") {
@@ -205,7 +205,7 @@ TEST_CASE("We can override the default number of tries") {
         {"nameserver", "130.192.91.231"}, {"attempts", "2"}, {"timeout", "0.5"},
     });
 
-    auto ticks = measurement_kit::time_now();
+    auto ticks = mk::time_now();
     reso.query("IN", "A", "www.neubot.org", [&](Error e, Response response) {
         REQUIRE(e == TimeoutError());
         REQUIRE(response.get_reply_authoritative() == "unknown");
@@ -214,13 +214,13 @@ TEST_CASE("We can override the default number of tries") {
         REQUIRE(response.get_ttl() == 0);
         REQUIRE(response.get_rtt() == 0.0);
 
-        auto elapsed = measurement_kit::time_now() - ticks;
+        auto elapsed = mk::time_now() - ticks;
         REQUIRE(elapsed > 0.8);
         REQUIRE(elapsed < 1.2);
 
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 //
@@ -240,7 +240,7 @@ TEST_CASE("The default custom resolver works as expected") {
 
     DelayedCall d(10.0, [&](void) {
         failed = true;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
     Resolver reso;
@@ -253,9 +253,9 @@ TEST_CASE("The default custom resolver works as expected") {
         REQUIRE(response.get_results()[0] == "130.192.16.172");
         REQUIRE(response.get_rtt() > 0.0);
         REQUIRE(response.get_ttl() > 0);
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query(
         "IN", "REVERSE_A", "130.192.16.172", [&](Error e, Response response) {
@@ -266,9 +266,9 @@ TEST_CASE("The default custom resolver works as expected") {
             REQUIRE(response.get_results()[0] == "server-nexa.polito.it");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "PTR", "172.16.192.130.in-addr.arpa.",
                [&](Error e, Response response) {
@@ -280,9 +280,9 @@ TEST_CASE("The default custom resolver works as expected") {
                            "server-nexa.polito.it");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "AAAA", "ooni.torproject.org",
                [&](Error e, Response response) {
@@ -299,9 +299,9 @@ TEST_CASE("The default custom resolver works as expected") {
                        }
                    }
                    REQUIRE(found);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
                [&](Error e, Response response) {
@@ -313,9 +313,9 @@ TEST_CASE("The default custom resolver works as expected") {
                            "listera.torproject.org");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "PTR", "6.2.4.1.0.2.e.f.f.f.1.2.3.1.2.0.b.e.d.0.2.0.2.0.8."
                             "b.1.4.1.0.0.2.ip6.arpa.",
@@ -328,9 +328,9 @@ TEST_CASE("The default custom resolver works as expected") {
                            "listera.torproject.org");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     REQUIRE(!failed);
 }
@@ -345,7 +345,7 @@ TEST_CASE("A specific custom resolver works as expected") {
 
     DelayedCall d(10.0, [&](void) {
         failed = true;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
     Resolver reso(Settings({
@@ -360,9 +360,9 @@ TEST_CASE("A specific custom resolver works as expected") {
         REQUIRE(response.get_results()[0] == "130.192.16.172");
         REQUIRE(response.get_rtt() > 0.0);
         REQUIRE(response.get_ttl() > 0);
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query(
         "IN", "REVERSE_A", "130.192.16.172", [&](Error e, Response response) {
@@ -373,9 +373,9 @@ TEST_CASE("A specific custom resolver works as expected") {
             REQUIRE(response.get_results()[0] == "server-nexa.polito.it");
             REQUIRE(response.get_rtt() > 0.0);
             REQUIRE(response.get_ttl() > 0);
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "PTR", "172.16.192.130.in-addr.arpa.",
                [&](Error e, Response response) {
@@ -387,9 +387,9 @@ TEST_CASE("A specific custom resolver works as expected") {
                            "server-nexa.polito.it");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "AAAA", "ooni.torproject.org",
                [&](Error e, Response response) {
@@ -406,9 +406,9 @@ TEST_CASE("A specific custom resolver works as expected") {
                        }
                    }
                    REQUIRE(found);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "REVERSE_AAAA", "2001:41b8:202:deb:213:21ff:fe20:1426",
                [&](Error e, Response response) {
@@ -420,9 +420,9 @@ TEST_CASE("A specific custom resolver works as expected") {
                            "listera.torproject.org");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     reso.query("IN", "PTR", "6.2.4.1.0.2.e.f.f.f.1.2.3.1.2.0.b.e.d.0.2.0.2.0.8."
                             "b.1.4.1.0.0.2.ip6.arpa.",
@@ -435,9 +435,9 @@ TEST_CASE("A specific custom resolver works as expected") {
                            "listera.torproject.org");
                    REQUIRE(response.get_rtt() > 0.0);
                    REQUIRE(response.get_ttl() > 0);
-                   measurement_kit::break_loop();
+                   mk::break_loop();
                });
-    measurement_kit::loop();
+    mk::loop();
 
     REQUIRE(!failed);
 }
@@ -460,7 +460,7 @@ TEST_CASE("If the resolver dies the requests are aborted") {
         REQUIRE(response.get_evdns_status() == DNS_ERR_SHUTDOWN);
         REQUIRE(response.get_ttl() == 0);
         REQUIRE(response.get_rtt() == 0.0);
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
     DelayedCall d1(0.1, [&](void) {
@@ -473,10 +473,10 @@ TEST_CASE("If the resolver dies the requests are aborted") {
         // This *should not* be called, since the request callback
         // shold be called before than this one.
         failed = true;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
-    measurement_kit::loop();
+    mk::loop();
 
     REQUIRE(!failed);
 }
@@ -506,16 +506,16 @@ TEST_CASE("A request to a nonexistent server times out") {
         REQUIRE(response.get_evdns_status() == DNS_ERR_TIMEOUT);
         REQUIRE(response.get_ttl() == 0);
         REQUIRE(response.get_rtt() == 0.0);
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
     auto failed = false;
     DelayedCall d(10.0, [&](void) {
         failed = true;
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
 
-    measurement_kit::loop();
+    mk::loop();
 
     REQUIRE(!failed);
 }
@@ -551,9 +551,9 @@ TEST_CASE("It is safe to cancel requests in flight") {
                            total += response.get_rtt();
                            count += 1;
                        }
-                       measurement_kit::break_loop();
+                       mk::break_loop();
                    });
-        measurement_kit::loop();
+        mk::loop();
     }
     // We need at lest 8 good responses to compute the average
     // We do not require 16 to tolerate a few losses
@@ -568,15 +568,15 @@ TEST_CASE("It is safe to cancel requests in flight") {
             auto status_ok = (e == CancelError() || e == NoError());
             REQUIRE(status_ok);
             // Ignoring all the other fields here
-            measurement_kit::warn("- break_loop");
-            measurement_kit::break_loop();
+            mk::warn("- break_loop");
+            mk::break_loop();
         }, Logger::global(), reso.get_evdns_base());
         DelayedCall d(avgrtt, [&](void) {
-            measurement_kit::warn("- cancel");
+            mk::warn("- cancel");
             r->cancel();
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-        measurement_kit::loop();
+        mk::loop();
         delete r;
     }
 }
@@ -602,8 +602,8 @@ TEST_CASE("Make sure we can override host and number of tries") {
         REQUIRE(response.get_results().size() == 0);
         REQUIRE(e == TimeoutError());
         // Assuming all the other fields are OK
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 */

--- a/test/dns/response.cpp
+++ b/test/dns/response.cpp
@@ -11,8 +11,8 @@
 #include "src/common/utils.hpp"
 #include "src/common/delayed_call.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::dns;
+using namespace mk;
+using namespace mk::dns;
 
 //
 // Response unit tests.
@@ -38,7 +38,7 @@ TEST_CASE("The default Response() constructor sets sensible values") {
 //
 
 TEST_CASE("Response(...) only computes RTT when the server actually replied") {
-    auto ticks = measurement_kit::time_now() - 3.0;
+    auto ticks = mk::time_now() - 3.0;
 
     for (auto code = 0; code < 128; ++code) {
         auto r = Response(code, DNS_IPv4_A, 0, 123, ticks, NULL);

--- a/test/http/client.cpp
+++ b/test/http/client.cpp
@@ -12,9 +12,8 @@
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/http.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-using namespace measurement_kit::http;
+using namespace mk;
+using namespace mk::http;
 
 TEST_CASE("HTTP Client works as expected") {
     auto client = Client();
@@ -35,7 +34,7 @@ TEST_CASE("HTTP Client works as expected") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
@@ -52,7 +51,7 @@ TEST_CASE("HTTP Client works as expected") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
@@ -69,11 +68,11 @@ TEST_CASE("HTTP Client works as expected") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("HTTP Client works as expected over Tor") {
@@ -97,7 +96,7 @@ TEST_CASE("HTTP Client works as expected over Tor") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
@@ -116,7 +115,7 @@ TEST_CASE("HTTP Client works as expected over Tor") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
@@ -135,11 +134,11 @@ TEST_CASE("HTTP Client works as expected over Tor") {
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
             if (++count >= 3) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
@@ -158,10 +157,10 @@ TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
             std::cout << "Error: " << (int)error << std::endl;
             std::cout << response.body << "\r\n";
             std::cout << "[snip]\r\n";
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
 
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("Make sure that settings are not modified") {
@@ -185,10 +184,10 @@ TEST_CASE("Make sure that settings are not modified") {
                        std::cout << "Error: " << (int)error << std::endl;
                        std::cout << response.body << "\r\n";
                        std::cout << "[snip]\r\n";
-                       measurement_kit::break_loop();
+                       mk::break_loop();
                    });
 
-    measurement_kit::loop();
+    mk::loop();
 
     // Make sure that no changes were made
     for (auto &iter : settings) {

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -14,9 +14,9 @@
 
 #include "src/http/request.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-using namespace measurement_kit::http;
+using namespace mk;
+using namespace mk::net;
+using namespace mk::http;
 
 TEST_CASE("HTTP Request works as expected") {
     Request r(
@@ -31,7 +31,7 @@ TEST_CASE("HTTP Request works as expected") {
         "", [&](Error error, Response &&response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
-                measurement_kit::break_loop();
+                mk::break_loop();
                 return;
             }
             std::cout << "HTTP/" << response.http_major << "."
@@ -43,9 +43,9 @@ TEST_CASE("HTTP Request works as expected") {
             std::cout << "\r\n";
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("HTTP request behaves correctly when EOF indicates body END") {
@@ -101,7 +101,7 @@ TEST_CASE("HTTP Request correctly receives errors") {
         "", [&](Error error, Response &&response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
-                measurement_kit::break_loop();
+                mk::break_loop();
                 return;
             }
             std::cout << "HTTP/" << response.http_major << "."
@@ -113,9 +113,9 @@ TEST_CASE("HTTP Request correctly receives errors") {
             std::cout << "\r\n";
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("HTTP Request works as expected over Tor") {
@@ -132,7 +132,7 @@ TEST_CASE("HTTP Request works as expected over Tor") {
         "", [&](Error error, Response &&response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
-                measurement_kit::break_loop();
+                mk::break_loop();
                 return;
             }
             std::cout << "HTTP/" << response.http_major << "."
@@ -144,9 +144,9 @@ TEST_CASE("HTTP Request works as expected over Tor") {
             std::cout << "\r\n";
             std::cout << response.body.substr(0, 128) << "\r\n";
             std::cout << "[snip]\r\n";
-            measurement_kit::break_loop();
+            mk::break_loop();
         });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("Behavior is correct when only tor_socks_port is specified") {

--- a/test/http/request_serializer.cpp
+++ b/test/http/request_serializer.cpp
@@ -14,9 +14,9 @@
 
 #include "src/http/request_serializer.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-using namespace measurement_kit::http;
+using namespace mk;
+using namespace mk::net;
+using namespace mk::http;
 
 TEST_CASE("HTTP Request serializer works as expected") {
     auto serializer = RequestSerializer(

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -10,9 +10,9 @@
 
 #include "src/http/response_parser.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-using namespace measurement_kit::http;
+using namespace mk;
+using namespace mk::net;
+using namespace mk::http;
 
 TEST_CASE("We don't leak when we receive an invalid message") {
 
@@ -96,7 +96,7 @@ TEST_CASE("The HTTP response parser works as expected") {
     parser.on_end([&](void) { REQUIRE(body == "1234567"); });
 
     for (auto c : data) {
-        measurement_kit::debug("%c\n", c);
+        mk::debug("%c\n", c);
         parser.feed(c);
     }
 
@@ -134,7 +134,7 @@ TEST_CASE("The HTTP response parser works as expected") {
     parser.on_end([&](void) { REQUIRE(body == "abcabcabc"); });
 
     for (auto c : data) {
-        measurement_kit::debug("%c\n", c);
+        mk::debug("%c\n", c);
         parser.feed(c);
     }
 }

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -15,9 +15,9 @@
 #include "src/http/stream.hpp"
 #include "src/common/check_connectivity.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
-using namespace measurement_kit::http;
+using namespace mk;
+using namespace mk::net;
+using namespace mk::http;
 
 TEST_CASE("HTTP stream works as expected") {
     if (CheckConnectivity::is_down()) {
@@ -27,13 +27,13 @@ TEST_CASE("HTTP stream works as expected") {
         {"address", "www.google.com"}, {"port", "80"},
     });
     stream->on_connect([&]() {
-        measurement_kit::debug("Connection made... sending request");
+        mk::debug("Connection made... sending request");
         *stream << "GET /robots.txt HTTP/1.1\r\n"
                 << "Host: www.google.com\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
         stream->on_flush([]() {
-            measurement_kit::debug("Request sent... waiting for response");
+            mk::debug("Request sent... waiting for response");
         });
         stream->on_headers_complete(
             [&](unsigned short major, unsigned short minor, unsigned int status,
@@ -47,14 +47,14 @@ TEST_CASE("HTTP stream works as expected") {
                 stream->on_end([&](void) {
                     std::cout << "\r\n";
                     stream->close();
-                    measurement_kit::break_loop();
+                    mk::break_loop();
                 });
                 stream->on_body([&](std::string && /*chunk*/) {
                     // std::cout << chunk;
                 });
             });
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("HTTP stream is robust to EOF") {
@@ -102,18 +102,18 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
     });
     stream->set_timeout(1.0);
     stream->on_error([&](Error e) {
-        measurement_kit::debug("Connection error: %d", (int)e);
+        mk::debug("Connection error: %d", (int)e);
         stream->close();
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
     stream->on_connect([&]() {
-        measurement_kit::debug("Connection made... sending request");
+        mk::debug("Connection made... sending request");
         *stream << "GET /robots.txt HTTP/1.1\r\n"
                 << "Host: www.google.com\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
         stream->on_flush([]() {
-            measurement_kit::debug("Request sent... waiting for response");
+            mk::debug("Request sent... waiting for response");
         });
         stream->on_headers_complete(
             [&](unsigned short major, unsigned short minor, unsigned int status,
@@ -127,14 +127,14 @@ TEST_CASE("HTTP stream works as expected when using Tor") {
                 stream->on_end([&](void) {
                     std::cout << "\r\n";
                     stream->close();
-                    measurement_kit::break_loop();
+                    mk::break_loop();
                 });
                 stream->on_body([&](std::string && /*chunk*/) {
                     // std::cout << chunk;
                 });
             });
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("HTTP stream receives connection errors") {
@@ -146,9 +146,9 @@ TEST_CASE("HTTP stream receives connection errors") {
     });
     stream->set_timeout(1.0);
     stream->on_error([&](Error e) {
-        measurement_kit::debug("Connection error: %d", (int)e);
+        mk::debug("Connection error: %d", (int)e);
         stream->close();
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -14,8 +14,8 @@
 
 #include <event2/buffer.h>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+using namespace mk;
+using namespace mk::net;
 
 TEST_CASE("The constructor works correctly", "[Buffer]") {
     REQUIRE_NOTHROW(Buffer());

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -16,8 +16,8 @@
 #include "src/net/connection.hpp"
 #include "src/common/check_connectivity.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+using namespace mk;
+using namespace mk::net;
 
 TEST_CASE("Connection::close() is idempotent") {
     if (CheckConnectivity::is_down()) {
@@ -33,9 +33,9 @@ TEST_CASE("Connection::close() is idempotent") {
         // It shall be safe to call close() more than once
         s.close();
         s.close();
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("It is safe to manipulate Connection after close") {
@@ -53,9 +53,9 @@ TEST_CASE("It is safe to manipulate Connection after close") {
         // where safe means that we don't segfault
         REQUIRE_THROWS(s.enable_read());
         REQUIRE_THROWS(s.disable_read());
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("It is safe to close Connection while resolve is in progress") {
@@ -64,8 +64,8 @@ TEST_CASE("It is safe to close Connection while resolve is in progress") {
     }
     Connection s("PF_INET", "nexa.polito.it", "80");
     DelayedCall unsched(0.001, [&s]() { s.close(); });
-    DelayedCall bail_out(2.0, []() { measurement_kit::break_loop(); });
-    measurement_kit::loop();
+    DelayedCall bail_out(2.0, []() { mk::break_loop(); });
+    mk::loop();
 }
 
 TEST_CASE("connect() iterates over all the available addresses") {
@@ -77,9 +77,9 @@ TEST_CASE("connect() iterates over all the available addresses") {
     s.on_error([](Error error) {
         auto ok = (error == SocketError() || error == ConnectFailedError());
         REQUIRE(ok);
-        measurement_kit::break_loop();
+        mk::break_loop();
     });
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("It is possible to use Connection with a custom poller") {

--- a/test/net/connection_check_fds.cpp
+++ b/test/net/connection_check_fds.cpp
@@ -15,8 +15,8 @@
 
 #include "src/net/connection.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+using namespace mk;
+using namespace mk::net;
 
 TEST_CASE("Ensure that the constructor socket-validity checks work") {
 

--- a/test/net/transport.cpp
+++ b/test/net/transport.cpp
@@ -10,8 +10,8 @@
 
 #include "src/common/check_connectivity.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::net;
+using namespace mk;
+using namespace mk::net;
 
 TEST_CASE("It is possible to use Transport with a custom poller") {
     // Note: this is how Portolan uses measurement-kit
@@ -19,7 +19,7 @@ TEST_CASE("It is possible to use Transport with a custom poller") {
         return;
     }
     Poller poller;
-    Maybe<Var<Transport>> maybe_s = measurement_kit::net::connect({
+    Maybe<Var<Transport>> maybe_s = mk::net::connect({
         {"family", "PF_UNSPEC"},
         {"address", "nexa.polito.it"},
         {"port", "22"},

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -8,8 +8,8 @@
 #include "src/ooni/dns_injection.hpp"
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::ooni;
+using namespace mk;
+using namespace mk::ooni;
 
 TEST_CASE(
     "The DNS Injection test should run with an input file of DNS hostnames") {
@@ -17,8 +17,8 @@ TEST_CASE(
     options["nameserver"] = "8.8.8.1:53";
     DNSInjection dns_injection("test/fixtures/hosts.txt", options);
     dns_injection.begin(
-        [&]() { dns_injection.end([]() { measurement_kit::break_loop(); }); });
-    measurement_kit::loop();
+        [&]() { dns_injection.end([]() { mk::break_loop(); }); });
+    mk::loop();
 }
 
 TEST_CASE("The DNS Injection test should throw an exception if an invalid file "

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -12,8 +12,7 @@
 #include <string>
 #include <thread>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit;
+using namespace mk;
 
 TEST_CASE("Synchronous dns-injection test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -8,15 +8,15 @@
 #include "src/ooni/http_invalid_request_line.hpp"
 #include <measurement_kit/common.hpp>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::ooni;
+using namespace mk;
+using namespace mk::ooni;
 
 TEST_CASE("The HTTP Invalid Request Line test should run") {
     Settings options;
     options["backend"] = "http://213.138.109.232/";
     HTTPInvalidRequestLine http_invalid_request_line(options);
     http_invalid_request_line.begin([&]() {
-        http_invalid_request_line.end([]() { measurement_kit::break_loop(); });
+        http_invalid_request_line.end([]() { mk::break_loop(); });
     });
-    measurement_kit::loop();
+    mk::loop();
 }

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -12,8 +12,7 @@
 #include <string>
 #include <thread>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit;
+using namespace mk;
 
 TEST_CASE("Synchronous http-invalid-request-line test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);

--- a/test/ooni/net_test.cpp
+++ b/test/ooni/net_test.cpp
@@ -8,10 +8,10 @@
 #include <measurement_kit/common.hpp>
 #include "src/ooni/net_test.hpp"
 
-using namespace measurement_kit::ooni;
+using namespace mk::ooni;
 
 TEST_CASE("The NetTest should callback when it has finished running") {
-    measurement_kit::ooni::NetTest test("");
-    test.begin([&]() { test.end([]() { measurement_kit::break_loop(); }); });
-    measurement_kit::loop();
+    mk::ooni::NetTest test("");
+    test.begin([&]() { test.end([]() { mk::break_loop(); }); });
+    mk::loop();
 }

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -8,8 +8,8 @@
 #include <measurement_kit/common.hpp>
 #include "src/ooni/tcp_connect.hpp"
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::ooni;
+using namespace mk;
+using namespace mk::ooni;
 
 TEST_CASE(
     "The TCP connect test should run with an input file of DNS hostnames") {
@@ -17,8 +17,8 @@ TEST_CASE(
                                                        {"port", "80"},
                                                       });
     tcp_connect.begin(
-        [&]() { tcp_connect.end([]() { measurement_kit::break_loop(); }); });
-    measurement_kit::loop();
+        [&]() { tcp_connect.end([]() { mk::break_loop(); }); });
+    mk::loop();
 }
 
 TEST_CASE("The TCP connect test should throw an exception if an invalid file "

--- a/test/ooni/tcp_connect_test.cpp
+++ b/test/ooni/tcp_connect_test.cpp
@@ -12,8 +12,7 @@
 #include <string>
 #include <thread>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit;
+using namespace mk;
 
 TEST_CASE("Synchronous tcp-connect test") {
     Var<std::list<std::string>> logs(new std::list<std::string>);

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -10,43 +10,8 @@
 
 #include <iostream>
 
-using namespace measurement_kit::common;
-using namespace measurement_kit::ooni;
-
-TEST_CASE("TCPTest test should run") {
-#if 0
-
-    auto client = TCPClient("www.torproject.org", "80");
-
-    client.on("error", [](Error error) {
-        std::cout << std::endl;  // Terminate eventual body
-        if (error.error == 0) {
-            std::cout << "Error: " << error.error << std::endl;
-        }
-        measurement_kit::break_loop();
-    });
-
-    client.on("connect", [&]() {
-        std::cout << "Connection established..." << std::endl;
-
-        client.write("GET /robots.txt HTTP/1.1\r\n"
-                     "Connection: close\r\n"
-                     "Host: www.neubot.org\r\n"
-                     "Accept: */*\r\n"
-                     "\r\n");
-
-        client.on("flush", []() {
-            std::cout << "Request sent... waiting for response" << std::endl;
-        });
-
-        client.on("data", [](std::string&& data) {
-            std::cout << data;
-        });
-    });
-
-    measurement_kit::loop();
-#endif
-}
+using namespace mk;
+using namespace mk::ooni;
 
 TEST_CASE("TCPTest works as expected in a common case") {
 
@@ -59,7 +24,7 @@ TEST_CASE("TCPTest works as expected in a common case") {
         },
         [&count]() {
             if (++count >= 2) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
@@ -69,9 +34,9 @@ TEST_CASE("TCPTest works as expected in a common case") {
         },
         [&count]() {
             if (++count >= 2) {
-                measurement_kit::break_loop();
+                mk::break_loop();
             }
         });
 
-    measurement_kit::loop();
+    mk::loop();
 }

--- a/test/report/file.cpp
+++ b/test/report/file.cpp
@@ -8,7 +8,7 @@
 #include <ctime>
 #include "src/report/file_reporter.hpp"
 
-using namespace measurement_kit::report;
+using namespace mk::report;
 
 TEST_CASE("The constructor for [FileReport] works correctly", "[BaseReport]") {
     REQUIRE_NOTHROW(FileReporter());

--- a/test/traceroute/android.cpp
+++ b/test/traceroute/android.cpp
@@ -15,8 +15,8 @@
 
 #include <iostream>
 
-using namespace measurement_kit::traceroute;
-using namespace measurement_kit;
+using namespace mk::traceroute;
+using namespace mk;
 
 TEST_CASE("Typical IPv4 traceroute usage") {
 
@@ -27,7 +27,7 @@ TEST_CASE("Typical IPv4 traceroute usage") {
     prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
         std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
         if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
@@ -36,23 +36,23 @@ TEST_CASE("Typical IPv4 traceroute usage") {
     prober.on_timeout([&prober, &ttl, &payload]() {
         std::cout << ttl << " *\n";
         if (ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
     });
 
-    prober.on_error([&prober, &ttl, &payload](common::Error err) {
+    prober.on_error([&prober, &ttl, &payload](Error err) {
         std::cout << ttl << " error: " << err.what() << "\n";
         if (ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
     });
 
     prober.send_probe("8.8.8.8", 33434, ttl, payload, 1.0);
-    measurement_kit::loop();
+    mk::loop();
 }
 
 TEST_CASE("Check whether it works when destination sends reply") {
@@ -64,7 +64,7 @@ TEST_CASE("Check whether it works when destination sends reply") {
     prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
         std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
         if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
@@ -73,23 +73,23 @@ TEST_CASE("Check whether it works when destination sends reply") {
     prober.on_timeout([&prober, &ttl, &payload]() {
         std::cout << ttl << " *\n";
         if (ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
     });
 
-    prober.on_error([&prober, &ttl, &payload](common::Error err) {
+    prober.on_error([&prober, &ttl, &payload](Error err) {
         std::cout << ttl << " error: " << err.what() << "\n";
         if (ttl >= 64) {
-            measurement_kit::break_loop();
+            mk::break_loop();
             return;
         }
         prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
     });
 
     prober.send_probe("208.67.222.222", 53, ttl, payload, 1.0);
-    measurement_kit::loop();
+    mk::loop();
 }
 
 #else


### PR DESCRIPTION
- Use `mk` as namespace rather than `measurement_kit`. On this there is agreement between me, @hellais (who originally prodded the idea), and @AntonioLangiu.

- Zap the common namespace. Prodded by @AntonioLangiu with me in favour and @hellais agnostic with respect to this. Removing the common namespace is good because stuff in such namespace is nearly always pulled and having the namespace forces you either to do `using namespace...` or to write (too many) times`common::<something>`.

Closes #284.