### PR TITLE
Issue 347

### DIFF
--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -14,14 +14,14 @@
 namespace mk {
 namespace ooni {
 
-class DNSInjectionImpl : public DNSTest {
-    using DNSTest::DNSTest;
+class DNSInjectionImpl : public DNSTestImpl {
+    using DNSTestImpl::DNSTestImpl;
 
     std::function<void(report::Entry)> have_entry;
 
   public:
     DNSInjectionImpl(std::string input_filepath_, Settings options_)
-        : DNSTest(input_filepath_, options_) {
+        : DNSTestImpl(input_filepath_, options_) {
         test_name = "dns_injection";
         test_version = "0.0.1";
 

--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -14,13 +14,13 @@
 namespace mk {
 namespace ooni {
 
-class DNSInjection : public DNSTest {
+class DNSInjectionImpl : public DNSTest {
     using DNSTest::DNSTest;
 
     std::function<void(report::Entry)> have_entry;
 
   public:
-    DNSInjection(std::string input_filepath_, Settings options_)
+    DNSInjectionImpl(std::string input_filepath_, Settings options_)
         : DNSTest(input_filepath_, options_) {
         test_name = "dns_injection";
         test_version = "0.0.1";

--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -7,8 +7,8 @@
 
 #include <measurement_kit/dns.hpp>
 #include "src/ooni/errors.hpp"
-#include "src/ooni/ooni_test.hpp"
-#include "src/ooni/dns_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
+#include "src/ooni/dns_test_impl.hpp"
 #include <sys/stat.h>
 
 namespace mk {

--- a/src/ooni/dns_test_impl.hpp
+++ b/src/ooni/dns_test_impl.hpp
@@ -8,7 +8,7 @@
 #include <measurement_kit/common/var.hpp>
 
 #include <measurement_kit/dns.hpp>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 namespace mk {
 namespace ooni {

--- a/src/ooni/dns_test_impl.hpp
+++ b/src/ooni/dns_test_impl.hpp
@@ -13,13 +13,13 @@
 namespace mk {
 namespace ooni {
 
-class DNSTest : public ooni::OoniTest {
+class DNSTestImpl : public ooni::OoniTest {
     using ooni::OoniTest::OoniTest;
 
     Var<dns::Resolver> resolver;
 
   public:
-    DNSTest(std::string input_filepath_, Settings options_)
+    DNSTestImpl(std::string input_filepath_, Settings options_)
         : ooni::OoniTest(input_filepath_, options_) {
         test_name = "dns_test";
         test_version = "0.0.1";

--- a/src/ooni/dns_test_impl.hpp
+++ b/src/ooni/dns_test_impl.hpp
@@ -13,14 +13,14 @@
 namespace mk {
 namespace ooni {
 
-class DNSTestImpl : public ooni::OoniTest {
-    using ooni::OoniTest::OoniTest;
+class DNSTestImpl : public ooni::OoniTestImpl {
+    using ooni::OoniTestImpl::OoniTestImpl;
 
     Var<dns::Resolver> resolver;
 
   public:
     DNSTestImpl(std::string input_filepath_, Settings options_)
-        : ooni::OoniTest(input_filepath_, options_) {
+        : ooni::OoniTestImpl(input_filepath_, options_) {
         test_name = "dns_test";
         test_version = "0.0.1";
     };

--- a/src/ooni/http_invalid_request_line_impl.hpp
+++ b/src/ooni/http_invalid_request_line_impl.hpp
@@ -14,7 +14,7 @@
 namespace mk {
 namespace ooni {
 
-class HTTPInvalidRequestLine : public HTTPTest {
+class HTTPInvalidRequestLineImpl : public HTTPTest {
     using HTTPTest::HTTPTest;
 
     int tests_run = 0;
@@ -22,7 +22,7 @@ class HTTPInvalidRequestLine : public HTTPTest {
     std::function<void(report::Entry)> callback;
 
   public:
-    HTTPInvalidRequestLine(Settings options_) : HTTPTest(options_) {
+    HTTPInvalidRequestLineImpl(Settings options_) : HTTPTest(options_) {
         test_name = "http_invalid_request_line";
         test_version = "0.0.1";
     };

--- a/src/ooni/http_invalid_request_line_impl.hpp
+++ b/src/ooni/http_invalid_request_line_impl.hpp
@@ -8,21 +8,21 @@
 #include "src/common/utils.hpp"
 #include "src/ooni/errors.hpp"
 #include "src/ooni/ooni_test.hpp"
-#include "src/ooni/http_test.hpp"
+#include "src/ooni/http_test_impl.hpp"
 #include <sys/stat.h>
 
 namespace mk {
 namespace ooni {
 
-class HTTPInvalidRequestLineImpl : public HTTPTest {
-    using HTTPTest::HTTPTest;
+class HTTPInvalidRequestLineImpl : public HTTPTestImpl {
+    using HTTPTestImpl::HTTPTestImpl;
 
     int tests_run = 0;
 
     std::function<void(report::Entry)> callback;
 
   public:
-    HTTPInvalidRequestLineImpl(Settings options_) : HTTPTest(options_) {
+    HTTPInvalidRequestLineImpl(Settings options_) : HTTPTestImpl(options_) {
         test_name = "http_invalid_request_line";
         test_version = "0.0.1";
     };

--- a/src/ooni/http_invalid_request_line_impl.hpp
+++ b/src/ooni/http_invalid_request_line_impl.hpp
@@ -7,7 +7,7 @@
 
 #include "src/common/utils.hpp"
 #include "src/ooni/errors.hpp"
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 #include "src/ooni/http_test_impl.hpp"
 #include <sys/stat.h>
 

--- a/src/ooni/http_test_impl.hpp
+++ b/src/ooni/http_test_impl.hpp
@@ -12,14 +12,14 @@
 namespace mk {
 namespace ooni {
 
-class HTTPTestImpl : public ooni::OoniTest {
-    using ooni::OoniTest::OoniTest;
+class HTTPTestImpl : public ooni::OoniTestImpl {
+    using ooni::OoniTestImpl::OoniTestImpl;
 
     http::Client http_client;
 
   public:
     HTTPTestImpl(std::string input_filepath_, Settings options_)
-        : ooni::OoniTest(input_filepath_, options_) {
+        : ooni::OoniTestImpl(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
     }

--- a/src/ooni/http_test_impl.hpp
+++ b/src/ooni/http_test_impl.hpp
@@ -12,19 +12,19 @@
 namespace mk {
 namespace ooni {
 
-class HTTPTest : public ooni::OoniTest {
+class HTTPTestImpl : public ooni::OoniTest {
     using ooni::OoniTest::OoniTest;
 
     http::Client http_client;
 
   public:
-    HTTPTest(std::string input_filepath_, Settings options_)
+    HTTPTestImpl(std::string input_filepath_, Settings options_)
         : ooni::OoniTest(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
     }
 
-    HTTPTest(Settings options_) : HTTPTest("", options_) {}
+    HTTPTestImpl(Settings options_) : HTTPTestImpl("", options_) {}
 
     void request(Settings settings, http::Headers headers, std::string body,
                  http::RequestCallback &&callback) {

--- a/src/ooni/http_test_impl.hpp
+++ b/src/ooni/http_test_impl.hpp
@@ -7,7 +7,7 @@
 
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/http.hpp>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 namespace mk {
 namespace ooni {

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -39,7 +39,7 @@ void BaseTest::run(std::function<void()> callback) {
 }
 
 Var<NetTest> DnsInjectionTest::create_test_() {
-    OoniTest *test = new DNSInjection(input_path, settings);
+    OoniTest *test = new DNSInjectionImpl(input_path, settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -7,14 +7,14 @@
 #include <measurement_kit/common/async.hpp>    // for Async
 #include <measurement_kit/ooni/base_test.hpp>  // for BaseTest
 #include <measurement_kit/ooni/dns_injection_test.hpp>
-#include <measurement_kit/ooni/http_invalid_request_line_test.hpp>
+#include <measurement_kit/ooni/http_invalid_request_line_test_impl.hpp>
 #include <measurement_kit/ooni/tcp_connect_test.hpp>
 #include <measurement_kit/common/var.hpp>      // for Var
 #include <ratio>                               // for ratio
 #include <sys/stat.h>
 #include <thread>                              // for sleep_for
 #include "src/ooni/dns_injection.hpp"
-#include "src/ooni/http_invalid_request_line.hpp"
+#include "src/ooni/http_invalid_request_line_impl.hpp"
 #include "src/ooni/tcp_connect.hpp"
 
 namespace mk {
@@ -48,7 +48,7 @@ Var<NetTest> DnsInjectionTest::create_test_() {
 }
 
 Var<NetTest> HttpInvalidRequestLineTest::create_test_() {
-    OoniTest *test = new HTTPInvalidRequestLine(settings);
+    OoniTest *test = new HTTPInvalidRequestLineImpl(settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -15,7 +15,7 @@
 #include <thread>                              // for sleep_for
 #include "src/ooni/dns_injection_impl.hpp"
 #include "src/ooni/http_invalid_request_line_impl.hpp"
-#include "src/ooni/tcp_connect.hpp"
+#include "src/ooni/tcp_connect_impl.hpp"
 
 namespace mk {
 
@@ -57,7 +57,7 @@ Var<NetTest> HttpInvalidRequestLineTest::create_test_() {
 }
 
 Var<NetTest> TcpConnectTest::create_test_() {
-    OoniTestImpl *test = new TCPConnect(input_path, settings);
+    OoniTestImpl *test = new TCPConnectImpl(input_path, settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -6,14 +6,14 @@
 #include <functional>                          // for function
 #include <measurement_kit/common/async.hpp>    // for Async
 #include <measurement_kit/ooni/base_test.hpp>  // for BaseTest
-#include <measurement_kit/ooni/dns_injection_test.hpp>
+#include <measurement_kit/ooni/dns_injection_test_impl.hpp>
 #include <measurement_kit/ooni/http_invalid_request_line_test_impl.hpp>
 #include <measurement_kit/ooni/tcp_connect_test.hpp>
 #include <measurement_kit/common/var.hpp>      // for Var
 #include <ratio>                               // for ratio
 #include <sys/stat.h>
 #include <thread>                              // for sleep_for
-#include "src/ooni/dns_injection.hpp"
+#include "src/ooni/dns_injection_impl.hpp"
 #include "src/ooni/http_invalid_request_line_impl.hpp"
 #include "src/ooni/tcp_connect.hpp"
 

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -39,7 +39,7 @@ void BaseTest::run(std::function<void()> callback) {
 }
 
 Var<NetTest> DnsInjectionTest::create_test_() {
-    OoniTest *test = new DNSInjectionImpl(input_path, settings);
+    OoniTestImpl *test = new DNSInjectionImpl(input_path, settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
@@ -48,7 +48,7 @@ Var<NetTest> DnsInjectionTest::create_test_() {
 }
 
 Var<NetTest> HttpInvalidRequestLineTest::create_test_() {
-    OoniTest *test = new HTTPInvalidRequestLineImpl(settings);
+    OoniTestImpl *test = new HTTPInvalidRequestLineImpl(settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);
@@ -57,7 +57,7 @@ Var<NetTest> HttpInvalidRequestLineTest::create_test_() {
 }
 
 Var<NetTest> TcpConnectTest::create_test_() {
-    OoniTest *test = new TCPConnect(input_path, settings);
+    OoniTestImpl *test = new TCPConnect(input_path, settings);
     if (output_path != "") test->set_report_filename(output_path);
     if (is_verbose) test->set_verbose(1);
     if (log_handler) test->on_log(log_handler);

--- a/src/ooni/libooni.cpp
+++ b/src/ooni/libooni.cpp
@@ -6,8 +6,8 @@
 #include <functional>                          // for function
 #include <measurement_kit/common/async.hpp>    // for Async
 #include <measurement_kit/ooni/base_test.hpp>  // for BaseTest
-#include <measurement_kit/ooni/dns_injection_test_impl.hpp>
-#include <measurement_kit/ooni/http_invalid_request_line_test_impl.hpp>
+#include <measurement_kit/ooni/dns_injection_test.hpp>
+#include <measurement_kit/ooni/http_invalid_request_line_test.hpp>
 #include <measurement_kit/ooni/tcp_connect_test.hpp>
 #include <measurement_kit/common/var.hpp>      // for Var
 #include <ratio>                               // for ratio

--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -25,7 +25,7 @@
 namespace mk {
 namespace ooni {
 
-class OoniTest : public mk::NetTest {
+class OoniTestImpl : public mk::NetTest {
     std::string input_filepath;
     report::FileReporter file_report;
     std::string report_filename;
@@ -125,22 +125,22 @@ class OoniTest : public mk::NetTest {
     std::string probe_asn = "AS0";
     std::string probe_cc = "ZZ";
 
-    OoniTest() : OoniTest("", Settings()) {}
+    OoniTestImpl() : OoniTestImpl("", Settings()) {}
 
-    virtual ~OoniTest() {
+    virtual ~OoniTestImpl() {
         delete input;
         input = nullptr;
     }
 
-    OoniTest(OoniTest &) = delete;
-    OoniTest &operator=(OoniTest &) = delete;
-    OoniTest(OoniTest &&) = default;
-    OoniTest &operator=(OoniTest &&) = default;
+    OoniTestImpl(OoniTestImpl &) = delete;
+    OoniTestImpl &operator=(OoniTestImpl &) = delete;
+    OoniTestImpl(OoniTestImpl &&) = default;
+    OoniTestImpl &operator=(OoniTestImpl &&) = default;
 
-    OoniTest(std::string input_filepath_)
-        : OoniTest(input_filepath_, Settings()) {}
+    OoniTestImpl(std::string input_filepath_)
+        : OoniTestImpl(input_filepath_, Settings()) {}
 
-    OoniTest(std::string input_filepath_, Settings options_)
+    OoniTestImpl(std::string input_filepath_, Settings options_)
         : input_filepath(input_filepath_), options(options_),
           test_name("net_test"), test_version("0.0.1") {}
 

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -6,14 +6,14 @@
 #define SRC_OONI_TCP_CONNECT_HPP
 
 #include "src/ooni/errors.hpp"
-#include "src/ooni/tcp_test.hpp"
+#include "src/ooni/tcp_test_impl.hpp"
 #include <sys/stat.h>
 
 namespace mk {
 namespace ooni {
 
-class TCPConnectImpl : public TCPTest {
-    using TCPTest::TCPTest;
+class TCPConnectImpl : public TCPTestImpl {
+    using TCPTestImpl::TCPTestImpl;
 
     TCPClient client;
 
@@ -21,7 +21,7 @@ class TCPConnectImpl : public TCPTest {
 
   public:
     TCPConnectImpl(std::string input_filepath_, Settings options_)
-        : TCPTest(input_filepath_, options_) {
+        : TCPTestImpl(input_filepath_, options_) {
         test_name = "tcp_connect";
         test_version = "0.0.1";
 

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -12,7 +12,7 @@
 namespace mk {
 namespace ooni {
 
-class TCPConnect : public TCPTest {
+class TCPConnectImpl : public TCPTest {
     using TCPTest::TCPTest;
 
     TCPClient client;
@@ -20,7 +20,7 @@ class TCPConnect : public TCPTest {
     std::function<void(report::Entry)> have_entry;
 
   public:
-    TCPConnect(std::string input_filepath_, Settings options_)
+    TCPConnectImpl(std::string input_filepath_, Settings options_)
         : TCPTest(input_filepath_, options_) {
         test_name = "tcp_connect";
         test_version = "0.0.1";

--- a/src/ooni/tcp_test.hpp
+++ b/src/ooni/tcp_test.hpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/common/settings.hpp>
 #include <measurement_kit/common/var.hpp>
 
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 #include "src/net/connection.hpp"
 
 namespace mk {
@@ -24,12 +24,12 @@ namespace ooni {
 
 typedef Var<net::Connection> TCPClient; /* XXX */
 
-class TCPTest : public ooni::OoniTest {
-    using ooni::OoniTest::OoniTest;
+class TCPTest : public ooni::OoniTestImpl {
+    using ooni::OoniTestImpl::OoniTestImpl;
 
   public:
     TCPTest(std::string input_filepath_, Settings options_)
-        : ooni::OoniTest(input_filepath_, options_) {
+        : ooni::OoniTestImpl(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
     };

--- a/src/ooni/tcp_test_impl.hpp
+++ b/src/ooni/tcp_test_impl.hpp
@@ -24,11 +24,11 @@ namespace ooni {
 
 typedef Var<net::Connection> TCPClient; /* XXX */
 
-class TCPTest : public ooni::OoniTestImpl {
+class TCPTestImpl : public ooni::OoniTestImpl {
     using ooni::OoniTestImpl::OoniTestImpl;
 
   public:
-    TCPTest(std::string input_filepath_, Settings options_)
+    TCPTestImpl(std::string input_filepath_, Settings options_)
         : ooni::OoniTestImpl(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -5,7 +5,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include "src/ooni/dns_injection.hpp"
+#include "src/ooni/dns_injection_impl.hpp"
 #include <measurement_kit/common.hpp>
 
 using namespace mk;

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -15,7 +15,7 @@ TEST_CASE(
     "The DNS Injection test should run with an input file of DNS hostnames") {
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
-    DNSInjection dns_injection("test/fixtures/hosts.txt", options);
+    DNSInjectionImpl dns_injection("test/fixtures/hosts.txt", options);
     dns_injection.begin(
         [&]() { dns_injection.end([]() { mk::break_loop(); }); });
     mk::loop();
@@ -25,7 +25,7 @@ TEST_CASE("The DNS Injection test should throw an exception if an invalid file "
           "path is given") {
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
-    REQUIRE_THROWS_AS(DNSInjection dns_injection(
+    REQUIRE_THROWS_AS(DNSInjectionImpl dns_injection(
                           "/tmp/this-file-does-not-exist.txt", options),
                       InputFileDoesNotExist);
 }
@@ -34,6 +34,6 @@ TEST_CASE("The DNS Injection test should throw an exception if no file path is "
           "given") {
     Settings options;
     options["nameserver"] = "8.8.8.1:53";
-    REQUIRE_THROWS_AS(DNSInjection dns_injection("", options),
+    REQUIRE_THROWS_AS(DNSInjectionImpl dns_injection("", options),
                       InputFileRequired);
 }

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -46,7 +46,7 @@ TEST_CASE("Make sure that set_output_path() works") {
         .set_input_file_path("test/fixtures/hosts.txt")
         .set_output_file_path("foo.txt")
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
@@ -56,6 +56,6 @@ TEST_CASE("Make sure that default get_output_path() is nonempty") {
         // called inside create_test_() throws an exception
         .set_input_file_path("test/fixtures/hosts.txt")
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -5,7 +5,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include "src/ooni/http_invalid_request_line.hpp"
+#include "src/ooni/http_invalid_request_line_impl.hpp"
 #include <measurement_kit/common.hpp>
 
 using namespace mk;
@@ -14,7 +14,7 @@ using namespace mk::ooni;
 TEST_CASE("The HTTP Invalid Request Line test should run") {
     Settings options;
     options["backend"] = "http://213.138.109.232/";
-    HTTPInvalidRequestLine http_invalid_request_line(options);
+    HTTPInvalidRequestLineImpl http_invalid_request_line(options);
     http_invalid_request_line.begin([&]() {
         http_invalid_request_line.end([]() { mk::break_loop(); });
     });

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -50,13 +50,13 @@ TEST_CASE("Make sure that set_output_path() works") {
     auto instance = ooni::HttpInvalidRequestLineTest()
         .set_output_file_path("foo.txt")
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
 TEST_CASE("Make sure that default get_output_path() is nonempty") {
     auto instance = ooni::HttpInvalidRequestLineTest()
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }

--- a/test/ooni/net_test.cpp
+++ b/test/ooni/net_test.cpp
@@ -6,12 +6,12 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/common.hpp>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk::ooni;
 
 TEST_CASE("The NetTest should callback when it has finished running") {
-    mk::ooni::OoniTest test("");
+    mk::ooni::OoniTestImpl test("");
     test.begin([&]() { test.end([]() { mk::break_loop(); }); });
     mk::loop();
 }

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -6,14 +6,14 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/common.hpp>
-#include "src/ooni/tcp_connect.hpp"
+#include "src/ooni/tcp_connect_impl.hpp"
 
 using namespace mk;
 using namespace mk::ooni;
 
 TEST_CASE(
     "The TCP connect test should run with an input file of DNS hostnames") {
-    TCPConnect tcp_connect("test/fixtures/hosts.txt", {
+    TCPConnectImpl tcp_connect("test/fixtures/hosts.txt", {
                                                        {"port", "80"},
                                                       });
     tcp_connect.begin(
@@ -24,11 +24,11 @@ TEST_CASE(
 TEST_CASE("The TCP connect test should throw an exception if an invalid file "
           "path is given") {
     REQUIRE_THROWS_AS(
-        TCPConnect("/tmp/this-file-does-not-exist.txt", Settings()),
+        TCPConnectImpl("/tmp/this-file-does-not-exist.txt", Settings()),
         InputFileDoesNotExist);
 }
 
 TEST_CASE(
     "The TCP connect test should throw an exception if no file path is given") {
-    REQUIRE_THROWS_AS(TCPConnect("", Settings()), InputFileRequired);
+    REQUIRE_THROWS_AS(TCPConnectImpl("", Settings()), InputFileRequired);
 }

--- a/test/ooni/tcp_connect_test.cpp
+++ b/test/ooni/tcp_connect_test.cpp
@@ -11,7 +11,7 @@
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test.hpp"
+#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -46,7 +46,7 @@ TEST_CASE("Make sure that set_output_path() works") {
         .set_input_file_path("test/fixtures/hosts.txt")
         .set_output_file_path("foo.txt")
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
@@ -56,6 +56,6 @@ TEST_CASE("Make sure that default get_output_path() is nonempty") {
         // called inside create_test_() throws an exception
         .set_input_file_path("test/fixtures/hosts.txt")
         .create_test_();
-    auto ptr = static_cast<ooni::OoniTest *>(instance.get());
+    auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -5,7 +5,7 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include "src/ooni/tcp_test.hpp"
+#include "src/ooni/tcp_test_impl.hpp"
 #include <measurement_kit/common.hpp>
 
 #include <iostream>
@@ -13,10 +13,10 @@
 using namespace mk;
 using namespace mk::ooni;
 
-TEST_CASE("TCPTest works as expected in a common case") {
+TEST_CASE("TCPTestImpl works as expected in a common case") {
 
     auto count = 0;
-    TCPTest tcp_test("", Settings());
+    TCPTestImpl tcp_test("", Settings());
 
     auto client1 = tcp_test.connect(
         {


### PR DESCRIPTION
Every test file in `src/ooni/` was renamed according to #347.
Not renamed files are:

- input_file_generator.hpp  
- input_generator.hpp
- libooni.cpp 
- error.hpp

Should i procede with these files?

Closes #347