### PR TITLE
Teach transport to record received/sent bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ test/net/bufferevent
 test/net/connect
 test/net/connection
 test/net/connection_check_fds
+test/net/emitter
 test/net/evbuffer
 test/net/transport
 test/ooni/dns_injection

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -31,12 +31,20 @@ class Transport {
     virtual void on_flush(std::function<void()>) = 0;
     virtual void on_error(std::function<void(Error)>) = 0;
 
+    virtual void record_received_data() = 0;
+    virtual void dont_record_received_data() = 0;
+    virtual Buffer &received_data() = 0;
+
+    virtual void record_sent_data() = 0;
+    virtual void dont_record_sent_data() = 0;
+    virtual Buffer &sent_data() = 0;
+
     virtual void set_timeout(double) = 0;
     virtual void clear_timeout() = 0;
 
-    virtual void send(const void *, size_t) = 0;
-    virtual void send(std::string) = 0;
-    virtual void send(Buffer) = 0;
+    virtual void write(const void *, size_t) = 0;
+    virtual void write(std::string) = 0;
+    virtual void write(Buffer) = 0;
 
     virtual void close() = 0;
 

--- a/src/http/stream.hpp
+++ b/src/http/stream.hpp
@@ -166,7 +166,7 @@ class Stream {
      * \returns A reference to this stream for chaining operations.
      */
     Stream &operator<<(std::string data) {
-        connection->send(data);
+        connection->write(data);
         return *this;
     }
 

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -42,7 +42,7 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
         throw std::runtime_error("not implemented");
     }
 
-    void send(Buffer data) override { data >> bufferevent_get_output(bev); }
+    void do_send(Buffer data) override { data >> bufferevent_get_output(bev); }
 
     void enable_read() override {
         if (bufferevent_enable(this->bev, EV_READ) != 0) {

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -38,7 +38,7 @@ void Socks5::socks5_connect_() {
     out.write_uint8(5); // Version
     out.write_uint8(1); // Number of methods
     out.write_uint8(0); // "NO_AUTH" meth.
-    conn.send(out);
+    conn.write(out);
 
     logger->debug("socks5: >> version=5");
     logger->debug("socks5: >> number of methods=1");
@@ -96,7 +96,7 @@ void Socks5::socks5_connect_() {
 
         logger->debug("socks5: >> port=%d", portnum);
 
-        conn.send(out);
+        conn.write(out);
 
         // Step #4: receive Tor's response
 

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -20,7 +20,7 @@ class Socks5 : public Emitter {
 
     void clear_timeout() override { conn.clear_timeout(); }
 
-    void send(Buffer data) override { conn.send(data); }
+    void do_send(Buffer data) override { conn.write(data); }
 
     void close() override {
         isclosed = true;

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Connection::close() is idempotent") {
     Emitter &s = static_cast<Emitter &>(conn);
     s.on_connect([&s]() {
         s.enable_read();
-        s.send("GET / HTTP/1.0\r\n\r\n");
+        s.write("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](Buffer) {
         s.close();
@@ -47,7 +47,7 @@ TEST_CASE("It is safe to manipulate Connection after close") {
     Emitter &s = static_cast<Emitter &>(conn);
     s.on_connect([&s]() {
         s.enable_read();
-        s.send("GET / HTTP/1.0\r\n\r\n");
+        s.write("GET / HTTP/1.0\r\n\r\n");
     });
     s.on_data([&s](Buffer) {
         s.close();

--- a/test/net/emitter.cpp
+++ b/test/net/emitter.cpp
@@ -1,0 +1,89 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+#include "src/net/emitter.hpp"
+
+using namespace mk;
+using namespace mk::net;
+
+TEST_CASE("The record-received-data feature works") {
+    SECTION("By default recording is disabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.emit_data(Buffer("foobar"));
+        REQUIRE(transport.received_data().length() == 0);
+    }
+
+    SECTION("Recording works correctly when enabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.record_received_data();
+        transport.emit_data(Buffer("foobar"));
+        REQUIRE(transport.received_data().peek() == "foobar");
+    }
+
+    SECTION("Recording can also be disabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.record_received_data();
+        transport.emit_data(Buffer("foobar"));
+        transport.dont_record_received_data();
+        transport.emit_data(Buffer("baz"));
+        REQUIRE(transport.received_data().peek() == "foobar");
+    }
+
+    SECTION("Recording input data does not modify input data") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.record_received_data();
+        transport.on_data([](Buffer data) { REQUIRE(data.read() == "foo"); });
+        transport.emit_data(Buffer("foo"));
+        REQUIRE(transport.received_data().read() == "foo");
+    }
+}
+
+class Helper : public Emitter {
+  public:
+    void do_send(Buffer data) override { REQUIRE(data.read() == "foo"); }
+};
+
+TEST_CASE("The record-sent-data feature works") {
+    SECTION("By default recording is disabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.write("foobar");
+        REQUIRE(transport.sent_data().length() == 0);
+    }
+
+    SECTION("Recording works correctly when enabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.record_sent_data();
+        transport.write("foobar");
+        REQUIRE(transport.sent_data().peek() == "foobar");
+    }
+
+    SECTION("Recording can also be disabled") {
+        Emitter emitter;
+        Transport &transport = emitter;
+        transport.record_sent_data();
+        transport.write("foobar");
+        transport.dont_record_sent_data();
+        transport.write("baz");
+        REQUIRE(transport.sent_data().peek() == "foobar");
+    }
+
+    SECTION("Recording output data does not modify output data") {
+        Helper emitter;
+        Transport &transport = emitter;
+        transport.record_sent_data();
+        transport.write("foo");
+        REQUIRE(transport.sent_data().read() == "foo");
+    }
+}


### PR DESCRIPTION
Closes #102.

To make sure I was not doing mistakes in this diff, I renamed the transport's functions to send as write() and the actual function used to implement send as do_send(). This way the compiler helped me to find out all the places where refactoring was needed.

Besides, given Twisted, I prefer `transport.write` to `send` :-).