### PR TITLE
Add tutorials

### DIFF
--- a/doc/tutorial/android.md
+++ b/doc/tutorial/android.md
@@ -1,0 +1,29 @@
+# Android Tutorial
+
+Measurement Kit is written in C++. Android applications are written
+in Java. For an Android application to use Measurement Kit, there is
+need to write JNI (Java Native Interface) code.
+
+We already wrote JNI code for Measurement Kit. This code is hosted by
+the [measurement-kit-android](
+https://github.com/measurement-kit/measurement-kit-android) GitHub
+repository.
+
+If your objective is to develop Android applications based on Measurement
+Kit, you are really looking for that repository. It also contains a tutorial
+explaining how to integrate Measurement Kit into your Android app.
+
+This tutorial, instead, explains how you could write your own JNI
+code based on Measurement Kit cross compiled for Android.
+
+To understand this, you first need to understand how to cross compile
+Measurement Kit for Android. Then, you need to understand how to write
+your own JNI wrappers for Measurement Kit API.
+
+## How to cross compile for Android
+
+We have not written this section of the tutorial yet.
+
+## Writing your own JNI wrappers
+
+We have not written this section of the tutorial yet.

--- a/doc/tutorial/ios.md
+++ b/doc/tutorial/ios.md
@@ -1,0 +1,393 @@
+# iOS tutorial
+
+This tutorial explains how to integrate Measurement Kit into your
+iOS Objective-C application. You need to understand how to generate
+(or obtain) Measurement Kit frameworks. And how to integrate your
+code with Measurement Kit code.
+
+Throughout this tutorial we assume that you are running MacOSX
+10.11 El Capitain (i.e. the version of OSX with which we tested
+the code presented in this tutorial) and Xcode 9.2. Other versions
+of both may work, especially if close to the ones we tested.
+
+## How to generate (or obtain) the frameworks
+
+We have published
+[specification for Measurement Kit](
+https://github.com/CocoaPods/Specs/tree/master/Specs/measurement_kit
+) on [CocoaPods](https://cocoapods.org/).
+We have not yet published a specification to directly get the
+binaries, however. Hence, for now you will need the command line tools
+installed on your build system to build the Pod.
+
+To install Xcode command line tools on your system, run:
+
+    xcode-select --install
+
+Next, you need to install CocoaPods. To this end, run this command:
+
+    sudo gem install cocoapods
+
+As a third step, create a new Xcode project, following these steps:
+
+- open Xcode and select "Create a new XCode project"
+- select "Create a single view application"
+- fill in the product name
+- make sure that the selected language is Objective-C
+- select the place where to save the application
+
+Then, you shall use the terminal and `cd` to the directory containing
+the `.xcodeproj` file. There, create a file called `Podfile` and write
+inside it the following content:
+
+```
+pod 'measurement_kit', '>= 0.1.0-beta.5'
+```
+
+(Instead, if you want to install measurement_kit directly from its
+git repository, write the following inside the `Podfile`:
+
+```
+pod 'measurement_kit',
+  :git => 'https://github.com/measurement-kit/measurement-kit.git'
+```
+)
+
+Save and quit, then type:
+
+    pod install --verbose
+
+This will run for a long time. It will download Measurement Kit from
+GitHub and cross-compile it for the iOS emulator and devices.
+
+When this command terminates, new files will appear in your application
+directory, including a `.xcworkspace` file that, from now on, you shall use
+to open your application. Basically it is an Xcode project container,
+which references both the application `.xcodeproj` and the compiled Pods.
+
+As for the compiled Pods, they are inside the `Pods` directory. In
+particular, if you're curious, under the following path
+
+    Pods/measurement_kit/mobile/ios/Frameworks/
+
+you will find all the frameworks needed to integrate Measurement Kit
+with your application. (In general, you can use the `.xcworkspace` file
+to manage you project, but you may also want instead to use directly
+the frameworks, even though this is not the expected usage.)
+
+## How to integrate Measurement Kit code
+
+Open the `.xcworkspace` file using Xcode. For example clicking over
+it, or with `open` if you are using the command line.
+
+You will find that your workspace contains two projects. One named `Pods`
+will contain the compiled frameworks. The other, named after your
+project, unsurprisingly contains exactly your project.
+
+Here, for simplicity, we are not going to change the view. Rather we
+are going to run a Measurement Kit test just after the application has
+started (i.e. in the `didFinishLaunchingWithOptions` method of the
+`AppDelegate.m` file).
+
+As a first step, we need to rename the file `AppDelegate.mm`. In fact,
+Measurement Kit is written in C++. So, we need to tell Xcode that the app
+delegate should be compiled using Objective-C++ (`.mm`) rather than
+using Objective-C (`.m`). To rename the file, click on its name for a
+long time until it becomes editable, then rename it.
+
+We are going to implement OONI's tcp-connect test. So, you need to include
+Measurement Kit OONI's functionality. To this end, modify the top of
+your `AppDelegate.mm` file such that it looks like this:
+
+```Objective-C
+#import "AppDelegate.h"
+#include <measurement_kit/ooni.hpp>
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+// more code below...
+```
+
+We have basically just added `measurement_kit/ooni.hpp` header to the
+auto-generated file. Such header contains all MeasurementKit definitions
+useful to run OONI tests. Then, try to build the project to ensure that
+everything works.
+
+To implement the test, we need to add more code to the currently-empty
+implementation of `didFinishLaunchingWithOptions`. To do that, we need to
+understand the ingredients required for running the test.
+
+The tcp-connect tests is a test that attempts to connect to a list of
+domain names of IP addresses. And measures, for each domain name or IP
+address, whether the connection suceeded or not.
+
+The first thing we need to tell Measurement Kit is the address of the
+DNS resolver currently used by the device. To do this, modify the
+`didFinishLaunchingWithOptions` method such that it looks like this:
+
+```Objective-C
+- (BOOL)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    BOOL result = NO;
+    res_state res = nullptr;
+    do {
+
+        // Copy DNS resolver(s) from device
+        res = (res_state) malloc(sizeof(struct __res_state));
+        if (res == nullptr) break;
+        if (res_ninit(res) != 0) break;
+        mk::clear_nameservers();
+        for (int i = 0; i < res->nscount; ++i) {
+            char addr[INET_ADDRSTRLEN];
+            if (inet_ntop(AF_INET, &res->nsaddr_list[i].sin_addr, addr,
+                          sizeof (addr)) == nullptr) {
+                continue;
+            }
+            mk::add_nameserver(addr);
+            NSLog(@"adding DNS resolver: %s", addr);
+        }
+        free(res);
+        res = nullptr;
+
+        // TODO: more code here
+
+        result = YES;
+    } while (0);
+    if (res) free(res);
+    return result;
+}
+```
+
+This will query the device for the available DNS servers and configure them
+as resolvers for Measurement Kit. For this code to work, you also need to add
+`libresolv.tdb` to the list of frameworks of your project. And you also
+need to add the following headers to `AppDelegate.mm`:
+
+```Objective-C
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <resolv.h>
+#include <dns.h>
+```
+
+As a second step, you need to add to the application a file telling the
+tcp-connect test which hosts to test. To this end, create a new file named
+`inputs.txt` in the "Supporting Files" folder of your project in Xcode.
+
+To create a new file, right click on "Supporting Files" and then select
+"New File" from the drop-down menu. Then select "Empty", and name the
+file "inputs.txt". Write some domain names inside this file, for example:
+
+```
+ooni.torproject.org
+nexa.polito.it
+measurement-kit.github.io
+```
+
+Now you need to obtain the path of this file in the final application. To
+this end, append the following code snippet near the end of the above loop,
+just below the TODO comment indicated above:
+
+```Objective-C
+        // Get path of input file:
+        NSBundle *bundle = [NSBundle mainBundle];
+        NSString *path = [bundle pathForResource:@"inputs" ofType:@"txt"];
+        const char *input_path = [path UTF8String];
+        NSLog(@"path of input file: %s", input_path);
+```
+
+We are now ready to invoke the tcp-connect test. Add the following code
+just below the code you just added:
+
+```Objective-C
+        mk::ooni::TcpConnectTest()
+            .set_verbose(true)
+            .set_port("80")
+            .set_input_file_path(input_path)
+            .run();
+```
+
+This will run the tcp-connect test in synchronous mode. That is, the current
+thread will be blocked until the test completes.
+
+Running a synchronous test, however, is not so good for a mobile application
+because it blocks the UX for the whole duration of the test.
+
+To instruct Measurement Kit to run the test asynchronously (i.e. to run
+the test in the background and notify us when done) we can modify the code
+above as follows:
+
+```Objective-C
+        mk::ooni::TcpConnectTest()
+            .set_verbose(true)
+            .set_port("80")
+            .set_input_file_path(input_path)
+            .run([]() {
+                // TODO This code runs in a background thread and is
+                // called when the tcp-connect test is complete
+            });
+```
+
+Basically, the C++11 lambda passed to `run()` is called from a background
+thread when the test is complete. Now, to do something useful in that lamba,
+let's simulate sending a message to the UX using `dispatch_async`.
+
+Let's create the message before running the test. Let's edit the C++11
+lambda capture list to retain a reference to `message`. And finally let's
+use `dispatch_async` to dispatch the message when we are done.
+
+```Objective-C
+        NSString *message = @"message-0xdeadidea";
+        mk::ooni::TcpConnectTest()
+            .set_verbose(true)
+            .set_port("80")
+            .set_input_file_path(input_path)
+            .run([message]() {
+                // Caution: code called from a background thread
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSLog(@"test complete: %@", message);
+                });
+            });
+        NSLog(@"test in progress: %@", message);
+```
+
+The "test in progress" message is there so that it's clear from the logs
+that the test is run asynchronously (i.e. that the `run()` returns immediately
+and the C++11 lambda is only called when the test is complete).
+
+To complete our example, let's also capture the test logs and insert them
+into an array, which will be printed once the test is complete. This simulates
+the case where you store separate logs for different tests.
+
+```Objective-C
+        NSString *message = @"message-0xdeadidea";
+        NSMutableArray *logs = [[NSMutableArray alloc] init];
+        NSLock *mtx = [[NSLock alloc] init];
+        mk::ooni::TcpConnectTest()
+            .set_verbose(true)
+            .set_port("80")
+            .set_input_file_path(input_path)
+            .on_log([logs, mtx](const char *s) {
+                // Caution: code called from a background thread
+                // Caution: `s` points to a static buffer, so I must copy it
+                [mtx lock];
+                [logs addObject:[NSString stringWithUTF8String:s]];
+                [mtx unlock];
+            })
+            .run([message, logs, mtx]() {
+                // Caution: code called from a background thread
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSLog(@"test complete: %@", message);
+                    [mtx lock];
+                    for (NSString *line in logs) {
+                        NSLog(@"> %@", line);
+                    }
+                    [mtx unlock];
+                });
+            });
+        NSLog(@"test in progress: %@", message);
+```
+
+I've also added a lock to ensure that the logs object is always accessed
+safely. In this example, that is way overkill. But I wanted to show you the
+most general case (i.e. the one in which the view is allowed to access the
+`logs` object while tests are running). Also, the reason why I copy `s`
+is that actually `s` is just a pointer in a static buffer, hence it must
+be copied. Storing only the pointer is not very useful, since the buffer is
+overwritten every time a new log line is generated.
+
+The final example code is the following:
+
+```Objective-C
+#import "AppDelegate.h"
+#include <measurement_kit/ooni.hpp>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <resolv.h>
+#include <dns.h>
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application
+didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    BOOL result = NO;
+    res_state res = nullptr;
+    do {
+
+        // Copy DNS resolver(s) from device
+        res = (res_state) malloc(sizeof(struct __res_state));
+        if (res == nullptr) break;
+        if (res_ninit(res) != 0) break;
+        mk::clear_nameservers();
+        for (int i = 0; i < res->nscount; ++i) {
+            char addr[INET_ADDRSTRLEN];
+            if (inet_ntop(AF_INET, &res->nsaddr_list[i].sin_addr, addr,
+                          sizeof (addr)) == nullptr) {
+                continue;
+            }
+            mk::add_nameserver(addr);
+            NSLog(@"adding DNS resolver: %s", addr);
+        }
+        free(res);
+        res = nullptr;
+
+        // Get path of input file:
+        NSBundle *bundle = [NSBundle mainBundle];
+        NSString *path = [bundle pathForResource:@"inputs" ofType:@"txt"];
+        const char *input_path = [path UTF8String];
+        NSLog(@"path of input file: %s", input_path);
+
+        NSString *message = @"message-0xdeadidea";
+        NSMutableArray *logs = [[NSMutableArray alloc] init];
+        NSLock *mtx = [[NSLock alloc] init];
+        mk::ooni::TcpConnectTest()
+            .set_verbose(true)
+            .set_port("80")
+            .set_input_file_path(input_path)
+            .on_log([logs, mtx](const char *s) {
+                // Caution: code called from a background thread
+                // Caution: `s` points to a static buffer, so I must copy it
+                [mtx lock];
+                [logs addObject:[NSString stringWithUTF8String:s]];
+                [mtx unlock];
+            })
+            .run([message, logs, mtx]() {
+                // Caution: code called from a background thread
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSLog(@"test complete: %@", message);
+                    [mtx lock];
+                    for (NSString *line in logs) {
+                        NSLog(@"> %@", line);
+                    }
+                    [mtx unlock];
+                });
+            });
+        NSLog(@"test in progress: %@", message);
+
+        result = YES;
+    } while (0);
+    if (res) free(res);
+    return result;
+}
+
+// more code here...
+```
+
+As a final remark, to test this sample application on a real device I
+also needed to disable bitcode, since the frameworks compiled using Cocoa
+Pods do not use bitcode.

--- a/doc/tutorial/ios.md
+++ b/doc/tutorial/ios.md
@@ -41,7 +41,7 @@ the `.xcodeproj` file. There, create a file called `Podfile` and write
 inside it the following content:
 
 ```
-pod 'measurement_kit', '>= 0.1.0-beta.5'
+pod 'measurement_kit'
 ```
 
 (Instead, if you want to install measurement_kit directly from its
@@ -101,6 +101,7 @@ your `AppDelegate.mm` file such that it looks like this:
 
 ```Objective-C
 #import "AppDelegate.h"
+#include <measurement_kit/common.hpp>
 #include <measurement_kit/ooni.hpp>
 
 @interface AppDelegate ()
@@ -121,7 +122,8 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 We have basically just added `measurement_kit/ooni.hpp` header to the
 auto-generated file. Such header contains all MeasurementKit definitions
 useful to run OONI tests. Then, try to build the project to ensure that
-everything works.
+everything works. We have also added `measurement_kit/common.hpp` that
+contains functionality that we will need later.
 
 To implement the test, we need to add more code to the currently-empty
 implementation of `didFinishLaunchingWithOptions`. To do that, we need to
@@ -310,6 +312,7 @@ The final example code is the following:
 
 ```Objective-C
 #import "AppDelegate.h"
+#include <measurement_kit/common.hpp>
 #include <measurement_kit/ooni.hpp>
 
 #include <arpa/inet.h>

--- a/doc/tutorial/unix.md
+++ b/doc/tutorial/unix.md
@@ -1,0 +1,286 @@
+# Unix tutorial
+
+This tutorial explains how to integrate Measurement Kit into your Unix
+application. To start off, you need to get the sources.
+
+## Download Measurement Kit
+
+To this end, you can either clone the git repository or go straight
+into the download page and grab the latest sources.
+
+To clone the repository using git, type:
+
+    git clone https://github.com/measurement-kit/measurement-kit
+
+The download page is available here:
+
+    https://github.com/measurement-kit/measurement-kit/releases
+
+If you clone using git, you will find a directory named `measurement-kit`
+inside your current directory. Otherwise, you will get a tarball named
+after the version number (e.g. `v0.1.0-beta.4.tar.gz`). Once you unpack
+that tarball, you will get a directory named `measurement-kit-VERSION`
+(e.g. `measurement-kit-0.1.0-beta.4`) inside your current directory.
+
+In either case, enter into this directory to configure the sources and
+compile Measurement Kit.
+
+## Configure, make, make install
+
+Measurement Kit build system is based on the so-called [GNU build
+system](https://en.wikipedia.org/wiki/GNU_build_system). Specifically,
+it uses `autoconf`, `automake`, and `libtool`. Make sure you have those
+three packages installed on your system before proceeding.
+
+To compile and install Measurement Kit you need to follow a number of
+steps. The first step is to generate the `configure` script. To do that,
+run this command from the toplevel directory:
+
+    autoreconf -i
+
+At this point you are ready to *configure* Measurement Kit to build
+on your system. The bare minimum requirements to built it are a C++11
+compiler, a C90 compiler, make (not necessarily GNU make), a C++ standard
+library, a C library. Measurement Kit is known to work with recent
+versions of [clang](http://clang.llvm.org/) and [gcc](https://gcc.gnu.org/),
+of [libc++](http://libcxx.llvm.org/) and [libstdc++](
+https://gcc.gnu.org/libstdc++/). At the moment of writing this tutorial
+we tested Measurement Kit with clang 3.6 and gcc 5.2.
+
+Measurement Kit depends at build time on other pieces of software. At the
+moment of writing this tutorial, it depends on:
+
+- [libevent](https://github.com/libevent/libevent)
+- [yaml-cpp](https://github.com/jbeder/yaml-cpp)
+- [boost](https://github.com/boostorg/)
+- [jansson](https://github.com/akheron/jansson)
+- [libmaxminddb](https://github.com/maxmind/libmaxminddb)
+
+You may want to check the most recent version of [README.md](
+https://github.com/measurement-kit/measurement-kit/blob/master/README.md)
+to check whether the dependencies changed since this tutorial was
+written. If so, please let us know.
+
+By default, if dependencies are not found in the host system, Measurement
+Kit will use a bundled copy of such dependencies. Instead, if they are
+available on host host system, they are used. In the latter case the build
+process is much faster, because less code needs to be compiled.
+
+The `configure` script will warn you if a dependency is missing on the
+host system and a bundled dependency is being used instead.
+
+To start the `configure` script run:
+
+    ./configure
+
+If this script succeeds, Measurement Kit is now configured to build
+on your system. To compile, run:
+
+    make V=0
+
+The `V=0` enables the silent build process, which is more readable than
+the standard super-verbose build process.
+
+If also this step succeeds, you may want to run Measurement Kit tests
+to make sure that everything was compiled correctly. To do so, run:
+
+    make check-am V=0
+
+(We prefer `check-am` over `check` because we do not want to also run the
+dependencies tests, in case builtin dependencies were used. Also note that
+some tests requiring network connectivity may fail due to transient
+network errors, even though that is not so common.)
+
+As a final step, to install Measurement Kit under `/usr/local`, you need
+to become *root* and type:
+
+    make install
+
+This will install Measurement Kit headers under `/usr/local/include` and
+Measurement Kit libraries under `/usr/local/lib`. If bundled dependencies
+were compiled, they would be installed under `/usr/local` as well.
+
+## Using Measurement Kit
+
+Now that Measurement Kit is installed, we can use it. To this end, we
+will write a small C++ program that uses Measurement Kit api. Specifically,
+we will use the [OONI API](
+https://github.com/measurement-kit/measurement-kit/tree/master/doc/api/ooni)
+to run OONI's [DNS injection test](
+https://github.com/TheTorProject/ooni-spec/blob/master/test-specs/ts-012-dns-injection.md).
+
+To start off, create a file called `main.cpp`. We need to tell the compiler
+that we need to use Measurement Kit's OONI API. To do so, you need to add
+the following at the top of your file:
+
+```C++
+#include <measurement_kit/ooni.hpp>
+```
+
+This tells the C++ compiler to import the C++ header containing all the
+definitions of Measurement Kit's OONI API.
+
+Then, we need to write a skeleton main program. So, we will have:
+
+```C++
+#include <measurement_kit/ooni.hpp>
+
+int main() {}
+```
+
+To compile this on your system, use the following command:
+
+    c++ -Wall -std=c++11 -o main main.cpp
+
+If this works, it means that the compiler is a C++11 compiler and that
+Measurement Kit headers have been correctly found.
+
+Next, let's write some code inside `main()` to read command line arguments
+and act accordingly. Specifically, the user shall be able to specify an
+optional backend server address (using the `-b` flag) and one or more files
+containing domain names to be resolved using the selected backend (or the
+default backend). Also, when invoked with zero arguments (or with incorrect
+arguments) the program should print an help message.
+
+```C++
+#include <measurement_kit/ooni.hpp>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    const char *backend = "8.8.8.1:53";
+    const char *progname = argv[0];
+    int verbose = 0;
+    int chr;
+
+    while ((chr = getopt(argc, argv, "b:v")) >= 0) {
+        switch (chr) {
+        case 'b':
+            backend = optarg;
+            break;
+        case 'v':
+            verbose = 1;
+            break;
+        default:
+            printf("usage: %s [-v] [-b backend] input-file [...]\n", progname);
+            exit(1);
+        }
+    }
+    argc -= optind;
+    argv += optind;
+    if (argc <= 0) {
+        printf("usage: %s [-v] [-b backend] input-file [...]\n", progname);
+        exit(1);
+    }
+}
+```
+
+Next we want to run OONI DNSInjection test on all the remaining arguments,
+using as backend the specified backend, or the default one. We will iterate
+over all the remaining command line options and launch an instance of the
+DNS Injection test for each file. All these tests will run in parallel and
+the program will terminate when all of them are complete. To track the
+completion status of tests we will use a `volatile int` variable.
+
+```C++
+    volatile int running = 0;
+    for (; argc > 0; --argc, ++argv, ++running) {
+        mk::ooni::DnsInjectionTest()
+            .set_backend(backend)
+            .set_input_file_path(argv[0])
+            .set_verbose(verbose)
+            .run([&running]() { --running; });
+    }
+```
+
+This is enough to run the test asynchronously. All tests will be run in a
+background thread. When the test completes, the C++11 lambda passed to `run()`
+is called and decrements the shared `running` variable.
+
+Now, we only need to add code to wait for all tests to complete.
+
+```C++
+    while (running > 0) sleep(1);
+```
+
+Putting everything together:
+
+```C++
+#include <measurement_kit/ooni.hpp>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    const char *backend = "8.8.8.1:53";
+    const char *progname = argv[0];
+    int verbose = 0;
+    int chr;
+
+    while ((chr = getopt(argc, argv, "b:v")) >= 0) {
+        switch (chr) {
+        case 'b':
+            backend = optarg;
+            break;
+        case 'v':
+            verbose = 1;
+            break;
+        default:
+            printf("usage: %s [-v] [-b backend] input-file [...]\n", progname);
+            exit(1);
+        }
+    }
+    argc -= optind;
+    argv += optind;
+    if (argc <= 0) {
+        printf("usage: %s [-v] [-b backend] input-file [...]\n", progname);
+        exit(1);
+    }
+
+    volatile int running = 0;
+    for (; argc > 0; --argc, ++argv, ++running) {
+        mk::ooni::DnsInjectionTest()
+            .set_backend(backend)
+            .set_input_file_path(argv[0])
+            .set_verbose(verbose)
+            .run([&running]() { --running; });
+    }
+
+    while (running > 0) sleep(1);
+}
+```
+
+We can now compile (and link) the code using the following command:
+
+    c++ -Wall -std=c++11 -o main main.cpp -lmeasurement_kit
+
+On Linux you may need to update the dynamic linker after you have installed
+to `/usr/local`, running the following command as root:
+
+    /sbin/ldconfig
+
+(There are distributions, e.g. Fedora, that unified / and /usr where the above
+shall be written as `/usr/sbin/ldconfig` instead.)
+
+Then create a file named INPUT and paste inside it this content:
+
+```
+measurement-kitgithub.io
+nexa.polito.it
+ooni.torproject.org
+```
+
+Finally, we can run the program using this input as follows:
+
+    ./main -v INPUT INPUT INPUT
+
+Here we repeated `INPUT` three times to show that you can schedule
+three different instances of the DNS Injection test in parallel.
+
+At this point, you may have already noticed that the backend we are
+using (`8.8.8.1:53`) is not a valid DNS server. This is on purpose since
+the point of the test is to spot cases where someone in the middle
+maliciously injects DNS responses. To run again the test with instead
+a valid DNS server (quite pointless for the purpose of the test but
+still an interesting exercise), type:
+
+    ./main -vb 8.8.8.8 INPUT

--- a/doc/tutorial/unix.md
+++ b/doc/tutorial/unix.md
@@ -100,6 +100,11 @@ This will install Measurement Kit headers under `/usr/local/include` and
 Measurement Kit libraries under `/usr/local/lib`. If bundled dependencies
 were compiled, they would be installed under `/usr/local` as well.
 
+On Linux you may need to update the dynamic linker after you have installed
+to `/usr/local`, running the following command as root:
+
+    ldconfig
+
 ## Using Measurement Kit
 
 Now that Measurement Kit is installed, we can use it. To this end, we
@@ -252,14 +257,6 @@ int main(int argc, char **argv) {
 We can now compile (and link) the code using the following command:
 
     c++ -Wall -std=c++11 -o main main.cpp -lmeasurement_kit
-
-On Linux you may need to update the dynamic linker after you have installed
-to `/usr/local`, running the following command as root:
-
-    /sbin/ldconfig
-
-(There are distributions, e.g. Fedora, that unified / and /usr where the above
-shall be written as `/usr/sbin/ldconfig` instead.)
 
 Then create a file named INPUT and paste inside it this content:
 


### PR DESCRIPTION
Closes #269.

- android
- ios
- unix

The actual tutorial for Android is actually a non-tutorial. In fact, it only explains that what the user is looking like is inside the `measurement-kit-android` repository instead.

The iOS tutorial was tested both using Xcode emulator and on a real device.

The C++ tutorial was tested under Ubuntu 15.10.