### PR TITLE
ooni: allow to use specific poller

### DIFF
--- a/include/measurement_kit/http.hpp
+++ b/include/measurement_kit/http.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/var.hpp>
 #include <set>
@@ -77,7 +78,8 @@ class Client {
   public:
     /// Issue HTTP request.
     void request(Settings settings, Headers headers, std::string body,
-                 RequestCallback callback, Logger *lp = Logger::global());
+                 RequestCallback callback, Logger *lp = Logger::global(),
+                 Poller *poller = Poller::global());
 
     /// Get the global HTTP client instance
     static Var<Client> global() {
@@ -99,9 +101,11 @@ class Client {
 /// \param headers Optional HTTP request headers.
 /// \param body Optional HTTP request body.
 /// \param lp Optional logger.
+/// \param pol Optional poller.
 /// \param client Optional HTTP client.
 void request(Settings settings, RequestCallback cb, Headers headers = {},
              std::string body = "", Logger *lp = Logger::global(),
+             Poller *pol = Poller::global(),
              Var<Client> client = Client::global());
 
 } // namespace http

--- a/include/measurement_kit/ooni/base_test.hpp
+++ b/include/measurement_kit/ooni/base_test.hpp
@@ -5,8 +5,9 @@
 #ifndef MEASUREMENT_KIT_OONI_BASE_TEST_HPP
 #define MEASUREMENT_KIT_OONI_BASE_TEST_HPP
 
-#include <measurement_kit/common/var.hpp>
+#include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>
+#include <measurement_kit/common/var.hpp>
 #include <functional>
 #include <string>
 
@@ -40,6 +41,12 @@ class BaseTest {
         return *this;
     }
 
+    /// Set poller to be used
+    BaseTest &set_poller(Poller *p) {
+        poller = p;
+        return *this;
+    }
+
     /// Set log-message handler
     BaseTest &on_log(std::function<void(const char *)> func) {
         log_handler = func;
@@ -62,6 +69,7 @@ class BaseTest {
     std::function<void(const char *)> log_handler; ///< Log handler func
     std::string input_path;                        ///< Input file path
     std::string output_path;                       ///< Output file path
+    Poller *poller = Poller::global();             ///< Poller to use
 };
 
 } // namespace ooni

--- a/src/http/client.cpp
+++ b/src/http/client.cpp
@@ -9,9 +9,9 @@ namespace mk {
 namespace http {
 
 void Client::request(Settings settings, Headers headers, std::string body,
-                     RequestCallback callback, Logger *lp) {
-    auto r =
-        new Request(settings, headers, body, std::move(callback), lp, &pending);
+                     RequestCallback callback, Logger *lp, Poller *po) {
+    auto r = new Request(settings, headers, body, std::move(callback), lp,
+                         po, &pending);
     pending.insert(r);
 }
 
@@ -29,8 +29,8 @@ Client::~Client() {
 }
 
 void request(Settings settings, RequestCallback cb, Headers headers,
-             std::string body, Logger *lp, Var<Client> client) {
-    client->request(settings, headers, body, cb, lp);
+             std::string body, Logger *lp, Poller *po, Var<Client> client) {
+    client->request(settings, headers, body, cb, lp, po);
 }
 
 } // namespace http

--- a/src/http/stream.hpp
+++ b/src/http/stream.hpp
@@ -112,13 +112,14 @@ class Stream {
      * \param settings Settings passed to the transport to initialize
      *        it (see transport.cpp for more info).
      */
-    Stream(Settings settings, Logger *lp = Logger::global()) {
+    Stream(Settings settings, Logger *lp = Logger::global(),
+           Poller *pol = Poller::global()) {
         parser = std::make_shared<ResponseParser>(lp);
         // XXX Taking .as_value() here causes an exception to be thrown if
         // the connect() function failed in some way. This is to be fixed once
         // release v0.1.0 is rolled out, when we'll deal with all the errors
         // that can happen in the implementation of HTTP.
-        connection = net::connect(settings, lp).as_value();
+        connection = net::connect(settings, lp, pol).as_value();
         //
         // While the connection is in progress, just forward the
         // error if needed, we'll deal with body-terminated-by-EOF

--- a/src/ooni/dns_test.hpp
+++ b/src/ooni/dns_test.hpp
@@ -32,7 +32,7 @@ class DNSTest : public ooni::OoniTest {
             Settings{
                 {"nameserver", nameserver}, {"attempts", "1"},
             },
-            &logger, libs);
+            &logger, libs, poller);
 
         std::string nameserver_part;
         std::stringstream nameserver_ss(nameserver);

--- a/src/ooni/http_test.hpp
+++ b/src/ooni/http_test.hpp
@@ -60,7 +60,7 @@ class HTTPTest : public ooni::OoniTest {
                 entry["agent"] = "agent";
                 entry["socksproxy"] = "";
                 callback(error, std::move(response));
-            }, &logger);
+            }, &logger, poller);
     }
 };
 

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -43,6 +43,7 @@ Var<NetTest> DnsInjectionTest::create_test_() {
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
+    test->set_poller(poller);
     return Var<NetTest>(test);
 }
 
@@ -51,6 +52,7 @@ Var<NetTest> HttpInvalidRequestLineTest::create_test_() {
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
+    test->set_poller(poller);
     return Var<NetTest>(test);
 }
 
@@ -59,6 +61,7 @@ Var<NetTest> TcpConnectTest::create_test_() {
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
+    test->set_poller(poller);
     return Var<NetTest>(test);
 }
 

--- a/src/ooni/ooni_test.hpp
+++ b/src/ooni/ooni_test.hpp
@@ -11,6 +11,7 @@
 #include <functional>                           // for function, __base
 #include <measurement_kit/common/logger.hpp>    // for Logger
 #include <measurement_kit/common/net_test.hpp>  // for NetTest
+#include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/settings.hpp>  // for Settings
 #include <string>                               // for allocator, operator+
 #include <type_traits>                          // for move
@@ -195,6 +196,10 @@ class OoniTest : public mk::NetTest {
         file_report.close();
         cb();
     }
+
+    Poller *poller = Poller::global();
+
+    void set_poller(Poller *p) { poller = p; }
 };
 
 } // namespace ooni

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -44,7 +44,8 @@ class TCPTest : public ooni::OoniTest {
         }
 
         auto connection = std::make_shared<net::Connection>(
-            "PF_UNSPEC", options["host"].c_str(), options["port"].c_str());
+            "PF_UNSPEC", options["host"].c_str(), options["port"].c_str(),
+            &logger, poller);
 
         //
         // FIXME The connection and this are bound in the


### PR DESCRIPTION
Useful in tor code to use tor's poller rather than the default poller.