### PR TITLE
poller: allow to modify default evdns-base state

### DIFF
--- a/doc/api/common/poller.md
+++ b/doc/api/common/poller.md
@@ -16,6 +16,15 @@ poller.loop();                    // Blocking method to run the event loop
 poller.break_loop();              // Break out of event loop
 poller.loop_once();               // Just one iteration of event loop
 
+// Functions to work with the DNS server addresses
+// They are especially useful in mobile applications where typically
+// we do not have /etc/resolv.conf and hence by default no name-server
+// is configured and name resolution does not work at all
+if (poller.count_nameservers() <= 0) {
+    poller.add_nameserver("8.8.8.8");        // Leaving the port implied
+    poller.add_nameserver("8.8.4.4:53");     // Also with port
+}
+
 mk::Poller *root = mk::Poller::global();
 ```
 

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -8,6 +8,8 @@
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/libs.hpp>
 
+#include <string>
+
 struct evdns_base;
 struct event_base;
 
@@ -27,6 +29,13 @@ class Poller : public NonCopyable, public NonMovable {
     void loop_once();
 
     void break_loop();
+
+    /// Get number of configured nameservers in default resolver
+    int count_nameservers();
+
+    /// Add nameserver to the list of name-servers of the default resolver
+    /// \param address Address and optionally port (e.g. "8.8.8.8:53")
+    void add_nameserver(std::string address);
 
     static Poller *global() {
         static Poller singleton;
@@ -60,6 +69,12 @@ inline void loop(void) { Poller::global()->loop(); }
 inline void loop_once(void) { Poller::global()->loop_once(); }
 
 inline void break_loop(void) { Poller::global()->break_loop(); }
+
+inline int count_nameservers() { return Poller::global()->count_nameservers(); }
+
+inline void add_nameserver(std::string address) {
+    Poller::global()->add_nameserver(address);
+}
 
 } // namespace mk
 #endif

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -4,6 +4,7 @@
 
 #include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common/error.hpp>
 #include <stdexcept>
 #include "src/common/libs_impl.hpp"
 
@@ -38,6 +39,16 @@ void Poller::loop_once() {
     auto result = libs_->event_base_loop(base_, EVLOOP_ONCE);
     if (result < 0) throw std::runtime_error("event_base_loop() failed");
     if (result == 1) warn("loop: no pending and/or active events");
+}
+
+int Poller::count_nameservers() {
+    return evdns_base_count_nameservers(dnsbase_);
+}
+
+void Poller::add_nameserver(std::string address) {
+    if (evdns_base_nameserver_ip_add(dnsbase_, address.c_str()) != 0) {
+        throw GenericError();
+    }
 }
 
 } // namespace mk


### PR DESCRIPTION
I need this in the mobile applications. For example, with Android there is no /etc/resolv.conf, and I need a mechanism to specify the name servers to be used by the default evdns-base instance.

Note that in MeasurementKit there is also a custom Resolver object constructed with default parameters, but this is not the same as the evdns-base instance used by the Poller. The latter is, in fact, the instance actually used when running, e.g., OONI tests.

More can be done to improve MeasurementKit with respect to the poller and resolver facilities used when running tests, but this is not the right moment to do so. We are close to a stable release and hence we should make as minimal changes as possible.