### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ system where XCode and its command line tools have been installed:
 
 ### How to add MeasurementKit to an Xcode project.
 
-The Cocoapods podspec hasn't been submitted yet, but you can already use
+The CocoaPods podspec hasn't been submitted yet, but you can already use
 it in your project adding this line in your Podfile:
 
     pod 'measurement_kit', :git => 'https://github.com/measurement-kit/measurement-kit.git'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
