### PR TITLE
Update poller implementation to prepare for #390

### DIFF
--- a/doc/api/common/poller.md
+++ b/doc/api/common/poller.md
@@ -25,6 +25,16 @@ if (poller.count_nameservers() <= 0) {
     poller.add_nameserver("8.8.4.4:53");     // Also with port
 }
 
+// Schedule a call to run in the next I/O cycle
+poller.call_soon([objects]() {
+    // Do something with `objects`
+});
+
+// Schedule a call 3.14 seconds in the future
+poller.call_later(3.14, [objects]() {
+    // Do something with `objects`
+});
+
 mk::Poller *root = mk::Poller::global();
 ```
 

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -34,6 +34,8 @@ class Poller : public NonCopyable, public NonMovable {
 
     void loop();
 
+    // Deprecated: this function was required to implement src/common/async.cpp
+    // and after async will be rewritten this function could be removed.
     void loop_once();
 
     void break_loop();

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -30,6 +30,8 @@ class Poller : public NonCopyable, public NonMovable {
     /// \throw Error if the underlying libevent call fails.
     void call_soon(std::function<void()> cb);
 
+    void call_later(double, std::function<void()> cb);
+
     void loop();
 
     void loop_once();

--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -60,10 +60,16 @@ class Poller : public NonCopyable, public NonMovable {
         return &singleton;
     }
 
+    // BEGIN internal functions used to test periodic event functionality
+    void handle_periodic_();
+    void on_periodic_(std::function<void(Poller *)> callback);
+    // END internal functions used to test periodic event functionality
+
   private:
     event_base *base_;
     evdns_base *dnsbase_;
     Libs *libs_ = get_global_libs();
+    std::function<void(Poller *)> periodic_cb_;
 };
 
 /*

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -20,6 +20,11 @@ static void mk_call_soon_cb(evutil_socket_t, short, void *p) {
     delete cbp;
 }
 
+static void do_periodic(evutil_socket_t, short, void *ptr) {
+    mk::Poller *poller = static_cast<mk::Poller *>(ptr);
+    poller->handle_periodic_();
+}
+
 } // extern "C"
 
 namespace mk {
@@ -50,11 +55,6 @@ void Poller::call_later(double timeo, std::function<void()> cb) {
 
 void Poller::call_soon(std::function<void()> cb) {
     call_later(-1.0, cb);
-}
-
-static void do_periodic(evutil_socket_t, short, void *ptr) {
-    Poller *poller = static_cast<Poller *>(ptr);
-    poller->handle_periodic_();
 }
 
 void Poller::handle_periodic_() {

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -159,3 +159,16 @@ TEST_CASE("poller.call_later() works") {
     poller.call_later(3.14, [&poller]() { poller.break_loop(); });
     poller.loop();
 }
+
+TEST_CASE("The periodic event is fired when we call loop()") {
+    mk::Poller poller;
+    unsigned int count = 0;
+    poller.on_periodic_([&count](Poller *poller) {
+        if (++count < 3) {
+            return;
+        }
+        poller->break_loop();
+    });
+    poller.loop();
+    REQUIRE(count == 3);
+}

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -153,3 +153,9 @@ TEST_CASE("poller.call_soon() works") {
     poller.call_soon([&poller]() { poller.break_loop(); });
     poller.loop();
 }
+
+TEST_CASE("poller.call_later() works") {
+    mk::Poller poller;
+    poller.call_later(3.14, [&poller]() { poller.break_loop(); });
+    poller.loop();
+}

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -12,6 +12,7 @@
 #include <measurement_kit/common.hpp>
 #include "src/common/delayed_call.hpp"
 #include "src/common/check_connectivity.hpp"
+#include "src/common/utils.hpp"
 
 #include <event2/dns.h>
 
@@ -150,14 +151,18 @@ TEST_CASE("We can clear all name servers and then issue a query") {
 
 TEST_CASE("poller.call_soon() works") {
     mk::Poller poller;
+    auto now = mk::time_now();
     poller.call_soon([&poller]() { poller.break_loop(); });
     poller.loop();
+    REQUIRE((mk::time_now() - now) < 1.00); // Very conservative check
 }
 
 TEST_CASE("poller.call_later() works") {
     mk::Poller poller;
+    auto now = mk::time_now();
     poller.call_later(3.14, [&poller]() { poller.break_loop(); });
     poller.loop();
+    REQUIRE((mk::time_now() - now) > 3.00); // Very conservative check
 }
 
 TEST_CASE("The periodic event is fired when we call loop()") {


### PR DESCRIPTION
This contains poller-related changes that are required by #390.

1. implement call_later()

2. make sure event-loop does not exit

3. deprecate loop_once()

The deprecation of loop_once() is because after #390 that functionality becomes unused.