### PR TITLE
Version number updated from 0.1.0 to 0.2.0-alpha

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,12 +11,12 @@ LIBMEASUREMENT_KIT_I_FLAGS = -I $(top_srcdir)/include
 LIBMEASUREMENT_KIT_I_FLAGS += -I $(top_srcdir)/src
 LIBMEASUREMENT_KIT_W_FLAGS = -Wall -Wextra -pedantic
 
-VERSION_INFO = 0:1:0
+VERSION_INFO = -release @VERSION@ -version-info 0
 AM_CFLAGS = -pthread $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
 AM_CXXFLAGS = -pthread $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
 
 lib_LTLIBRARIES =  # Empty
-libmeasurement_kit_la_LDFLAGS = -pthread -version-info $(VERSION_INFO) -lyaml-cpp
+libmeasurement_kit_la_LDFLAGS = -pthread $(VERSION_INFO) -lyaml-cpp
 libmeasurement_kit_la_SOURCES =  # Empty
 
 noinst_LTLIBRARIES =  # Empty

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 # information on the copying conditions.
 
 # Autoconf requirements
-AC_INIT(measurement_kit, 0.1.0, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.2.0-alpha, bassosimone@gmail.com)
 
 # information on the package
 AC_CONFIG_SRCDIR([src/common/poller.cpp])

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-Welcome to Measurement Kit **v0.1.0** documentation!
+Welcome to Measurement Kit **v0.1.3** documentation!
 
 # How to generate documentation
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-Welcome to Measurement Kit **v0.1.3** documentation!
+Welcome to Measurement Kit **v0.2.0-alpha** documentation!
 
 # How to generate documentation
 

--- a/include/measurement_kit/common/version.hpp
+++ b/include/measurement_kit/common/version.hpp
@@ -6,6 +6,6 @@
 #define MEASUREMENT_KIT_COMMON_VERSION_HPP
 
 // Note: we use semantic versioning (see: http://semver.org/)
-#define MEASUREMENT_KIT_VERSION "0.1.3"
+#define MEASUREMENT_KIT_VERSION "0.2.0-alpha"
 
 #endif

--- a/include/measurement_kit/common/version.hpp
+++ b/include/measurement_kit/common/version.hpp
@@ -6,6 +6,6 @@
 #define MEASUREMENT_KIT_COMMON_VERSION_HPP
 
 // Note: we use semantic versioning (see: http://semver.org/)
-#define MEASUREMENT_KIT_VERSION "0.1.0"
+#define MEASUREMENT_KIT_VERSION "0.1.3"
 
 #endif

--- a/measurement_kit.podspec
+++ b/measurement_kit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "measurement_kit"
-  s.version = "0.1.2"
+  s.version = "0.2.0-alpha"
   s.summary = "Portable network measurement library"
   s.author = "Davide Allavena",
              "Simone Basso",


### PR DESCRIPTION
This PR updates version number.

The patch can be used to locate version number in the project (al least where i found it). 

An exaustive process is still not defined. An update-script or a single file with the version maybe?

Closes #359.
