### PR TITLE
Increase net/transport abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,10 @@ config.status
 config.sub
 configure
 depcomp
+example/dns/query
 example/http/request
 example/mlabns/query
+example/net/connect
 example/ooni/dns_injection
 example/ooni/http_invalid_request_line
 example/ooni/tcp_connect

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -1,125 +1,52 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
 #ifndef MEASUREMENT_KIT_NET_TRANSPORT_HPP
 #define MEASUREMENT_KIT_NET_TRANSPORT_HPP
 
-//
-// Generic transport (stream socket, SOCKSv5, etc.)
-//
-
 #include <functional>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net/buffer.hpp>
+#include <stddef.h>
 #include <string>
 
-#include <measurement_kit/common/constraints.hpp>
-#include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/maybe.hpp>
-#include <measurement_kit/common/poller.hpp>
-#include <measurement_kit/common/settings.hpp>
-#include <measurement_kit/common/var.hpp>
-
-#include <measurement_kit/net/buffer.hpp>
-
 namespace mk {
+
+// Forward declaration
+class Error;
+
 namespace net {
 
-class TransportInterface {
-  public:
-    virtual void emit_connect() = 0;
-
-    virtual void emit_data(Buffer) = 0;
-
-    virtual void emit_flush() = 0;
-
-    virtual void emit_error(Error) = 0;
-
-    TransportInterface() {}
-
-    virtual ~TransportInterface() {}
-
-    virtual void on_connect(std::function<void()>) = 0;
-
-    virtual void on_data(std::function<void(Buffer)>) = 0;
-
-    virtual void on_flush(std::function<void()>) = 0;
-
-    virtual void on_error(std::function<void(Error)>) = 0;
-
-    virtual void set_timeout(double) = 0;
-
-    virtual void clear_timeout() = 0;
-
-    virtual void send(const void *, size_t) = 0;
-
-    virtual void send(std::string) = 0;
-
-    virtual void send(Buffer) = 0;
-
-    virtual void close() = 0;
-
-    virtual std::string socks5_address() = 0;
-
-    virtual std::string socks5_port() = 0;
-};
+// Forward declaration
+class TransportInterface;
 
 /// A connection with TCP-like properties
 class Transport {
   public:
+    void emit_connect() const;        ///< Emit CONNECT event
+    void emit_data(Buffer buf) const; ///< Emit DATA event
+    void emit_flush() const;          ///< Emit FLUSH event
+    void emit_error(Error err) const; ///< Emit ERROR event
 
-    /// Emit the CONNECT event
-    void emit_connect() const { impl->emit_connect(); };
+    Transport(TransportInterface * = nullptr); ///< Constructor
+    ~Transport() {};                           ///< Destructor
 
-    /// Emit the DATA event
-    void emit_data(Buffer buf) const { impl->emit_data(buf); };
+    void on_connect(std::function<void()>) const;    ///< Set CONNECT handler
+    void on_data(std::function<void(Buffer)>) const; ///< Set DATA handler
+    void on_flush(std::function<void()>) const;      ///< Set FLUSH handler
+    void on_error(std::function<void(Error)>) const; ///< Set ERROR handler
 
-    /// Emit the FLUSH event
-    void emit_flush() const { impl->emit_flush(); };
+    void set_timeout(double) const; ///< Set I/O timeout
+    void clear_timeout() const;     ///< Clear I/O timeout
 
-    /// Emit the ERROR event
-    void emit_error(Error err) const { impl->emit_error(err); };
+    void send(const void *, size_t) const; ///< Send C string
+    void send(std::string) const;          ///< Send C++ string
+    void send(Buffer) const;               ///< Send buffer
 
-    /// Construct from pointer to interface
-    Transport(TransportInterface *ptr = nullptr) : impl(ptr) {}
+    void close() const; ///< Close underlying socket
 
-    ~Transport() {}; ///< Destructor
-
-    /// Set CONNECT handler
-    void on_connect(std::function<void()> f) const { impl->on_connect(f); }
-
-    /// Set DATA handler
-    void on_data(std::function<void(Buffer)> f) const { impl->on_data(f); }
-
-    /// Set FLUSH handler
-    void on_flush(std::function<void()> f) const { impl->on_flush(f); }
-
-    /// Set ERROR handler
-    void on_error(std::function<void(Error)> f) const { impl->on_error(f); }
-
-    /// Set I/O timeout
-    void set_timeout(double t) const { impl->set_timeout(t); }
-
-    /// Clear I/O timeout
-    void clear_timeout() const { impl->clear_timeout(); }
-
-    /// Send N bytes of data starting from P
-    void send(const void *p, size_t n) const { impl->send(p, n); }
-
-    /// Send data contained by string
-    void send(std::string d) const { impl->send(d); }
-
-    /// Send data contained by buffer (this method is zero copy)
-    void send(Buffer d) const { impl->send(d); }
-
-    /// Close the underlying socket
-    void close() const { impl->close(); }
-
-    /// Get SOCKS5 proxy address (if any)
-    std::string socks5_address() const { return impl->socks5_address(); }
-
-    /// Get SOCKS5 proxy port (if any)
-    std::string socks5_port() const { return impl->socks5_port(); }
+    std::string socks5_address() const; ///< Get SOCKS5 proxy address (if any)
+    std::string socks5_port() const;    ///< Get SOCKS5 proxy port (if any)
 
   private:
     Var<TransportInterface> impl;

--- a/src/net/emitter.hpp
+++ b/src/net/emitter.hpp
@@ -9,8 +9,10 @@
 // Emitter transport
 //
 
-#include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/net/transport.hpp>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+
+#include "src/net/transport_interface.hpp"
 
 namespace mk {
 namespace net {

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -2,16 +2,58 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
+#include <measurement_kit/net.hpp>
+#include "src/net/connect.hpp"
 #include "src/net/connection.hpp"
 #include "src/net/emitter.hpp"
+#include "src/net/transport_interface.hpp"
 #include "src/net/socks5.hpp"
-#include <measurement_kit/net/transport.hpp>
 
 namespace mk {
 namespace net {
 
+void Transport::emit_connect() const { impl->emit_connect(); };
+
+void Transport::emit_data(Buffer buf) const { impl->emit_data(buf); };
+
+void Transport::emit_flush() const { impl->emit_flush(); };
+
+void Transport::emit_error(Error err) const { impl->emit_error(err); };
+
+Transport::Transport(TransportInterface *ptr) : impl(ptr) {}
+
+void Transport::on_connect(std::function<void()> f) const {
+    impl->on_connect(f);
+}
+
+void Transport::on_data(std::function<void(Buffer)> f) const {
+    impl->on_data(f);
+}
+
+void Transport::on_flush(std::function<void()> f) const { impl->on_flush(f); }
+
+void Transport::on_error(std::function<void(Error)> f) const {
+    impl->on_error(f);
+}
+
+void Transport::set_timeout(double t) const { impl->set_timeout(t); }
+
+void Transport::clear_timeout() const { impl->clear_timeout(); }
+
+void Transport::send(const void *p, size_t n) const { impl->send(p, n); }
+
+void Transport::send(std::string d) const { impl->send(d); }
+
+void Transport::send(Buffer d) const { impl->send(d); }
+
+void Transport::close() const { impl->close(); }
+
+std::string Transport::socks5_address() const { return impl->socks5_address(); }
+
+std::string Transport::socks5_port() const { return impl->socks5_port(); }
+
 static Transport connect_internal(Settings settings, Logger *logger,
-                                       Poller *poller) {
+                                  Poller *poller) {
 
     if (settings.find("dumb_transport") != settings.end()) {
         return Transport(new Emitter(logger));
@@ -42,9 +84,9 @@ static Transport connect_internal(Settings settings, Logger *logger,
     }
 
     return Transport(new Connection(settings["family"].c_str(),
-                                         settings["address"].c_str(),
-                                         settings["port"].c_str(),
-                                         logger, poller));
+                                    settings["address"].c_str(),
+                                    settings["port"].c_str(),
+                                    logger, poller));
 }
 
 Maybe<Transport> connect(Settings settings, Logger *lp, Poller *poller) {

--- a/src/net/transport_interface.hpp
+++ b/src/net/transport_interface.hpp
@@ -1,0 +1,60 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifndef SRC_NET_TRANSPORT_INTERFACE_HPP
+#define SRC_NET_TRANSPORT_INTERFACE_HPP
+
+#include <functional>
+#include <measurement_kit/net/buffer.hpp>
+#include <stddef.h>
+#include <string>
+
+namespace mk {
+
+// Forward declaration
+class Error;
+
+namespace net {
+
+class TransportInterface {
+  public:
+    virtual void emit_connect() = 0;
+
+    virtual void emit_data(Buffer) = 0;
+
+    virtual void emit_flush() = 0;
+
+    virtual void emit_error(Error) = 0;
+
+    TransportInterface() {}
+
+    virtual ~TransportInterface() {}
+
+    virtual void on_connect(std::function<void()>) = 0;
+
+    virtual void on_data(std::function<void(Buffer)>) = 0;
+
+    virtual void on_flush(std::function<void()>) = 0;
+
+    virtual void on_error(std::function<void(Error)>) = 0;
+
+    virtual void set_timeout(double) = 0;
+
+    virtual void clear_timeout() = 0;
+
+    virtual void send(const void *, size_t) = 0;
+
+    virtual void send(std::string) = 0;
+
+    virtual void send(Buffer) = 0;
+
+    virtual void close() = 0;
+
+    virtual std::string socks5_address() = 0;
+
+    virtual std::string socks5_port() = 0;
+};
+
+} // namespace net
+} // namespace mk
+#endif


### PR DESCRIPTION
Move the TransportInterface definition in a private header and let users of Transport only pull the bare minimum they need.

While there also commit the updated .gitignore file which features more recently added tests. This was updated when I run `./autogen.sh`.