### PR TITLE
net/filter.hpp: filter for bufferevent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ example/dns/query
 example/http/request
 example/mlabns/query
 example/net/connect
+example/net/filter
 example/net/listen
 example/ooni/dns_injection
 example/ooni/http_invalid_request_line

--- a/example/net/filter.cpp
+++ b/example/net/filter.cpp
@@ -1,0 +1,89 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include "src/net/filter.hpp"
+#include "src/net/listen.hpp"
+#include <functional>
+#include <iostream>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
+
+using namespace mk;
+using namespace mk::net;
+
+static const char *kv_usage = "usage: ./example/net/filter [-v] [-p port]\n";
+
+int main(int argc, char **argv) {
+
+    int port = 54321;
+    char ch;
+    while ((ch = getopt(argc, argv, "p:v")) != -1) {
+        switch (ch) {
+        case 'p':
+            port = lexical_cast<int>(optarg);
+            break;
+        case 'v':
+            set_verbose(1);
+            break;
+        default:
+            std::cout << kv_usage;
+            exit(1);
+        }
+    }
+    argc -= optind, argv += optind;
+    if (argc != 0) {
+        std::cout << kv_usage;
+        exit(1);
+    }
+    const std::string addr = "127.0.0.1";
+
+    loop_with_initial_event([&addr, &port]() {
+        listen4(addr, port, [](bufferevent *orig) {
+            filter_bufferevent<Filter>(orig, [](Error error, Filter *filter) {
+                if (error) {
+                    return;
+                }
+
+                // Setup filter to make input uppercase
+                filter->on_input([](evbuffer *src, evbuffer *dst, ev_ssize_t,
+                        bufferevent_flush_mode) {
+                    std::string out;
+                    for (auto chr : Buffer(src).read()) {
+                        out += toupper(chr);
+                    }
+                    Buffer obuf = out;
+                    obuf >> dst;
+                    return BEV_OK;
+                });
+
+                // Auto-removing output filter to write banner
+                filter->on_output([filter](evbuffer *, evbuffer *dst,
+                        ev_ssize_t, bufferevent_flush_mode) {
+                    Buffer buf("THIS ECHO SERVER MAKES INPUT UPPERCASE\r\n");
+                    buf >> dst;
+                    filter->on_output(nullptr);
+                    return BEV_OK;
+                });
+
+                // This is the standard code to echo input back
+                Var<Transport> transport(new Connection(filter->bev));
+                transport->on_data(
+                        [transport](Buffer data) { transport->write(data); });
+                transport->on_error([transport](Error) {
+                    transport->on_error(nullptr);
+                    transport->on_data(nullptr);
+                    // FIXME: if we close now in response to EOF not
+                    // all output is written in all cases
+                    transport->close();
+                });
+
+                // Immediately trigger filter output to write banner
+                filter->trigger_output();
+            });
+        });
+    });
+}

--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -119,6 +119,16 @@ class BuffereventSocketNewError : public Error {
     BuffereventSocketNewError() : Error(1017, "unknown_failure 1017") {}
 };
 
+class BuffereventFilterNewError : public Error {
+  public:
+    BuffereventFilterNewError() : Error(1018, "unknown_failure 1018") {}
+};
+
+class BuffereventFlushError : public Error {
+  public:
+    BuffereventFlushError() : Error(1019, "unknown_failure 1019") {}
+};
+
 } // namespace net
 } // namespace mk
 #endif

--- a/src/net/filter.cpp
+++ b/src/net/filter.cpp
@@ -1,0 +1,21 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include "src/net/filter.hpp"
+
+using namespace mk::net;
+
+extern "C" {
+
+bufferevent_filter_result mk_filter_in(evbuffer *s, evbuffer *d, ev_ssize_t c,
+        bufferevent_flush_mode m, void *o) {
+    return static_cast<Filter *>(o)->emit_input(s, d, c, m);
+}
+bufferevent_filter_result mk_filter_out(evbuffer *s, evbuffer *d, ev_ssize_t c,
+        bufferevent_flush_mode m, void *o) {
+    return static_cast<Filter *>(o)->emit_output(s, d, c, m);
+}
+void mk_filter_free(void *o) { delete static_cast<Filter *>(o); }
+
+} // extern "C"

--- a/src/net/filter.hpp
+++ b/src/net/filter.hpp
@@ -1,0 +1,125 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifndef SRC_NET_FILTER_HPP
+#define SRC_NET_FILTER_HPP
+
+// Documentation: doc/private/net/filter.md
+
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/event.h>
+#include <event2/util.h>
+#include <functional>
+#include <limits.h>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+
+struct evbuffer;
+struct bufferevent;
+
+extern "C" {
+
+bufferevent_filter_result mk_filter_in(evbuffer *src, evbuffer *dst,
+        ev_ssize_t count, bufferevent_flush_mode mode, void *);
+
+bufferevent_filter_result mk_filter_out(evbuffer *src, evbuffer *dst,
+        ev_ssize_t count, bufferevent_flush_mode mode, void *);
+
+void mk_filter_free(void *);
+
+} // extern "C"
+
+namespace mk {
+namespace net {
+
+class Filter {
+  public:
+    Filter() {}
+    ~Filter() {}
+
+    typedef bufferevent_filter_result R;
+    typedef bufferevent_flush_mode M;
+
+    R emit_input(evbuffer *src, evbuffer *dst, ev_ssize_t count, M mode) {
+        if (!filter_input_) {
+            return pass_through_(src, dst, count, mode);
+        }
+        // Function wrappers always return void, hand roll safe code
+        auto copy = filter_input_;
+        return copy(src, dst, count, mode);
+    }
+    void on_input(std::function<R(evbuffer *, evbuffer *, ev_ssize_t, M)> cb) {
+        filter_input_ = cb;
+    }
+    ErrorOr<int> trigger_input(M mode = BEV_FLUSH) {
+        return trigger_(EV_READ, mode);
+    }
+
+    R emit_output(evbuffer *src, evbuffer *dst, ev_ssize_t count, M mode) {
+        if (!filter_output_) {
+            return pass_through_(src, dst, count, mode);
+        }
+        // Function wrappers always return void, hand roll safe code
+        auto copy = filter_output_;
+        return copy(src, dst, count, mode);
+    }
+    void on_output(std::function<R(evbuffer *, evbuffer *, ev_ssize_t, M)> cb) {
+        filter_output_ = cb;
+    }
+    ErrorOr<int> trigger_output(M mode = BEV_FLUSH) {
+        return trigger_(EV_WRITE, mode);
+    }
+
+    ErrorOr<int> trigger_(int what, M mode) {
+        int rc = bufferevent_flush(bev, what, mode);
+        if (rc == -1) {
+            return BuffereventFlushError();
+        }
+        if (rc != 0 && rc != 1) {
+            throw std::runtime_error("unexpected return value");
+        }
+        return rc;
+    }
+
+    R pass_through_(evbuffer *src, evbuffer *dst, ev_ssize_t count, M) {
+
+        // If count is negative we read the maximum number we can read (i.e.
+        // INT_MAX because of evbuffer_remove_buffer return type).
+        // Likewise, if count is greater than INT_MAX, trim down count to
+        // be the maximum number we can read (i.e. INT_MAX).
+        int n = (count < 0 or count > INT_MAX) ? INT_MAX : (int)count;
+
+        // By construction n is positive, so casting to unsigned is safe
+        if (evbuffer_remove_buffer(src, dst, (unsigned)n) < 0) {
+            return BEV_ERROR;
+        }
+
+        return BEV_OK;
+    }
+
+    bufferevent *bev = nullptr; // Weak ref to the object owning us
+
+  private:
+    std::function<R(evbuffer *, evbuffer *, ev_ssize_t, M)> filter_input_;
+    std::function<R(evbuffer *, evbuffer *, ev_ssize_t, M)> filter_output_;
+};
+
+template <class Filter = Filter>
+void filter_bufferevent(bufferevent *underlying,
+        std::function<void(Error, Filter *)> cb) {
+    Filter *filter = new Filter;
+    if ((filter->bev = bufferevent_filter_new(underlying, mk_filter_in,
+                 mk_filter_out, BEV_OPT_CLOSE_ON_FREE, mk_filter_free,
+                 filter)) == nullptr) {
+        bufferevent_free(underlying);
+        delete filter;
+        cb(BuffereventFilterNewError(), nullptr);
+        return;
+    }
+    cb(NoError(), filter);
+}
+
+} // namespace net
+} // namespace mk
+#endif


### PR DESCRIPTION
This would be extremely useful to implement socks5 as a filter so that next it would be possible to have a ssl bufferevent over a socks5 bufferevent over a plain normal socket.
