### PR TITLE
travis: create build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,114 @@
 language: cpp
-dist: trusty
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y --force-yes gcc-4.8 g++-4.8
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 90
-  - sudo apt-get install -y tor
-  - pip install --user cpp-coveralls
-
-install: ./autogen.sh
-
+  - if [ "$INSTALL" = "true" ]; then 
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
+        sudo apt-get update -qq;
+        sudo apt-get install -qq -y --force-yes gcc-4.8 g++-4.8;
+    fi
+  - if [ "$OS" = "OSX" ]; then
+        brew update;
+        brew upgrade; 
+    fi
+install: 
+    - if [ "$EXPORT" = "true" ]; then
+        if [ "$CXX" = "g++" ]; then export CXX="g++-$CXX_V" CC="gcc-$CC_V"; fi;
+        if [ "$CXX" = "clang++" ]; then
+          export CXX="clang++-$CXX_V" CC="clang-$CC_V";
+        fi;
+      fi
+    - ./autogen.sh
+    - ARG="-q --with-libevent=builtin --with-yaml-cpp=builtin
+           --with-boost=builtin --with-jansson=builtin
+           --with-libmaxminddb=builtin"
+    - if [ "$COVERAGE" = "true" ]; then
+          CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage;
+          pip install --user cpp-coveralls;
+      fi 
+    - if [ "$VALGRIND" = "true" ]; then
+          ARG+=" --disable-shared";
+      fi  
 # Only measure coverage with clang for now because I cannot manage to
 # convince coveralls to find all sources when using gcc-4.8 and gcov-4.8
 # (For more context see measurement-kit/measurement-kit#255)
 script:
-  - if [ "$CXX" = "clang++" ]; then
-      ./configure -q --with-libevent=builtin --with-yaml-cpp=builtin
-                     --with-boost=builtin --with-jansson=builtin
-                     --with-libmaxminddb=builtin
-                     CFLAGS=--coverage CXXFLAGS=--coverage
-                     LDFLAGS=--coverage;
-    else
-      ./configure -q --with-libevent=builtin --with-yaml-cpp=builtin
-                     --with-boost=builtin --with-jansson=builtin
-                     --with-libmaxminddb=builtin;
-    fi
-  - make -j2 V=0
-  - make -j2 check-am V=0
+    - if [ "$BUILD_TYPE" = "ios" ]; then 
+          ./mobile/ios/scripts/build.sh;
+      else
+          ./configure $ARG && make -j2 V=0 && make -j2 check-am V=0;
+          if [ "$VALGRIND" = "true" ]; then 
+              make run-valgrind;
+          fi
+      fi
 
 # Silence gcov standard output since it produces way too much output
 after_success:
-  - if [ "$CXX" = "clang++" ]; then
-      coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext > /dev/null;
-    fi
+    - if [ "$COVERAGE" = "true" ]; then
+        coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext > /dev/null;
+      fi
 
-compiler:
-  - clang
-  - g++
+after_failure:
+    - if [ -f "test-suite.log" ]; then 
+        cat test-suite.log;
+      fi
+matrix:
+  fast_finish: true
+  include:
+    - sudo: false
+      compiler: g++-5
+      env: OS="Ubuntu 12.04" CXX_V=5 CC_V=5 EXPORT=true
+      addons:
+        apt:
+            packages:
+                - g++-5
+                - gcc-5
+            sources:
+                - ubuntu-toolchain-r-test 
+    - sudo: false
+      compiler: g++-4.8
+      env: OS="Ubuntu 12.04" CXX_V=4.8 CC_V=4.8 EXPORT=true
+      addons: 
+        apt:
+            packages:
+                - g++-4.8
+                - gcc-4.8
+            sources:
+                - ubuntu-toolchain-r-test 
+    - sudo: false
+      compiler: clang-3.6 
+      env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true 
+      addons:
+        apt:
+            packages:
+                - clang-3.6
+                - llvm-3.6-dev
+                - valgrind
+            sources:
+                - llvm-toolchain-precise-3.6
+                - ubuntu-toolchain-r-test
+    - sudo: false
+      compiler: g++-4.8
+      env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=4.8 CC_V=4.8 EXPORT=true
+      addons: 
+        apt:
+            packages:
+                - g++-4.8
+                - gcc-4.8
+            sources:
+                - ubuntu-toolchain-r-test 
+    - dist: trusty
+      compiler: clang-3.5
+      env: OS="Ubuntu 14.04"
+    - dist: trusty
+      compiler: g++-4.8
+      env: OS="Ubuntu 14.04"
+    - os: osx
+      compiler: g++-4.8
+      env: OS=OSX CXX_V=4.8 CC_V=4.8 EXPORT=true
+    - os: osx
+      compiler: g++
+      env: OS=OSX BUILD_TYPE=ios
+  allow_failures:
+    - env: OS=OSX BUILD_TYPE=ios
+    - env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true
+    - env: OS=OSX CXX_V=4.8 CC_V=4.8 EXPORT=true


### PR DESCRIPTION
I have implemented a build matrix for the Travis-ci script. Now we are able to test the build with different systems (Ubuntu 12.04, Ubuntu 14.04, MacOSX, iOS). There are 11 different builds with a combination of OS and compiler, but maybe they are too much now. What do you think @bassosimone?

The first three build are done in a container environment, so they should [start immediately and with more resources](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/), and the other are not in a container and can use sudo, they need approximately 2/3 minutes to start. 