### PR TITLE
buffer: s/Evbuffer/Var<evbuffer>/g

### DIFF
--- a/include/measurement_kit/net/buffer.hpp
+++ b/include/measurement_kit/net/buffer.hpp
@@ -17,9 +17,6 @@ struct evbuffer;
 namespace mk {
 namespace net {
 
-// Forward declaration
-class Evbuffer;
-
 class Buffer {
   public:
     Buffer();
@@ -114,8 +111,7 @@ class Buffer {
 
     void write(size_t count, std::function<size_t(void *, size_t)> func);
 
-  private:
-    Var<Evbuffer> evbuf;
+    Var<evbuffer> evbuf;
 };
 
 } // namespace net

--- a/src/net/buffer.cpp
+++ b/src/net/buffer.cpp
@@ -16,11 +16,14 @@
 namespace mk {
 namespace net {
 
-Buffer::Buffer() { evbuf.reset(new Evbuffer); }
+Buffer::Buffer() {
+    evbuf = make_shared_evbuffer();
+}
 
 Buffer::Buffer(evbuffer *b) : Buffer() {
-    if (b != nullptr && evbuffer_add_buffer(*evbuf, b) != 0)
+    if (b != nullptr && evbuffer_add_buffer(evbuf.get(), b) != 0) {
         throw std::runtime_error("evbuffer_add_buffer failed");
+    }
 }
 
 Buffer::Buffer(std::string s) : Buffer() {
@@ -33,38 +36,38 @@ Buffer::Buffer(const void *p, size_t n) : Buffer() {
 
 Buffer &Buffer::operator<<(evbuffer *source) {
     if (source == nullptr) throw std::runtime_error("source is nullptr");
-    if (evbuffer_add_buffer(*evbuf, source) != 0)
+    if (evbuffer_add_buffer(evbuf.get(), source) != 0)
         throw std::runtime_error("evbuffer_add_buffer failed");
     return *this;
 }
 
 Buffer &Buffer::operator>>(evbuffer *dest) {
     if (dest == nullptr) throw std::runtime_error("dest is nullptr");
-    if (evbuffer_add_buffer(dest, *evbuf) != 0)
+    if (evbuffer_add_buffer(dest, evbuf.get()) != 0)
         throw std::runtime_error("evbuffer_add_buffer failed");
     return *this;
 }
 
 Buffer &Buffer::operator<<(Buffer &source) {
-    *this << *source.evbuf;
+    *this << source.evbuf.get();
     return *this;
 }
 
-Buffer &Buffer::operator>>(Buffer &source) {
-    *this >> *source.evbuf;
+Buffer &Buffer::operator>>(Buffer &dest) {
+    *this >> dest.evbuf.get();
     return *this;
 }
 
-size_t Buffer::length() { return evbuffer_get_length(*evbuf); }
+size_t Buffer::length() { return evbuffer_get_length(evbuf.get()); }
 
 void Buffer::for_each(std::function<bool(const void *, size_t)> fn) {
-    auto required = evbuffer_peek(*evbuf, -1, nullptr, nullptr, 0);
+    auto required = evbuffer_peek(evbuf.get(), -1, nullptr, nullptr, 0);
     if (required < 0) throw std::runtime_error("unexpected error");
     if (required == 0) return;
     std::unique_ptr<evbuffer_iovec[]> raii;
     raii.reset(new evbuffer_iovec[required]); // Guarantee cleanup
     auto iov = raii.get();
-    auto used = evbuffer_peek(*evbuf, -1, nullptr, iov, required);
+    auto used = evbuffer_peek(evbuf.get(), -1, nullptr, iov, required);
     if (used != required) throw std::runtime_error("unexpected error");
     for (auto i = 0; i < required && fn(iov[i].iov_base, iov[i].iov_len); ++i) {
         /* nothing */;
@@ -72,7 +75,7 @@ void Buffer::for_each(std::function<bool(const void *, size_t)> fn) {
 }
 
 void Buffer::discard(size_t count) {
-    if (evbuffer_drain(*evbuf, count) != 0)
+    if (evbuffer_drain(evbuf.get(), count) != 0)
         throw std::runtime_error("evbuffer_drain failed");
 }
 
@@ -98,7 +101,7 @@ ErrorOr<std::string> Buffer::readline(size_t maxline) {
 
     size_t eol_length = 0;
     auto search_result =
-        evbuffer_search_eol(*evbuf, nullptr, &eol_length, EVBUFFER_EOL_CRLF);
+        evbuffer_search_eol(evbuf.get(), nullptr, &eol_length, EVBUFFER_EOL_CRLF);
     if (search_result.pos < 0) {
         if (length() > maxline) {
             return EOLNotFoundError();
@@ -122,7 +125,7 @@ ErrorOr<std::string> Buffer::readline(size_t maxline) {
 
 void Buffer::write(const void *buf, size_t count) {
     if (buf == nullptr) throw std::runtime_error("buf is nullptr");
-    if (evbuffer_add(*evbuf, buf, count) != 0)
+    if (evbuffer_add(evbuf.get(), buf, count) != 0)
         throw std::runtime_error("evbuffer_add failed");
 }
 
@@ -143,7 +146,7 @@ void Buffer::write_rand(size_t count) {
     char *p = new char[count];
     evutil_secure_rng_get_bytes(p, count);
     auto ctrl = evbuffer_add_reference(
-        *evbuf, p, count, [](const void *, size_t, void *p) {
+        evbuf.get(), p, count, [](const void *, size_t, void *p) {
             delete[] static_cast<char *>(p);
         }, p);
     if (ctrl != 0) throw std::runtime_error("evbuffer_add_reference");
@@ -161,7 +164,7 @@ void Buffer::write(size_t count, std::function<size_t(void *, size_t)> func) {
         delete[] p;
         return;
     }
-    auto ctrl = evbuffer_add_reference(*evbuf, p,
+    auto ctrl = evbuffer_add_reference(evbuf.get(), p,
                                        used, [](const void *, size_t, void *p) {
                                            delete[] static_cast<char *>(p);
                                        }, p);


### PR DESCRIPTION
Replace the Evbuffer non-copyable, non-movable RAII evbuffer wrapper class with a Var<evbuffer> with correctly set deleter func.

Reduces the number of lines of code used and adds copyability and movability to the thing contained underlying a Buffer.

Also, make the Var<evbuffer> public such that one can access it easily if needed (this helps to call low-level libevent operations).

Also, deploy more curly braces here and there.