### PR TITLE
Fix several circular references

### DIFF
--- a/src/common/delayed_call.cpp
+++ b/src/common/delayed_call.cpp
@@ -42,6 +42,7 @@ DelayedCallState::~DelayedCallState() {
     if (evp_ == nullptr) return;
     libs_->event_free(evp_);
     evp_ = nullptr;
+    func_ = nullptr;
 }
 
 } // namespace mk

--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -17,8 +17,6 @@ namespace ooni {
 class DNSInjectionImpl : public DNSTestImpl {
     using DNSTestImpl::DNSTestImpl;
 
-    std::function<void(report::Entry)> have_entry;
-
   public:
     DNSInjectionImpl(std::string input_filepath_, Settings options_)
         : DNSTestImpl(input_filepath_, options_) {
@@ -38,16 +36,15 @@ class DNSInjectionImpl : public DNSTestImpl {
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb) {
         entry["injected"] = NULL;
-        have_entry = cb;
         query("A", "IN", input, options["nameserver"],
-              [this](dns::Response response) {
+              [this, cb](dns::Response response) {
                   logger.debug("dns_injection: got response");
                   if (response.get_evdns_status() == DNS_ERR_NONE) {
                       entry["injected"] = true;
                   } else {
                       entry["injected"] = false;
                   }
-                  have_entry(entry);
+                  cb(entry);
               });
     }
 };

--- a/src/ooni/http_invalid_request_line_impl.hpp
+++ b/src/ooni/http_invalid_request_line_impl.hpp
@@ -19,7 +19,6 @@ class HTTPInvalidRequestLineImpl : public HTTPTestImpl {
 
     int tests_run = 0;
 
-    std::function<void(report::Entry)> callback;
 
   public:
     HTTPInvalidRequestLineImpl(Settings options_) : HTTPTestImpl(options_) {
@@ -29,11 +28,10 @@ class HTTPInvalidRequestLineImpl : public HTTPTestImpl {
 
     void main(Settings options, std::function<void(report::Entry)> &&cb) {
 
-        callback = cb;
-        auto handle_response = [this](Error, http::Response &&) {
+        auto handle_response = [this, cb](Error, http::Response &&) {
             tests_run += 1;
             if (tests_run == 3) {
-                callback(entry);
+                cb(entry);
             }
             // XXX we currently don't set the tampering key, because this test
             // speaks to a TCP Echo helper, hence the response will not be valid

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -17,7 +17,6 @@ class TCPConnectImpl : public TCPTestImpl {
 
     TCPClient client;
 
-    std::function<void(report::Entry)> have_entry;
 
   public:
     TCPConnectImpl(std::string input_filepath_, Settings options_)
@@ -38,10 +37,10 @@ class TCPConnectImpl : public TCPTestImpl {
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb) {
         options["host"] = input;
-        have_entry = cb;
-        client = connect(options, [this]() {
+        
+        connect(options, [this, cb](TCPClient) {
             logger.debug("tcp_connect: Got response to TCP connect test");
-            have_entry(entry);
+            cb(entry);
         });
     }
 };

--- a/src/report/base_reporter.hpp
+++ b/src/report/base_reporter.hpp
@@ -22,7 +22,7 @@ class BaseReporter {
     std::string probe_asn;
     std::string probe_cc;
 
-    time_t start_time;
+    time_t start_time = 0;
 
     Settings options;
 

--- a/test/ooni/tcp_test.cpp
+++ b/test/ooni/tcp_test.cpp
@@ -18,21 +18,21 @@ TEST_CASE("TCPTestImpl works as expected in a common case") {
     auto count = 0;
     TCPTestImpl tcp_test("", Settings());
 
-    auto client1 = tcp_test.connect(
+    tcp_test.connect(
         {
          {"host", "www.neubot.org"}, {"port", "80"},
         },
-        [&count]() {
+        [&count](TCPClient) {
             if (++count >= 2) {
                 mk::break_loop();
             }
         });
 
-    auto client2 = tcp_test.connect(
+    tcp_test.connect(
         {
          {"host", "ooni.nu"}, {"port", "80"},
         },
-        [&count]() {
+        [&count](TCPClient) {
             if (++count >= 2) {
                 mk::break_loop();
             }


### PR DESCRIPTION
- make sure that there are no circular references in ooni implementation
- stop being interested in events when they are fired, such that we remove circular references
- make sure delayed call correctly clears its callback

I have already reviewed and approved this pull request offline, discussing it with @AntonioLangiu and adding one further fix to keep valgrind calm. Will merge as soon as travis completes.