### PR TITLE
Run regress tests through Valgrind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 90
-  - sudo apt-get install tor
+  - sudo apt-get install tor valgrind
   - pip install --user cpp-coveralls
 
 install: autoreconf -i

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,9 @@ install: autoreconf -i
 # convince coveralls to find all sources when using gcc-4.8 and gcov-4.8
 # (For more context see measurement-kit/measurement-kit#255)
 script:
-  - if [ "$CXX" = "clang++" ]; then
-      ./configure -q --with-libevent=builtin --with-yaml-cpp=builtin
+  - ./configure -q --with-libevent=builtin --with-yaml-cpp=builtin
                      --with-boost=builtin --with-jansson=builtin
-                     --with-libmaxminddb=builtin
-                     CFLAGS=--coverage CXXFLAGS=--coverage
-                     LDFLAGS=--coverage;
-    else
-      ./configure -q --with-libevent=builtin --with-yaml-cpp=builtin
-                     --with-boost=builtin --with-jansson=builtin
-                     --with-libmaxminddb=builtin;
-    fi
+                     --with-libmaxminddb=builtin --disable-shared
   - make -j2 V=0
   - make run-valgrind
 # Silence gcov standard output since it produces way too much output

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ script:
                      --with-libmaxminddb=builtin;
     fi
   - make -j2 V=0
-  - make -j2 check-am V=0
-
+  - make run-valgrind
 # Silence gcov standard output since it produces way too much output
 after_success:
   - if [ "$CXX" = "clang++" ]; then

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,3 +27,11 @@ include example/include.am
 include test/include.am
 
 lib_LTLIBRARIES += libmeasurement_kit.la
+
+VALGRIND = valgrind --trace-children=yes --error-exitcode=1 \
+                    --dsymutil=yes --leak-check=yes
+
+run-valgrind: $(check_PROGRAMS)
+	for test_name in $(TESTS); do                                          \
+	  $(VALGRIND) $$test_name || exit 1;                                   \
+	done


### PR DESCRIPTION
Using the variable `TESTS_ENVIRONMENT = valgrind` in Makefile.am we are now able to run regress tests through Valgrind. 

To enable it you should call ./configure with --enable-valgrind and --disable-shared.

To merge this PR we need first to fix the memory leak problems of 3 tests:

* [test/common/delayed_call](https://travis-ci.org/measurement-kit/measurement-kit/jobs/97945929#L1185)
* [test/net/connection](https://github.com/measurement-kit/measurement-kit/issues/191)
* [test/http/stream](https://travis-ci.org/measurement-kit/measurement-kit/jobs/97945929#L1509)

This closes #99 