### PR TITLE
connection: disable read when callback is null

### DIFF
--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -73,7 +73,11 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     void on_data(std::function<void(Buffer)> fn) override {
         Emitter::on_data(fn);
-        enable_read();
+        if (fn) {
+            enable_read();
+        } else {
+            disable_read();
+        }
     };
 
     evutil_socket_t get_fileno() { return (bufferevent_getfd(this->bev)); }


### PR DESCRIPTION
You may want to pause reading, for example because too much data is buffered. Now you can do this by passing `nullptr` to the transport's `on_data` method.