### PR TITLE
async: radically simplify implementation

### DIFF
--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -21,6 +21,8 @@ class Async {
     /// Default constructor
     Async(Poller *pol = Poller::global());
 
+    ~Async();
+
     /// Run the specified network test and call a callback when done
     /// \param func Callback called when test is done
     /// \warn The callback is called from a background thread

--- a/include/measurement_kit/common/async.hpp
+++ b/include/measurement_kit/common/async.hpp
@@ -5,6 +5,7 @@
 #ifndef MEASUREMENT_KIT_COMMON_ASYNC_HPP
 #define MEASUREMENT_KIT_COMMON_ASYNC_HPP
 
+#include <measurement_kit/common/poller.hpp>
 #include <measurement_kit/common/var.hpp>
 
 #include <functional>
@@ -18,7 +19,7 @@ struct AsyncState;
 class Async {
   public:
     /// Default constructor
-    Async();
+    Async(Poller *pol = Poller::global());
 
     /// Run the specified network test and call a callback when done
     /// \param func Callback called when test is done

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -28,9 +28,19 @@ class EvThreadSingleton {
     static void ensure() { static EvThreadSingleton singleton; }
 };
 
+// Make sure that, no matter what kind of poller we're using and what kind of
+// events it periodically schedules, if any, there is at least one event
+static void keep_me_alive(Var<AsyncState> state) {
+    state->poller->call_later(10.0, [state]() {
+        debug("async: keep-alive callback");
+        keep_me_alive(state);
+    });
+}
+
 void Async::loop_thread(Var<AsyncState> state) {
     EvThreadSingleton::ensure();
     debug("async: loop thread entered");
+    keep_me_alive(state);
     state->poller->loop();
     debug("async: exiting from thread");
 }

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -2,7 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#include <event2/event.h>
 #include <atomic>
 #include <measurement_kit/common/async.hpp>
 #include <measurement_kit/common/logger.hpp>
@@ -20,19 +19,9 @@ struct AsyncState {
     Poller *poller = Poller::global();
 };
 
-static void mk_do_nothing(evutil_socket_t, short, void *p) {}
-
 void Async::loop_thread(Var<AsyncState> state) {
     debug("async: loop thread entered");
-    struct timeval ten_seconds = {10, 0};
-    // Make sure that, no matter what kind of poller we're using and what kind
-    // of
-    // events it periodically schedules, if any, there is at least one event
-    event *ev = ::event_new(state->poller->get_event_base(), -1, EV_PERSIST,
-                            mk_do_nothing, nullptr);
-    ::event_add(ev, &ten_seconds);
     state->poller->loop();
-    ::event_free(ev);
     debug("async: exiting from thread");
 }
 

--- a/src/common/async.cpp
+++ b/src/common/async.cpp
@@ -2,29 +2,22 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
+#include <event2/thread.h>
+#include <atomic>
 #include <measurement_kit/common/async.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/net_test.hpp>
 #include <measurement_kit/common/poller.hpp>
-
-#include <mutex>
-#include <map>
+#include <measurement_kit/common/var.hpp>
 #include <thread>
-
-#include <event2/thread.h>
 
 namespace mk {
 
 // Shared state between foreground and background threads
 struct AsyncState {
-    std::map<NetTest *, std::function<void(Var<NetTest>)>> callbacks;
-    std::map<NetTest *, Var<NetTest>> ready;
-    std::map<NetTest *, Var<NetTest>> active;
-    std::map<NetTest *, Var<NetTest>> complete;
-    volatile bool interrupted = false;
-    std::mutex mutex;
+    std::atomic<int> running;
     std::thread thread;
-    volatile bool thread_running = false;
+    Poller *poller = Poller::global();
 };
 
 class EvThreadSingleton {
@@ -35,115 +28,41 @@ class EvThreadSingleton {
     static void ensure() { static EvThreadSingleton singleton; }
 };
 
-// Syntactic sugar
-#define LOCKED(foo)                                                            \
-    {                                                                          \
-        std::lock_guard<std::mutex> lck(state->mutex);                         \
-        foo                                                                    \
-    }
-
-// Ensure consistency
-#define INSERT(m, k, v)                                                        \
-    do {                                                                       \
-        auto ret = m.insert(std::make_pair(k, v));                             \
-        if (!ret.second) throw std::runtime_error("Element already there");    \
-    } while (0)
-#define GET(v, m, k)                                                           \
-    do {                                                                       \
-        auto there = (m.find(k) != m.end());                                   \
-        if (!there) throw std::runtime_error("Element not there");             \
-        v = m[k];                                                              \
-    } while (0)
-
 void Async::loop_thread(Var<AsyncState> state) {
     EvThreadSingleton::ensure();
-    state->interrupted = false; // Undo previous break_loop() if any
-
     debug("async: loop thread entered");
-    for (;;) {
-
-        LOCKED({
-            debug("async: loop thread locked");
-            auto empty = (state->ready.empty() && state->active.empty());
-            if (state->interrupted || empty) {
-                debug("async: %s", (empty) ? "empty" : "interrupted");
-                // Do this here so it's done while we're locked
-                debug("async: detaching thread...");
-                state->thread.detach();
-                state->thread_running = false;
-                break;
-            }
-
-            debug("async: not interrupted and not empty");
-            for (auto pair : state->ready) {
-                NetTest *ptr = pair.first;
-                debug("async: active: %lld", ptr->identifier());
-                INSERT(state->active, ptr, pair.second);
-                // Note: it should be safe to capture `state` by reference
-                // here because the destructor should not be able to destroy
-                // the background thread until we detach it and break.
-                ptr->begin([&state, ptr]() {
-                    ptr->end([&state, ptr]() {
-                        //
-                        // This callback is invoked by loop_once, when we do
-                        // not own the lock. For this reason it's important
-                        // to only modify state->active in the current thread,
-                        // i.e. in the background thread (i.e this function)
-                        //
-                        debug("async: test stopped");
-                        Var<NetTest> test;
-                        std::function<void(Var<NetTest>)> callback;
-                        LOCKED({
-                            GET(test, state->active, ptr);
-                            GET(callback, state->callbacks, ptr);
-                            state->active.erase(ptr);
-                            state->callbacks.erase(ptr);
-                            // Keep alive test until end of the loop
-                            INSERT(state->complete, ptr, test);
-                        });
-                        if (callback) {
-                            callback(test);
-                        }
-                    });
-                });
-            }
-            state->ready.clear();
-        })
-
-        debug("async: loop thread unlocked");
-        loop_once();
-
-        LOCKED({
-            // Do this here so tests have a chance to rewind their stack
-            debug("async: clearing terminated tests");
-            state->complete.clear();
-        })
-        debug("async: bottom of loop thread");
-    }
+    state->poller->loop();
     debug("async: exiting from thread");
 }
 
-Async::Async() { state.reset(new AsyncState()); }
+Async::Async(Poller *poller) {
+    state.reset(new AsyncState());
+    state->poller = poller;
+    state->thread = std::thread(loop_thread, state);
+}
 
 void Async::run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> fn) {
-    LOCKED({
-        debug("async: test inserted");
-        INSERT(state->ready, test.get(), test);
-        INSERT(state->callbacks, test.get(), fn);
-        if (!state->thread_running) {
-            debug("async: background thread started");
-            state->thread = std::thread(loop_thread, state);
-            state->thread_running = true;
-        }
-    })
+    debug("async: test inserted: %lld", test->identifier());
+    auto context = state;
+    ++context->running;
+    context->poller->call_soon([context, fn, test]() {
+        debug("async: test started: %lld", test->identifier());
+        test->begin([context, fn, test]() {
+            test->end([context, fn, test]() {
+                debug("async: test complete: %lld", test->identifier());
+                context->poller->call_soon([context, fn, test]() {
+                    debug("async: test removed: %lld", test->identifier());
+                    --context->running;
+                    fn(test);
+                });
+            });
+        });
+    });
 }
 
-void Async::break_loop() {
-    break_loop();
-    state->interrupted = true;
-}
+void Async::break_loop() { state->poller->break_loop(); }
 
-bool Async::empty() { return !state->thread_running; }
+bool Async::empty() { return state->running == 0; }
 
 Async *Async::global() {
     static Async singleton;

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -15,6 +15,8 @@
 #include <atomic>
 #include <unistd.h>
 
+#define NUM_TESTS 8
+
 using namespace mk;
 
 static void run_http_invalid_request_line(Async &async, std::atomic<int> &num) {
@@ -27,7 +29,7 @@ static void run_http_invalid_request_line(Async &async, std::atomic<int> &num) {
                        .create_test_(),
                    [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
-                       if (++num > 16) {
+                       if (++num > NUM_TESTS) {
                            return;
                        }
                        run_http_invalid_request_line(async, num);
@@ -45,7 +47,7 @@ static void run_dns_injection(Async &async, std::atomic<int> &num) {
                        .create_test_(),
                    [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
-                       if (++num > 16) {
+                       if (++num > NUM_TESTS) {
                            return;
                        }
                        run_dns_injection(async, num);
@@ -63,11 +65,11 @@ static void run_tcp_connect(Async &async, std::atomic<int> &num) {
                        .create_test_(),
                    [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
-                       if (++num > 16) {
+                       if (++num > NUM_TESTS) {
                            return;
                        }
                        run_tcp_connect(async, num);
-                   });
+                    });
 }
 
 TEST_CASE("The async engine works as expected") {
@@ -87,7 +89,7 @@ TEST_CASE("The async engine works as expected") {
         run_http_invalid_request_line(async, num_tests);
         run_tcp_connect(async, num_tests);
     });
-    while (num_tests < 16) {
+    while (not async.empty() or num_tests < NUM_TESTS) {
         sleep(5);
     }
 }

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -12,65 +12,82 @@
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/ooni.hpp>
 
+#include <atomic>
 #include <unistd.h>
 
 using namespace mk;
 
-static void run_http_invalid_request_line(Async &async) {
+static void run_http_invalid_request_line(Async &async, std::atomic<int> &num) {
     async.run_test(ooni::HttpInvalidRequestLineTest()
                        .set_backend("http://nexa.polito.it/")
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #1: %s\n", s);
                        })
+                       .set_verbose()
                        .create_test_(),
-                   [](Var<NetTest> test) {
+                   [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
+                       if (++num > 16) {
+                           return;
+                       }
+                       run_http_invalid_request_line(async, num);
                    });
 }
 
-static void run_dns_injection(Async &async) {
+static void run_dns_injection(Async &async, std::atomic<int> &num) {
     async.run_test(ooni::DnsInjectionTest()
                        .set_backend("8.8.8.8:53")
                        .set_input_file_path("test/fixtures/hosts.txt")
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #3: %s\n", s);
                        })
+                       .set_verbose()
                        .create_test_(),
-                   [](Var<NetTest> test) {
+                   [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
+                       if (++num > 16) {
+                           return;
+                       }
+                       run_dns_injection(async, num);
                    });
 }
 
-static void run_tcp_connect(Async &async) {
+static void run_tcp_connect(Async &async, std::atomic<int> &num) {
     async.run_test(ooni::TcpConnectTest()
                        .set_port("80")
                        .set_input_file_path("test/fixtures/hosts.txt")
                        .on_log([](const char *s) {
                            (void)fprintf(stderr, "test #4: %s\n", s);
                        })
+                       .set_verbose()
                        .create_test_(),
-                   [](Var<NetTest> test) {
+                   [&async, &num](Var<NetTest> test) {
                        mk::debug("test complete: %llu", test->identifier());
+                       if (++num > 16) {
+                           return;
+                       }
+                       run_tcp_connect(async, num);
                    });
 }
 
 TEST_CASE("The async engine works as expected") {
+    set_verbose(1);
 
     Async async;
+    std::atomic<int> num_tests(0);
 
-    for (int i = 0; i < 4; ++i) {
-        mk::debug("do another iteration of tests");
-
+    // The callback must be called some time in the future because otherwise
+    // it would never be fired, since at this time we don't know whether in the
+    // other thread the poller was actually already started or not.
+    Poller::global()->call_later(5.0, [&async, &num_tests]() {
         // Create tests in temporary void functions to also check that we can
         // create them in functions that later return in real apps
-        run_dns_injection(async);
-        run_http_invalid_request_line(async);
-        run_http_invalid_request_line(async);
-        run_tcp_connect(async);
-
-        // TODO Need to implement a better sync mechanism?
-        while (!async.empty()) {
-            sleep(1);
-        }
+        run_dns_injection(async, num_tests);
+        run_http_invalid_request_line(async, num_tests);
+        run_http_invalid_request_line(async, num_tests);
+        run_tcp_connect(async, num_tests);
+    });
+    while (num_tests < 16) {
+        sleep(5);
     }
 }


### PR DESCRIPTION
The only visible change in headers is that it is optionally possible to pass to the async constructor the specific poller to use. This, in turn, will allow us to pass to the async object the tor poller (which will be added as part of a *subsequent* pull request).

Speaking of the implementation, the radically simpler changes stem from the observation that the older implementation was basically doing the following:

1. schedule functions registered to be called (either for starting tests or for dispatching the news that they completed) making sure lists of functions to be called are accessed in a thread safe way

2. dispatch I/O events by calling `event_base_loop()` in a non-blocking way

That's basically re-implementing part of the functionality of `event_base_dispatch()` out of libevent, because libevent's event loop is thread safe and has indeed the capability of registering functions to be called at a later time. The only problem, before the recent `Poller::call_soon()` patch, was that using such feature of scheduling callback was not that practical in MeasurementKit.

Hence, for what was said above, we can perform the following 1:1 changes to the implementation:

1. re-implement `loop_thread` as `poller->loop()` (i.e., a blocking I/O loop that is handled by libevent in a thread safe way and that also schedules registered callbacks)

2. directly start the thread inside the constructor and never actually exit it, unless explicitly asked by the user (this changes behavior with respect to previous implementation, we discuss this below)

3. re-implement `run_test()` as a chain of lambdas where the external lambda (the one to insert the "job" into async) and the most internal lambda (the one to extract it and call the final callback) are implemented through `poller->call_soon()`

4. re-implement `empty()` by checking for the value of an atomic counter that is incremented and decremented properly by `run_test()`.

Now, as regards the discussion of the changes, let's start to discuss 2. The previous implementation took advantage of the possibility of entering/exit libevent's loop to stop the background thread when it was not used. We are about to add support to the tor event loop, which will be wrapped by the poller class interface, and where it is not possible to exit and then reenter the loop. To keep things simple, I have hence decided to make the code in here equal for all kinds of poller. Of course, all of this matters if we are not running tests; because, if we're running tests, it goes without saying that we will have a background thread active and running them. So, if we're not running tests and we have the traditional libevent poller, we will have a thread blocked in `event_base_loop()`, that is in a blocking system call, until new event arrives. This is to say that we are only consuming some stack. On the contrary, with a tor poller, we will have a thread *mostly* blocked by a blocking system call, except that once per second the periodic function calls of tor are called. And, given that by default the tor poller runs with `DisableNetwork=1`, this again means very light and very periodic activity. For all this reasons, I've decided not to bother to optimize things further (given than now optimization is more complex). Should the need arise in future, I am totally open create - maybe - a fire-off-one-time test function using the libevent poller to just run one/a few tests (maybe this would be optimal for apps not using tor). In any case, I think this aspect should be created as an issue tagged as discussion.

As regards the correctness of the code, instead:

1. `poller->call_soon()` creates a `new std::function<void()>` on the heap, then passes such pointer as the `void *` argument to `event_base_once()`

2. given that `EvThreadSingleton::ensure()` is called when the thread is started, libevent is initialized to use threads, and `event_base_once()` should ensure that `event_base` internals are locked before inserting the new "once" event in queue

3. the pointer allocated on the heap in 1. will then be freed, after the associated lambda has been called

4. this happens in another thread, however, this was also the case before

In any case, to ensure that we're not making any mistake, we shall check with Valgrind that there are neither memory leaks nor memory errors in the code.

- [ ] create issue describing the always-running measurement-thread as a place where to discuss whether the fact that we use such thread is really an issue or not

- [x] make sure there are no issues running Valgrind (no memory errors and/or leaks)

- [x] make sure that travis completes correctly

- [x] have the code in here reviewed by another developer

- [x] move changes fixing leaks in a separate pull request so that they could be tested independently (as explained in more detail below)

- [ ] merge the pull request