### PR TITLE
http_parser initializer functions used instead of memset.

### DIFF
--- a/src/http/request_serializer.cpp
+++ b/src/http/request_serializer.cpp
@@ -21,7 +21,7 @@ RequestSerializer::RequestSerializer(Settings settings, Headers headers_,
     : headers(headers_), body(body_) {
     auto url = settings["url"];
     http_parser_url url_parser;
-    memset(&url_parser, 0, sizeof(url_parser));
+    http_parser_url_init(&url_parser); 
     if (http_parser_parse_url(url.c_str(), url.length(), 0, &url_parser) != 0) {
         throw UrlParserError();
     }

--- a/src/http/response_parser.cpp
+++ b/src/http/response_parser.cpp
@@ -167,7 +167,7 @@ class ResponseParserImpl {
      * \brief Default constructor.
      */
     ResponseParserImpl(Logger *lp = Logger::global()) : logger(lp) {
-        memset(&settings, 0, sizeof(settings));
+        http_parser_settings_init(&settings);
         settings.on_message_begin = do_message_begin;
         settings.on_status = do_status;
         settings.on_header_field = do_header_field;
@@ -175,7 +175,6 @@ class ResponseParserImpl {
         settings.on_headers_complete = do_headers_complete;
         settings.on_body = do_body;
         settings.on_message_complete = do_message_complete;
-        memset(&parser, 0, sizeof(parser));
         http_parser_init(&parser, HTTP_RESPONSE);
         parser.data = this; /* Which makes this object non-movable */
     }


### PR DESCRIPTION
`http_parser_init` and `http_parser_settings_init` are used instead of `memset`.

Closes #292 