### PR TITLE
clang-format: improve format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 BasedOnStyle: LLVM
-AllowShortIfStatementsOnASingleLine: true
+ContinuationIndentWidth: 8
+AlignAfterOpenBracket: DontAlign
 IndentWidth: 4
 ---


### PR DESCRIPTION
1) do not collapse short ifs on a single line because that
   does not allow us to understand if they're covered

2) change formatting after open braces for long lines in
   a way that makes lambdas more readable and that causes
   less line diffs when we modify and then clang-format