### PR TITLE
Use M4 macros and a build script for dependencies

### DIFF
--- a/build/ios/scripts/build_arch.sh
+++ b/build/ios/scripts/build_arch.sh
@@ -13,6 +13,8 @@ ARCH=$2
 if [ "$PLATFORM" = "iPhoneOS" ]; then
     EXTRA_CONFIG="--host=arm-apple-darwin14 --target=arm-apple-darwin14"
 fi
+EXTRA_CONFIG="$EXTRA_CONFIG --disable-shared"
+export pkg_cmake_flags="-DBUILD_SHARED_LIBS=OFF"
 
 ROOTDIR=$(cd $(dirname $0) && pwd -P)
 SOURCEDIR="$ROOTDIR/../../../"
@@ -34,20 +36,28 @@ export CXX="/usr/bin/g++ -arch ${ARCH} -miphoneos-version-min=${MINIOSVERSION}"
 export CPPFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
 export CFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
 export CXXFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
+export LDFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
 
 (
     cd $SOURCEDIR
-    test -x ./configure || ./autogen.sh
+    export pkg_prefix=$BUILDDIR/build/${PLATFORM}/${ARCH}
+    export pkg_configure_flags=$EXTRA_CONFIG
+    ./build/dependency all
+    test -x ./configure || autoreconf -i
     ./configure -q --disable-shared \
                 --disable-examples \
-                --with-libevent=builtin \
-                --with-jansson=builtin \
-                --with-libmaxminddb=builtin \
-                --prefix=/ \
+                --with-libevent=${pkg_prefix} \
+                --with-yaml-cpp=${pkg_prefix} \
+                --with-boost=${pkg_prefix} \
+                --with-jansson=${pkg_prefix} \
+                --with-libmaxminddb=${pkg_prefix} \
+                --with-Catch=${pkg_prefix} \
+                --with-http-parser=${pkg_prefix} \
+                --prefix=$BUILDDIR/build/${PLATFORM}/${ARCH} \
                 $EXTRA_CONFIG
     make -j4 V=0
-    make install-strip V=0 DESTDIR=$BUILDDIR/build/${PLATFORM}/${ARCH}/
-    rm -rf $BUILDDIR/build/${PLATFORM}/${ARCH}/include/
-    make install-data-am V=0 DESTDIR=$BUILDDIR/build/${PLATFORM}/${ARCH}/
-    make distclean
+    make install-strip
+    rm -rf $BUILDDIR/build/${PLATFORM}/${ARCH}/include
+    make install-data-am
+    make distclean  # necessary since we build in place
 )


### PR DESCRIPTION
This allows to download, compile, and install dependencies through `./build/dependency all`.

Otherwise, the `./configure` script will stop when a dependency is missing and explain you how to install that dependency. Instructions explain how to use `apt-get`, `brew`, and `./build/dependency`.

The latter downloads, patches, configures, compiles, and installs a dependency inside the `./builtin` directory. To teach `./configure` to spot dependency `foo` installed like this, one shall pass the `--with-foo=builtin` flag to the `./configure` script.

This is an enhancement because we need to track less code (i.e., faster pulls) and because it disentangles building the core of MK from its dependencies. I tried also other approaches (see, e.g., #365; the end result however was always that I needed to couple tightly dependencies and MK and that more code than in this pull request needed to be added).

Furthermore, the `configure.ac` file has been refactored moving all the hand-rolled tests inside `m4/measurement_kit.m4` for increased readability, testability, and maintainability.

Contains also updates in the code to cross compile stuff for ios and android.

Code in this pull request is a super stripped-down version of [bassosimone/mkpm-ng](https://github.com/bassosimone/mkpm-ng).