### PR TITLE
Change name of Dumb class to Emitter

### DIFF
--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -72,7 +72,7 @@ void Connection::handle_event(bufferevent *bev, short what, void *opaque) {
 Connection::Connection(const char *family, const char *address,
                        const char *port, Poller *plr, Logger *lp,
                        evutil_socket_t filenum)
-    : Dumb(lp), poller(plr) {
+    : Emitter(lp), poller(plr) {
     filenum = mk::socket_normalize_if_invalid(filenum);
 
     this->bev.make(poller->get_event_base(), filenum,

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -14,7 +14,7 @@
 #include "src/common/utils.hpp"
 
 #include <measurement_kit/net/buffer.hpp>
-#include "src/net/dumb.hpp"
+#include "src/net/emitter.hpp"
 #include <measurement_kit/net/transport.hpp>
 
 #include "src/dns/query.hpp"
@@ -31,7 +31,7 @@
 namespace mk {
 namespace net {
 
-class Connection : public Dumb {
+class Connection : public Emitter {
   private:
     Bufferevent bev;
     dns::Query dns_request;
@@ -72,7 +72,7 @@ class Connection : public Dumb {
     ~Connection() override;
 
     void on_data(std::function<void(Buffer)> fn) override {
-        Dumb::on_data(fn);
+        Emitter::on_data(fn);
         enable_read();
     };
 

--- a/src/net/emitter.hpp
+++ b/src/net/emitter.hpp
@@ -2,11 +2,11 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#ifndef MEASUREMENT_KIT_NET_DUMB_HPP
-#define MEASUREMENT_KIT_NET_DUMB_HPP
+#ifndef MEASUREMENT_KIT_NET_EMITTER_HPP
+#define MEASUREMENT_KIT_NET_EMITTER_HPP
 
 //
-// Dumb transport
+// Emitter transport
 //
 
 #include <measurement_kit/common/logger.hpp>
@@ -15,7 +15,7 @@
 namespace mk {
 namespace net {
 
-class Dumb : public Transport {
+class Emitter : public Transport {
   private:
     std::function<void()> do_connect = []() {};
     std::function<void(Buffer)> do_data = [](Buffer) {};
@@ -27,7 +27,7 @@ class Dumb : public Transport {
 
   public:
     void emit_connect() override {
-        logger->debug("dumb: emit 'connect' event");
+        logger->debug("emitter: emit 'connect' event");
         // With GNU C++ library, if a std::function sets itself, the
         // associated context is free() leading to segfault
         auto fn = do_connect;
@@ -35,7 +35,7 @@ class Dumb : public Transport {
     }
 
     virtual void emit_data(Buffer data) override {
-        logger->debug("dumb: emit 'data' event");
+        logger->debug("emitter: emit 'data' event");
         // With GNU C++ library, if a std::function sets itself, the
         // associated context is free() leading to segfault
         auto fn = do_data;
@@ -43,7 +43,7 @@ class Dumb : public Transport {
     }
 
     void emit_flush() override {
-        logger->debug("dumb: emit 'flush' event");
+        logger->debug("emitter: emit 'flush' event");
         // With GNU C++ library, if a std::function sets itself, the
         // associated context is free() leading to segfault
         auto fn = do_flush;
@@ -51,52 +51,52 @@ class Dumb : public Transport {
     }
 
     void emit_error(Error err) override {
-        logger->debug("dumb: emit 'error' event");
+        logger->debug("emitter: emit 'error' event");
         // With GNU C++ library, if a std::function sets itself, the
         // associated context is free() leading to segfault
         auto fn = do_error;
         fn(err);
     }
 
-    Dumb(Logger *lp = Logger::global()) : logger(lp) {}
+    Emitter(Logger *lp = Logger::global()) : logger(lp) {}
 
-    ~Dumb() override {}
+    ~Emitter() override {}
 
     void on_connect(std::function<void()> fn) override {
-        logger->debug("dumb: register 'connect' handler");
+        logger->debug("emitter: register 'connect' handler");
         do_connect = fn;
     }
 
     virtual void on_data(std::function<void(Buffer)> fn) override {
-        logger->debug("dumb: register 'data' handler");
+        logger->debug("emitter: register 'data' handler");
         do_data = fn;
     }
 
     void on_flush(std::function<void()> fn) override {
-        logger->debug("dumb: register 'flush' handler");
+        logger->debug("emitter: register 'flush' handler");
         do_flush = fn;
     }
 
     void on_error(std::function<void(Error)> fn) override {
-        logger->debug("dumb: register 'error' handler");
+        logger->debug("emitter: register 'error' handler");
         do_error = fn;
     }
 
     void set_timeout(double timeo) override {
-        logger->debug("dumb: set_timeout %f", timeo);
+        logger->debug("emitter: set_timeout %f", timeo);
     }
 
-    void clear_timeout() override { logger->debug("dumb: clear_timeout"); }
+    void clear_timeout() override { logger->debug("emitter: clear_timeout"); }
 
     void send(const void *, size_t) override {
-        logger->debug("dumb: send opaque data");
+        logger->debug("emitter: send opaque data");
     }
 
-    void send(std::string) override { logger->debug("dumb: send string"); }
+    void send(std::string) override { logger->debug("emitter: send string"); }
 
-    void send(Buffer) override { logger->debug("dumb: send buffer"); }
+    void send(Buffer) override { logger->debug("emitter: send buffer"); }
 
-    void close() override { logger->debug("dumb: close"); }
+    void close() override { logger->debug("emitter: close"); }
 
     std::string socks5_address() override { return ""; }
 

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -9,7 +9,7 @@ namespace mk {
 namespace net {
 
 Socks5::Socks5(Settings s, Logger *lp, Poller *poller)
-    : Dumb(lp), settings(s),
+    : Emitter(lp), settings(s),
       conn(settings["family"].c_str(), settings["socks5_address"].c_str(),
            settings["socks5_port"].c_str(), lp, poller),
       proxy_address(settings["socks5_address"]),

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -10,13 +10,13 @@
 
 #include <measurement_kit/net/buffer.hpp>
 #include "src/net/connection.hpp"
-#include "src/net/dumb.hpp"
+#include "src/net/emitter.hpp"
 #include <measurement_kit/net/transport.hpp>
 
 namespace mk {
 namespace net {
 
-class Socks5 : public Dumb {
+class Socks5 : public Emitter {
   protected:
     Settings settings;
     Connection conn;

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -3,7 +3,7 @@
 // information on the copying conditions.
 
 #include "src/net/connection.hpp"
-#include "src/net/dumb.hpp"
+#include "src/net/emitter.hpp"
 #include "src/net/socks5.hpp"
 #include <measurement_kit/net/transport.hpp>
 
@@ -14,7 +14,7 @@ static Var<Transport> connect_internal(Settings settings, Logger *logger,
                                        Poller *poller) {
 
     if (settings.find("dumb_transport") != settings.end()) {
-        return Var<Transport>(new Dumb(logger));
+        return Var<Transport>(new Emitter(logger));
     }
 
     if (settings.find("family") == settings.end()) {


### PR DESCRIPTION
Like we said in the #279, I changed the name of the class to a more fitting one. 