### PR TITLE
Allow to clear DNS servers on Android

### DIFF
--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -30,12 +30,22 @@ class Poller : public NonCopyable, public NonMovable {
 
     void break_loop();
 
+    // When /etc/resolv.conf is not found, libevent configures as
+    // resolver 127.0.0.1:53, which unfortunately is not working on
+    // Android. Hence we need the following methods to force the
+    // App to clear existing resolver and use another one:
+
+    /// Clear previosuly configured nameservers
+    void clear_nameservers();
+
     /// Get number of configured nameservers in default resolver
     int count_nameservers();
 
     /// Add nameserver to the list of name-servers of the default resolver
     /// \param address Address and optionally port (e.g. "8.8.8.8:53")
     void add_nameserver(std::string address);
+
+    // End methods to set a different resolver on Android
 
     static Poller *global() {
         static Poller singleton;
@@ -69,6 +79,8 @@ inline void loop(void) { Poller::global()->loop(); }
 inline void loop_once(void) { Poller::global()->loop_once(); }
 
 inline void break_loop(void) { Poller::global()->break_loop(); }
+
+inline void clear_nameservers() { Poller::global()->clear_nameservers(); }
 
 inline int count_nameservers() { return Poller::global()->count_nameservers(); }
 

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -41,6 +41,13 @@ void Poller::loop_once() {
     if (result == 1) warn("loop: no pending and/or active events");
 }
 
+void Poller::clear_nameservers() {
+    if (evdns_base_clear_nameservers_and_suspend(dnsbase_) != 0 ||
+        evdns_base_resume(dnsbase_) != 0) {
+        throw std::runtime_error("unexpected evdns failure");
+    }
+}
+
 int Poller::count_nameservers() {
     return evdns_base_count_nameservers(dnsbase_);
 }


### PR DESCRIPTION
Previously I didn't notice that, when no /etc/resolv.conf is found on the device, libevent sets 127.0.0.1 as resolver.

This is not what we want on Android. Because on Android there is no resolver at 127.0.0.1. Hence add hooks to clear the configured name servers, such that we can start from scratch.

While here, add a regress test case to check that what I would like to do on Android (i.e. clear all nameservers and then force a specific nameserver address) works.