### PR TITLE
Add single dependency build script 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Makefile.in
 __venv__
 aclocal.m4
 autom4te.cache/
+builtin/
 compile
 config.guess
 config.h
@@ -107,3 +108,4 @@ test/ooni/tcp_connect_test
 test/ooni/tcp_test
 test/report/file
 test/traceroute/android
+third_party/

--- a/autogen.sh
+++ b/autogen.sh
@@ -98,7 +98,7 @@ gen_executables noinst_PROGRAMS example BUILD_EXAMPLES >> include.am
 gen_executables ALL_TESTS test BUILD_TESTS             >> include.am
 
 echo "* Updating .gitignore"
-sort -u .gitignore > .gitignore.new
+LC_ALL=C sort -u .gitignore > .gitignore.new
 mv .gitignore.new .gitignore
 
 echo "* Fetching dependencies"

--- a/build/dependency
+++ b/build/dependency
@@ -49,6 +49,9 @@ cd third_party/$pkg_name
 if [ ! -z "$pkg_branch" ]; then
     git checkout $pkg_branch
 fi
+if [ ! -z "$pkg_tag" ]; then
+    git checkout tags/$pkg_tag
+fi
 for diff in `ls ../../build/patch/$pkg_name`; do
     cp ../../build/patch/$pkg_name/$diff .
     git apply -v $diff

--- a/build/dependency
+++ b/build/dependency
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+print_usage() {
+    cat << EOF
+usage: $0 dependency-name
+
+Clones repository, configure, build and install dependency. By default sources
+are below './third_party' and installed software is below './builtin/'.
+
+Override default behavior by setting these environment variables:
+  - pkg_clone_flags: extra flags for 'git clone' (e.g. '--recursive')
+  - pkg_configure_flags: extra flags for './configure' (if any)
+  - pkg_cmake_flags: extra flags for 'cmake .' (if CMakeLists.txt exists)
+  - pkg_make_flags: extra flags for 'make' (e.g. 'V=0')
+  - pkg_prefix: prefix where to install (e.g. '/usr/local')
+  - pkg_make_install_flags: extra flags for 'make install' (e.g. DESTDIR=/opt)
+  - pkg_sudo: optional comand to execute 'make install' with (e.g. sudo)
+
+Examples:
+  - download, patch, compile, and install libevent at /opt:
+    - pkg_sudo=sudo pkg_prefix=/opt ./build/dependency libevent
+  - use four processors to compile libressl:
+    - pkg_make_flags=-j4 ./build/dependency libressl
+EOF
+}
+
+set -e
+if [ $# -ne 1 ]; then
+    print_usage
+    exit 1
+fi
+pkg_rootdir=$(cd $(dirname $(dirname $0)) && pwd -P)
+if [ -z "$pkg_prefix" ]; then
+    pkg_prefix=$pkg_rootdir/builtin
+fi
+export pkg_prefix
+cd $pkg_rootdir
+if [ -x build/spec/$1 ]; then
+    exec build/spec/$1  # If the spec is executable, pass control to it
+fi
+# Note that the spec has access to $pkg_rootdir
+. build/spec/$1
+if [ ! -d third_party/.cache/$pkg_name ]; then
+    git clone $pkg_clone_flags $pkg_repository third_party/.cache/$pkg_name
+fi
+rm -rf third_party/$pkg_name
+cp -R third_party/.cache/$pkg_name third_party/$pkg_name
+cd third_party/$pkg_name
+if [ ! -z "$pkg_branch" ]; then
+    git checkout $pkg_branch
+fi
+for diff in `ls ../../build/patch/$pkg_name`; do
+    cp ../../build/patch/$pkg_name/$diff .
+    git apply -v $diff
+    rm $diff
+done
+if [ -x ./autogen.sh ]; then
+    ./autogen.sh
+elif [ -f ./configure.ac ]; then
+    autoreconf -i
+fi
+if [ -x ./configure ]; then
+    ./configure --prefix=$pkg_prefix $pkg_configure_flags
+elif [ -f ./CMakeLists.txt ]; then
+    cmake -D CMAKE_INSTALL_PREFIX=$pkg_prefix $pkg_cmake_flags .
+fi
+make $pkg_make_flags
+$pkg_sudo make $pkg_make_install_flags install

--- a/build/patch/http-parser/000.diff
+++ b/build/patch/http-parser/000.diff
@@ -20,7 +20,7 @@ index 33c8ba0..407bc46 100644
 	$(CC) $(LDFLAGS_LIB) -o $(SONAME) $<
 
 +libhttp_parser.a: http_parser.o
-+ 	$(AR) $(ARFLAGS) libhttp_parser.a $<
++	$(AR) $(ARFLAGS) libhttp_parser.a $<
 +
 +library: $(SONAME) libhttp_parser.a
 +
@@ -31,25 +31,25 @@ index 33c8ba0..407bc46 100644
 	ctags $^
 
  install: library
-- 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-- 	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
-- 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
-+ 	$(INSTALL) -d $(INCLUDEDIR)
-+ 	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
-+ 	$(INSTALL) -d $(LIBDIR)
-+ 	$(INSTALL) $(SONAME) $(LIBDIR)/$(SONAME)
-+ 	$(INSTALL) libhttp_parser.a $(LIBDIR)/libhttp_parser.a
-+ 	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
+-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
++	$(INSTALL) -d $(INCLUDEDIR)
++	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
++	$(INSTALL) -d $(LIBDIR)
++	$(INSTALL) $(SONAME) $(LIBDIR)/$(SONAME)
++	$(INSTALL) libhttp_parser.a $(LIBDIR)/libhttp_parser.a
++	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
  install-strip: library
-- 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
-- 	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
-- 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
-+ 	$(INSTALL) -d $(INCLUDEDIR)
-+ 	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
-+ 	$(INSTALL) -d $(LIBDIR)
-+ 	$(INSTALL) -s $(SONAME) $(LIBDIR)/$(SONAME)
-+ 	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+-	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
+-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
++	$(INSTALL) -d $(INCLUDEDIR)
++	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
++	$(INSTALL) -d $(LIBDIR)
++	$(INSTALL) -s $(SONAME) $(LIBDIR)/$(SONAME)
++	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
 
  uninstall:
 	rm $(INCLUDEDIR)/http_parser.h

--- a/build/patch/http-parser/000.diff
+++ b/build/patch/http-parser/000.diff
@@ -1,0 +1,55 @@
+diff --git a/Makefile b/Makefile
+index 33c8ba0..407bc46 100644
+--- a/Makefile
++++ b/Makefile
+@@ -62,6 +62,8 @@ INCLUDEDIR = $(PREFIX)/include
+ ifneq (darwin,$(PLATFORM))
+ # TODO(bnoordhuis) The native SunOS linker expects -h rather than -soname...
+ LDFLAGS_LIB += -Wl,-soname=$(SONAME)
++else
++LDFLAGS_LIB += -install_name $(LIBDIR)/$(SONAME)
+ endif
+
+ test: test_g test_fast
+@@ -101,9 +103,14 @@ test-valgrind: test_g
+ libhttp_parser.o: http_parser.c http_parser.h Makefile
+	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_LIB) -c http_parser.c -o libhttp_parser.o
+
+-library: libhttp_parser.o
++$(SONAME): libhttp_parser.o
+	$(CC) $(LDFLAGS_LIB) -o $(SONAME) $<
+
++libhttp_parser.a: http_parser.o
++ 	$(AR) $(ARFLAGS) libhttp_parser.a $<
++
++library: $(SONAME) libhttp_parser.a
++
+ package: http_parser.o
+	$(AR) rcs libhttp_parser.a http_parser.o
+
+@@ -123,14 +130,19 @@ tags: http_parser.c http_parser.h test.c
+	ctags $^
+
+ install: library
+- 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+- 	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
+- 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
++ 	$(INSTALL) -d $(INCLUDEDIR)
++ 	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
++ 	$(INSTALL) -d $(LIBDIR)
++ 	$(INSTALL) $(SONAME) $(LIBDIR)/$(SONAME)
++ 	$(INSTALL) libhttp_parser.a $(LIBDIR)/libhttp_parser.a
++ 	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+
+ install-strip: library
+- 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
+- 	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
+- 	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
++ 	$(INSTALL) -d $(INCLUDEDIR)
++ 	$(INSTALL) http_parser.h $(INCLUDEDIR)/http_parser.h
++ 	$(INSTALL) -d $(LIBDIR)
++ 	$(INSTALL) -s $(SONAME) $(LIBDIR)/$(SONAME)
++ 	ln -sf $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+
+ uninstall:
+	rm $(INCLUDEDIR)/http_parser.h

--- a/build/patch/yaml-cpp/000.diff
+++ b/build/patch/yaml-cpp/000.diff
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1897775..49f8a08 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,6 +21,9 @@ include(CheckCXXCompilerFlag)
+ ###
+ project(YAML_CPP)
+
++# Make sure cmake pulls the exported CPPFLAGS (I'm appalled by this...)
++add_definitions ($ENV{CPPFLAGS})
++
+ set(YAML_CPP_VERSION_MAJOR "0")
+ set(YAML_CPP_VERSION_MINOR "5")
+ set(YAML_CPP_VERSION_PATCH "2")

--- a/build/spec/Catch
+++ b/build/spec/Catch
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+pkg_rootdir=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
+cd $pkg_rootdir
+if [ ! -d third_party/.cache/Catch ]; then
+    git clone --depth=50 https://github.com/philsquared/Catch                  \
+            third_party/.cache/Catch
+fi
+rm -rf third_party/Catch
+cp -R third_party/.cache/Catch third_party/Catch
+install -dv $pkg_prefix/include
+install -v third_party/Catch/single_include/catch.hpp $pkg_prefix/include

--- a/build/spec/all
+++ b/build/spec/all
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+pkg_rootdir=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
+cd $pkg_rootdir
+for dependency in Catch boost http-parser jansson libevent libmaxminddb        \
+                  yaml-cpp; do
+    ./build/dependency $dependency
+done

--- a/build/spec/all
+++ b/build/spec/all
@@ -3,6 +3,6 @@ set -e
 pkg_rootdir=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
 cd $pkg_rootdir
 for dependency in Catch boost http-parser jansson libevent libmaxminddb        \
-                  yaml-cpp; do
+                  yaml-cpp libressl; do
     ./build/dependency $dependency
 done

--- a/build/spec/boost
+++ b/build/spec/boost
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+pkg_rootdir=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
+cd $pkg_rootdir
+
+clone() {
+    if [ ! -d third_party/.cache/boost-$1 ]; then
+        git clone --recursive --depth 50 --branch master                       \
+                https://github.com/boostorg/$1 third_party/.cache/boost-$1
+    fi
+    rm -rf third_party/boost-$1
+    cp -R third_party/.cache/boost-$1 third_party/boost-$1
+    if [ ! -z "$2" ]; then
+        (cd third_party/boost-$1 && git checkout $2)
+    fi
+}
+
+clone assert boost-1.59.0
+clone config boost-1.59.0
+clone core boost-1.59.0-8-g3add966
+clone detail boost-1.59.0
+clone iterator boost-1.59.0
+clone mpl boost-1.59.0
+clone predef boost-1.59.0
+clone preprocessor boost-1.59.0
+clone smart_ptr boost-1.59.0
+clone static_assert boost-1.59.0
+clone throw_exception boost-1.59.0
+clone type_traits boost-1.59.0
+clone typeof boost-1.59.0
+clone utility boost-1.59.0
+install -d $pkg_prefix/include
+for dir in third_party/boost-*; do
+    cp -R $dir/include/* $pkg_prefix/include
+done

--- a/build/spec/http-parser
+++ b/build/spec/http-parser
@@ -1,4 +1,5 @@
 pkg_name=http-parser
 pkg_repository=https://github.com/nodejs/$pkg_name
+pkg_tag=v2.6.0
 pkg_make_flags="PREFIX=$pkg_prefix $pkg_make_flags library"
 pkg_make_install_flags="PREFIX=$pkg_prefix $pkg_make_install_flags"

--- a/build/spec/http-parser
+++ b/build/spec/http-parser
@@ -1,5 +1,4 @@
 pkg_name=http-parser
 pkg_repository=https://github.com/nodejs/$pkg_name
-pkg_branch=v2.6.0
 pkg_make_flags="PREFIX=$pkg_prefix $pkg_make_flags library"
 pkg_make_install_flags="PREFIX=$pkg_prefix $pkg_make_install_flags"

--- a/build/spec/http-parser
+++ b/build/spec/http-parser
@@ -1,0 +1,5 @@
+pkg_name=http-parser
+pkg_repository=https://github.com/nodejs/$pkg_name
+pkg_branch=v2.6.0
+pkg_make_flags="PREFIX=$pkg_prefix $pkg_make_flags library"
+pkg_make_install_flags="PREFIX=$pkg_prefix $pkg_make_install_flags"

--- a/build/spec/jansson
+++ b/build/spec/jansson
@@ -1,0 +1,3 @@
+pkg_name=jansson
+pkg_repository=https://github.com/akheron/$pkg_name
+pkg_branch=v2.7-52-ge44b223

--- a/build/spec/libevent
+++ b/build/spec/libevent
@@ -1,0 +1,3 @@
+pkg_name=libevent
+pkg_repository=https://github.com/measurement-kit/$pkg_name
+pkg_branch=patches-2.0

--- a/build/spec/libmaxminddb
+++ b/build/spec/libmaxminddb
@@ -1,0 +1,7 @@
+pkg_name=libmaxminddb
+pkg_repository=https://github.com/measurement-kit/$pkg_name
+pkg_clone_flags="--recursive $pkg_clone_flags"
+
+# Fix for the "missing _rpl_malloc() symbol" issue when cross-linking
+# See <http://wiki.buici.com/xwiki/bin/view/Programing+C+and+C%2B%2B/Autoconf+and+RPL_MALLOC>
+export ac_cv_func_malloc_0_nonnull=yes

--- a/build/spec/libressl
+++ b/build/spec/libressl
@@ -1,0 +1,2 @@
+pkg_name=libressl
+pkg_repository=https://github.com/libressl-portable/portable.git

--- a/build/spec/yaml-cpp
+++ b/build/spec/yaml-cpp
@@ -1,0 +1,8 @@
+pkg_name=yaml-cpp
+pkg_repository=https://github.com/jbeder/$pkg_name
+pkg_branch=release-0.5.2-16-g97d56c3
+
+# See <https://cmake.org/pipermail/cmake/2010-August/038941.html> for
+# an explanation of usage of CMAKE_INSTALL_NAME_DIR, etc.
+pkg_cmake_flags="-D Boost_INCLUDE_DIR=$pkg_prefix/include -DCMAKE_INSTALL_NAME_DIR=$pkg_prefix/lib -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_INSTALL_RPATH='${CMAKE_INSTALL_NAME_DIR}' -DYAML_CPP_BUILD_TOOLS=OFF -DYAML_CPP_BUILD_CONTRIB=OFF -DBUILD_SHARED_LIBS=ON $pkg_cmake_flags"
+pkg_make_flags="VERBOSE=1"


### PR DESCRIPTION
In this PR I'm integrating the work of @bassosimone in [this branch](https://github.com/measurement-kit/measurement-kit/tree/feature/build-improvements).

Pratically, now we are able to build a single dependency, with a script that downloads it from a git repository and builds it inside a defined folder.

To see more details check the script [./build/dependency](https://github.com/measurement-kit/measurement-kit/blob/feature/build/build/dependency)