### PR TITLE
connection: use extern-C for libevent callbacks

### DIFF
--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -11,10 +11,10 @@ namespace mk {
 namespace net {
 
 /// EOF error
-class EOFError : public Error {
+class EofError : public Error {
   public:
     /// Default constructor
-    EOFError() : Error(1000, "unknown_failure 1000") {}
+    EofError() : Error(1000, "unknown_failure 1000") {}
 };
 
 /// Timeout error

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -106,7 +106,7 @@ class Request : public NonCopyable, public NonMovable {
         }
         stream = std::make_shared<Stream>(settings, logger, poller);
         stream->on_error([this](Error err) {
-            if (err != net::EOFError()) {
+            if (err != net::EofError()) {
                 emit_end(err, std::move(response));
             } else {
                 // When EOF is received, on_end() is called, therefore we

--- a/src/http/stream.hpp
+++ b/src/http/stream.hpp
@@ -49,7 +49,7 @@ class Stream {
         //
         connection->on_error([&](Error error) {
             auto safe_eh = error_handler;
-            if (error == net::EOFError()) {
+            if (error == net::EofError()) {
                 parser->eof();
             }
             // parser->eof() may cause this object to go out of

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -6,16 +6,16 @@
 
 #include <event2/bufferevent.h>
 #include <event2/event.h>
+#include <list>
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/dns.hpp>
 #include <measurement_kit/net.hpp>
+#include <stdexcept>
+#include <string.h>
 #include "src/common/delayed_call.hpp"
 #include "src/common/utils.hpp"
 #include "src/net/bufferevent.hpp"
 #include "src/net/emitter.hpp"
-#include <list>
-#include <stdexcept>
-#include <string.h>
 
 namespace mk {
 namespace net {
@@ -58,14 +58,13 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     void close() override;
 
+    void handle_event_(short);
+    void handle_read_();
+    void handle_write_();
+
   private:
     Bufferevent bev;
     Poller *poller = Poller::global();
-
-    // Libevent callbacks
-    static void handle_read(bufferevent *, void *);
-    static void handle_write(bufferevent *, void *);
-    static void handle_event(bufferevent *, short, void *);
 
     // Stuff for connecting (later this will be removed):
 

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -85,7 +85,7 @@ TEST_CASE("HTTP stream is robust to EOF") {
         data << "1234567";
 
         transport->emit_data(data);
-        transport->emit_error(EOFError());
+        transport->emit_error(EofError());
     });
 
     transport->emit_connect();


### PR DESCRIPTION
While there: s/EOFError/EofError/g (I will gradually remove acronyms from class names; I think that EofError is more readable).