### PR TITLE
poller: add loop() with initial event

### DIFF
--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -32,6 +32,11 @@ class Poller : public NonCopyable, public NonMovable {
 
     void call_later(double, std::function<void()> cb);
 
+    void loop_with_initial_event(std::function<void()> cb) {
+        call_soon(cb);
+        loop();
+    }
+
     void loop();
 
     // Deprecated: this function was required to implement src/common/async.cpp
@@ -88,6 +93,10 @@ inline event_base *get_global_event_base(void) {
 
 inline evdns_base *get_global_evdns_base(void) {
     return (Poller::global()->get_evdns_base());
+}
+
+inline void loop_with_initial_event(std::function<void()> cb) {
+    Poller::global()->loop_with_initial_event(cb);
 }
 
 inline void loop(void) { Poller::global()->loop(); }


### PR DESCRIPTION
This is useful because there are many cases in the regress tests
in which we want something to happen and then in the corresponding
callback we break the loop. For example,

```C++
    net::connect("130.192.91.211", 80, [](Error err) {
        REQUIRE(!err);
        break_loop();
    });
    loop();
```

What happens is that sometimes `net::connect()` calls its callback
immediately, when the connection obviously fails.

Unfortunately in that case `break_loop()` would be called before
`loop()` which means that, as libevent does not cope well with this
case and in particular it happens that the loop runs forever.

Since this is mainly an issue with tests, I propose the following:

```C++
    loop_with_initial_event([]() {
        net::connect("130.192.91.211", 80, [](Error err) {
            REQUIRE(!err);
            break_loop();
        });
    });
```

This combines in the same call the registration of the initial event
in the event system and entering the loop.

By the way, this is the correct way of running event systems, because
it's quite logical that you need an initial event to initialize things
after (and not before!) the event loop engine is started.