### PR TITLE
travis: fix error checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ install:
           ARG="$ARG --disable-shared";
       fi  
 
+# Only measure coverage with clang for now because I cannot manage to
+# convince coveralls to find all sources when using gcc-4.8 and gcov-4.8
+# (For more context see measurement-kit/measurement-kit#255)
 script:
     - if [ "$BUILD_TYPE" = "ios" ]; then 
           ./mobile/ios/scripts/build.sh;
@@ -43,7 +46,7 @@ script:
 # Silence gcov standard output since it produces way too much output
 after_success:
     - if [ "$COVERAGE" = "true" ]; then
-        coveralls --gcov /usr/bin/gcov-5 --exclude src/ext > /dev/null;
+        coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext > /dev/null;
       fi
 
 after_failure:
@@ -78,8 +81,8 @@ matrix:
                 - ubuntu-toolchain-r-test 
 
     - sudo: false
-      compiler: clang-3.6 
-      env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true 
+      compiler: clang-3.6
+      env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true
       addons:
         apt:
             packages:
@@ -91,15 +94,17 @@ matrix:
                 - ubuntu-toolchain-r-test
 
     - sudo: false
-      compiler: g++-5
-      env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=5 CC_V=5 EXPORT=true
-      addons: 
+      compiler: clang-3.6 
+      env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=3.6 CC_V=3.6 EXPORT=true 
+      addons:
         apt:
             packages:
-                - g++-5
-                - gcc-5
+                - clang-3.6
+                - llvm-3.6-dev
+                - valgrind
             sources:
-                - ubuntu-toolchain-r-test 
+                - llvm-toolchain-precise-3.6
+                - ubuntu-toolchain-r-test
 
     - dist: trusty
       compiler: clang-3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,5 +111,6 @@ matrix:
       env: OS=OSX BUILD_TYPE=ios
   allow_failures:
     - env: OS=OSX BUILD_TYPE=ios
+    - env: OS="Ubuntu 12.04" CXX_V=4.8 CC_V=4.8 EXPORT=true
     - env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true
     - env: OS=OSX CXX_V=4.8 CC_V=4.8 EXPORT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,14 @@ script:
 # Silence gcov standard output since it produces way too much output
 after_success:
     - if [ "$COVERAGE" = "true" ]; then
-        coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext > /dev/null;
+        coveralls --gcov /usr/bin/gcov-5 --exclude src/ext > /dev/null;
       fi
 
 after_failure:
     - if [ -f "test-suite.log" ]; then 
         cat test-suite.log;
       fi
+
 matrix:
   fast_finish: true
   include:
@@ -87,13 +88,13 @@ matrix:
                 - llvm-toolchain-precise-3.6
                 - ubuntu-toolchain-r-test
     - sudo: false
-      compiler: g++-4.8
-      env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=4.8 CC_V=4.8 EXPORT=true
+      compiler: g++-5
+      env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=5 CC_V=5 EXPORT=true
       addons: 
         apt:
             packages:
-                - g++-4.8
-                - gcc-4.8
+                - g++-5
+                - gcc-5
             sources:
                 - ubuntu-toolchain-r-test 
     - dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
         brew update;
         brew upgrade; 
     fi
+
 install: 
     - if [ "$EXPORT" = "true" ]; then
         if [ "$CXX" = "g++" ]; then export CXX="g++-$CXX_V" CC="gcc-$CC_V"; fi;
@@ -22,15 +23,13 @@ install:
            --with-boost=builtin --with-jansson=builtin
            --with-libmaxminddb=builtin"
     - if [ "$COVERAGE" = "true" ]; then
-          CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage;
+          export CFLAGS=--coverage CXXFLAGS=--coverage LDFLAGS=--coverage;
           pip install --user cpp-coveralls;
       fi 
     - if [ "$VALGRIND" = "true" ]; then
-          ARG+=" --disable-shared";
+          ARG="$ARG --disable-shared";
       fi  
-# Only measure coverage with clang for now because I cannot manage to
-# convince coveralls to find all sources when using gcc-4.8 and gcov-4.8
-# (For more context see measurement-kit/measurement-kit#255)
+
 script:
     - if [ "$BUILD_TYPE" = "ios" ]; then 
           ./mobile/ios/scripts/build.sh;
@@ -55,6 +54,7 @@ after_failure:
 matrix:
   fast_finish: true
   include:
+
     - sudo: false
       compiler: g++-5
       env: OS="Ubuntu 12.04" CXX_V=5 CC_V=5 EXPORT=true
@@ -65,6 +65,7 @@ matrix:
                 - gcc-5
             sources:
                 - ubuntu-toolchain-r-test 
+
     - sudo: false
       compiler: g++-4.8
       env: OS="Ubuntu 12.04" CXX_V=4.8 CC_V=4.8 EXPORT=true
@@ -75,6 +76,7 @@ matrix:
                 - gcc-4.8
             sources:
                 - ubuntu-toolchain-r-test 
+
     - sudo: false
       compiler: clang-3.6 
       env: OS="Ubuntu 12.04" VALGRIND=true CXX_V=3.6 CC_V=3.6 EXPORT=true 
@@ -87,6 +89,7 @@ matrix:
             sources:
                 - llvm-toolchain-precise-3.6
                 - ubuntu-toolchain-r-test
+
     - sudo: false
       compiler: g++-5
       env: OS="Ubuntu 12.04" COVERAGE=true CXX_V=5 CC_V=5 EXPORT=true
@@ -97,18 +100,23 @@ matrix:
                 - gcc-5
             sources:
                 - ubuntu-toolchain-r-test 
+
     - dist: trusty
       compiler: clang-3.5
       env: OS="Ubuntu 14.04"
+
     - dist: trusty
       compiler: g++-4.8
       env: OS="Ubuntu 14.04"
+
     - os: osx
       compiler: g++-4.8
       env: OS=OSX CXX_V=4.8 CC_V=4.8 EXPORT=true
+
     - os: osx
       compiler: g++
       env: OS=OSX BUILD_TYPE=ios
+
   allow_failures:
     - env: OS=OSX BUILD_TYPE=ios
     - env: OS="Ubuntu 12.04" CXX_V=4.8 CC_V=4.8 EXPORT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ script:
           ./mobile/ios/scripts/build.sh;
       else
           ./configure $ARG && make -j2 V=0 && make -j2 check-am V=0;
-          if [ "$VALGRIND" = "true" ]; then 
-              make run-valgrind;
-          fi
+      fi
+    - if [ "$VALGRIND" = "true" ]; then
+          make run-valgrind;
       fi
 
 # Silence gcov standard output since it produces way too much output


### PR DESCRIPTION
Spotted by me and fixed by @AntonioLangiu. Move the if down otherwise the if steals the success/failure bit set by the build and the build does not actually fail.

In the future we should use external script for this. Relying on travis.yml is way too fragile.