### PR TITLE
Make the class connection non copyable and non movable

### DIFF
--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -31,7 +31,7 @@
 namespace mk {
 namespace net {
 
-class Connection : public Emitter {
+class Connection : public Emitter, public NonMovable, public NonCopyable {
   private:
     Bufferevent bev;
     dns::Query dns_request;


### PR DESCRIPTION
Fix little bug in the class Connection. 

This closes #280  