### PR TITLE
Avoid building examples when cross-compiling

### DIFF
--- a/mobile/android/scripts/build_target.sh
+++ b/mobile/android/scripts/build_target.sh
@@ -84,7 +84,7 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib${LIB_SUFFIX} -L${ANDROID_TOOLCHA
       --with-libevent=builtin --with-yaml-cpp=builtin \
       --with-boost=builtin --disable-shared --libdir=/ \
       --includedir=/include --with-libmaxminddb=builtin \
-      --with-jansson=builtin
+      --with-jansson=builtin --disable-examples
     make V=0
     echo "Installing library in ${BASEDIR}/build/${ANDROID_TOOLCHAIN}"
     # The rationale of the following algorithm is to install-strip and do

--- a/mobile/ios/scripts/build_arch.sh
+++ b/mobile/ios/scripts/build_arch.sh
@@ -38,6 +38,7 @@ export CXXFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer
     cd $SOURCEDIR
     test -x ./configure || autoreconf -i
     ./configure -q --disable-shared \
+                --disable-examples \
                 --with-libevent=builtin \
                 --with-yaml-cpp=builtin \
                 --with-boost=builtin \


### PR DESCRIPTION
It turns out that examples cannot be build when cross-compiling for Android for some architectures.

Already tested this. Before merging, I'd also like to check whether the same issue also prevents us from cross-compiling for iOS. So I can fix both issues in the same pull request.