### PR TITLE
socks5: separate connect() and after-connect()

### DIFF
--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -10,13 +10,13 @@ namespace net {
 Socks5::Socks5(Settings s, Logger *lp, Poller *poller)
     : Emitter(lp), settings(s),
       conn(settings["family"].c_str(), settings["socks5_address"].c_str(),
-           settings["socks5_port"].c_str(), lp, poller),
+              settings["socks5_port"].c_str(), lp, poller),
       proxy_address(settings["socks5_address"]),
       proxy_port(settings["socks5_port"]) {
 
     logger->debug("socks5: connecting to Tor at %s:%s",
-                  settings["socks5_address"].c_str(),
-                  settings["socks5_port"].c_str());
+            settings["socks5_address"].c_str(),
+            settings["socks5_port"].c_str());
 
     // Step #0: Steal "error", "connect", and "flush" handlers
 
@@ -25,140 +25,142 @@ Socks5::Socks5(Settings s, Logger *lp, Poller *poller)
         conn.on_flush([]() {
             // Nothing
         });
+        socks5_connect_();
+    });
+}
 
-        // Step #1: send out preferred authentication methods
+void Socks5::socks5_connect_() {
+    // Step #1: send out preferred authentication methods
 
-        logger->debug("socks5: connected to Tor!");
+    logger->debug("socks5: connected to Tor!");
+
+    Buffer out;
+    out.write_uint8(5); // Version
+    out.write_uint8(1); // Number of methods
+    out.write_uint8(0); // "NO_AUTH" meth.
+    conn.send(out);
+
+    logger->debug("socks5: >> version=5");
+    logger->debug("socks5: >> number of methods=1");
+    logger->debug("socks5: >> NO_AUTH (0)");
+
+    // Step #2: receive the allowed authentication methods
+
+    conn.on_data([this](Buffer d) {
+        buffer << d;
+        auto readbuf = buffer.readn(2);
+        if (readbuf == "") {
+            return; // Try again after next recv()
+        }
+
+        logger->debug("socks5: << version=%d", readbuf[0]);
+        logger->debug("socks5: << auth=%d", readbuf[1]);
+
+        if (readbuf[0] != 5 ||     // Reply version
+                readbuf[1] != 0) { // Preferred auth method
+            emit_error(BadSocksVersionError());
+            return;
+        }
+
+        // Step #3: ask Tor to connect to remote host
 
         Buffer out;
         out.write_uint8(5); // Version
-        out.write_uint8(1); // Number of methods
-        out.write_uint8(0); // "NO_AUTH" meth.
-        conn.send(out);
+        out.write_uint8(1); // CMD_CONNECT
+        out.write_uint8(0); // Reserved
+        out.write_uint8(3); // ATYPE_DOMAINNAME
 
         logger->debug("socks5: >> version=5");
-        logger->debug("socks5: >> number of methods=1");
-        logger->debug("socks5: >> NO_AUTH (0)");
+        logger->debug("socks5: >> CMD_CONNECT (0)");
+        logger->debug("socks5: >> Reserved (0)");
+        logger->debug("socks5: >> ATYPE_DOMAINNAME (3)");
 
-        // Step #2: receive the allowed authentication methods
+        auto address = settings["address"];
+
+        if (address.length() > 255) {
+            emit_error(SocksAddressTooLongError());
+            return;
+        }
+        out.write_uint8(address.length());            // Len
+        out.write(address.c_str(), address.length()); // String
+
+        logger->debug("socks5: >> domain len=%d", (uint8_t)address.length());
+        logger->debug("socks5: >> domain str=%s", address.c_str());
+
+        int portnum = settings["port"].as<int>();
+        if (portnum < 0 || portnum > 65535) {
+            emit_error(SocksInvalidPortError());
+            return;
+        }
+        out.write_uint16(portnum); // Port
+
+        logger->debug("socks5: >> port=%d", portnum);
+
+        conn.send(out);
+
+        // Step #4: receive Tor's response
 
         conn.on_data([this](Buffer d) {
+
             buffer << d;
-            auto readbuf = buffer.readn(2);
-            if (readbuf == "") {
+            if (buffer.length() < 5) {
                 return; // Try again after next recv()
             }
 
-            logger->debug("socks5: << version=%d", readbuf[0]);
-            logger->debug("socks5: << auth=%d", readbuf[1]);
+            auto peekbuf = buffer.peek(5);
 
-            if (readbuf[0] != 5 || // Reply version
-                readbuf[1] != 0) { // Preferred auth method
-                emit_error(BadSocksVersionError());
-                return;
-            }
+            logger->debug("socks5: << version=%d", peekbuf[0]);
+            logger->debug("socks5: << reply=%d", peekbuf[1]);
+            logger->debug("socks5: << reserved=%d", peekbuf[2]);
+            logger->debug("socks5: << atype=%d", peekbuf[3]);
 
-            // Step #3: ask Tor to connect to remote host
+            // TODO: Here we should process peekbuf[1] more
+            // carefully to map to the error that occurred
+            // and report it correctly to the caller
 
-            Buffer out;
-            out.write_uint8(5); // Version
-            out.write_uint8(1); // CMD_CONNECT
-            out.write_uint8(0); // Reserved
-            out.write_uint8(3); // ATYPE_DOMAINNAME
-
-            logger->debug("socks5: >> version=5");
-            logger->debug("socks5: >> CMD_CONNECT (0)");
-            logger->debug("socks5: >> Reserved (0)");
-            logger->debug("socks5: >> ATYPE_DOMAINNAME (3)");
-
-            auto address = settings["address"];
-
-            if (address.length() > 255) {
-                emit_error(SocksAddressTooLongError());
-                return;
-            }
-            out.write_uint8(address.length());            // Len
-            out.write(address.c_str(), address.length()); // String
-
-            logger->debug("socks5: >> domain len=%d",
-                          (uint8_t)address.length());
-            logger->debug("socks5: >> domain str=%s", address.c_str());
-
-            int portnum = settings["port"].as<int>();
-            if (portnum < 0 || portnum > 65535) {
-                emit_error(SocksInvalidPortError());
-                return;
-            }
-            out.write_uint16(portnum); // Port
-
-            logger->debug("socks5: >> port=%d", portnum);
-
-            conn.send(out);
-
-            // Step #4: receive Tor's response
-
-            conn.on_data([this](Buffer d) {
-
-                buffer << d;
-                if (buffer.length() < 5) {
-                    return; // Try again after next recv()
-                }
-
-                auto peekbuf = buffer.peek(5);
-
-                logger->debug("socks5: << version=%d", peekbuf[0]);
-                logger->debug("socks5: << reply=%d", peekbuf[1]);
-                logger->debug("socks5: << reserved=%d", peekbuf[2]);
-                logger->debug("socks5: << atype=%d", peekbuf[3]);
-
-                // TODO: Here we should process peekbuf[1] more
-                // carefully to map to the error that occurred
-                // and report it correctly to the caller
-
-                if (peekbuf[0] != 5 || // Version
+            if (peekbuf[0] != 5 ||     // Version
                     peekbuf[1] != 0 || // Reply
                     peekbuf[2] != 0) { // Reserved
-                    emit_error(SocksGenericError());
-                    return;
-                }
-                auto atype = peekbuf[3]; // Atype
+                emit_error(SocksGenericError());
+                return;
+            }
+            auto atype = peekbuf[3]; // Atype
 
-                size_t total = 4; // Version .. Atype size
-                if (atype == 1) {
-                    total += 4; // IPv4 addr size
-                } else if (atype == 3) {
-                    total += 1             // Len size
-                             + peekbuf[4]; // String size
-                } else if (atype == 4) {
-                    total += 16; // IPv6 addr size
-                } else {
-                    emit_error(SocksGenericError());
-                    return;
-                }
-                total += 2; // Port size
-                if (buffer.length() < total) {
-                    return; // Try again after next recv()
-                }
+            size_t total = 4; // Version .. Atype size
+            if (atype == 1) {
+                total += 4; // IPv4 addr size
+            } else if (atype == 3) {
+                total += 1             // Len size
+                         + peekbuf[4]; // String size
+            } else if (atype == 4) {
+                total += 16; // IPv6 addr size
+            } else {
+                emit_error(SocksGenericError());
+                return;
+            }
+            total += 2; // Port size
+            if (buffer.length() < total) {
+                return; // Try again after next recv()
+            }
 
-                buffer.discard(total);
+            buffer.discard(total);
 
-                //
-                // Step #5: we are now connected
-                // Restore the original hooks
-                // Tell upstream we are connected
-                // If more data, pass it up
-                //
+            //
+            // Step #5: we are now connected
+            // Restore the original hooks
+            // Tell upstream we are connected
+            // If more data, pass it up
+            //
 
-                conn.on_data([this](Buffer d) { emit_data(d); });
-                conn.on_flush([this]() { emit_flush(); });
+            conn.on_data([this](Buffer d) { emit_data(d); });
+            conn.on_flush([this]() { emit_flush(); });
 
-                emit_connect();
+            emit_connect();
 
-                // Note that emit_connect() may have called close()
-                if (!isclosed && buffer.length() > 0) {
-                    emit_data(buffer);
-                }
-            });
+            // Note that emit_connect() may have called close()
+            if (!isclosed && buffer.length() > 0) {
+                emit_data(buffer);
+            }
         });
     });
 }

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -32,6 +32,8 @@ class Socks5 : public Emitter {
     std::string socks5_port() override { return proxy_port; }
 
   protected:
+    void socks5_connect_();
+
     Settings settings;
     Connection conn;
     Buffer buffer;


### PR DESCRIPTION
Preparatory change for a subsequent pull request in which I will
teach the Socks5 class to attach to an already connected Var<Transport>.

This will go in a separate pull request because the diff is huge (even
though the `diff -w` is trivial).