### PR TITLE
simple http cleanups

### DIFF
--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -25,7 +25,6 @@ class ParserError : public Error {
     ParserError() : Error(3001, "unknown_error 3001") {};
 };
 
-
 /// Url Parse error occurred.
 class UrlParserError : public Error {
   public:

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -1,39 +1,25 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
-#ifndef MEASUREMENT_KIT_HTTP_REQUEST_HPP
-#define MEASUREMENT_KIT_HTTP_REQUEST_HPP
-
-#include <measurement_kit/common/constraints.hpp>
-#include <measurement_kit/common/settings.hpp>
-#include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/var.hpp>
-#include <measurement_kit/common/poller.hpp>
-
-#include <measurement_kit/net/buffer.hpp>
-#include <measurement_kit/net/error.hpp>
-
-#include <measurement_kit/http.hpp>
-#include "src/http/request_serializer.hpp"
-#include "src/http/response_parser.hpp"
-#include "src/http/stream.hpp"
+#ifndef SRC_HTTP_REQUEST_HPP
+#define SRC_HTTP_REQUEST_HPP
 
 #include <functional>
-#include <iosfwd>
 #include <map>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+#include <measurement_kit/http.hpp>
 #include <memory>
 #include <set>
 #include <string>
 #include <type_traits>
+#include "src/http/request_serializer.hpp"
+#include "src/http/response_parser.hpp"
+#include "src/http/stream.hpp"
 
 namespace mk {
 namespace http {
 
-/*!
- * \brief HTTP request.
- */
 class Request : public NonCopyable, public NonMovable {
 
     RequestCallback callback;
@@ -113,7 +99,7 @@ class Request : public NonCopyable, public NonMovable {
                 // don't need to call emit_end() again here.
             }
         });
-        stream->on_connect([this](void) {
+        stream->on_connect([this]() {
             // TODO: improve the way in which we serialize the request
             //       to reduce unnecessary copies
             net::Buffer buf;

--- a/src/http/response_parser.cpp
+++ b/src/http/response_parser.cpp
@@ -2,21 +2,18 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#include <measurement_kit/common/logger.hpp>
-#include "src/http/response_parser.hpp"
-#include <measurement_kit/net/buffer.hpp>
-#include <measurement_kit/http.hpp>
-#include "ext/http-parser/http_parser.h"
-
 #include <functional>
-#include <iosfwd>
 #include <map>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
+#include <measurement_kit/http.hpp>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
-
 #include <stddef.h>
 #include <string.h>
+#include <type_traits>
+#include "src/http/response_parser.hpp"
+#include "ext/http-parser/http_parser.h"
 
 #define MAXLINE 4096
 

--- a/src/http/response_parser.hpp
+++ b/src/http/response_parser.hpp
@@ -1,11 +1,11 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
+#ifndef SRC_HTTP_RESPONSE_PARSER_HPP
+#define SRC_HTTP_RESPONSE_PARSER_HPP
 
-#ifndef MEASUREMENT_KIT_HTTP_RESPONSE_PARSER_HPP
-#define MEASUREMENT_KIT_HTTP_RESPONSE_PARSER_HPP
-
-#include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
 #include <measurement_kit/http.hpp>
 
 #include <functional>
@@ -16,14 +16,9 @@
 #include <type_traits>
 
 namespace mk {
-
-namespace net { class Buffer; }
-
 namespace http {
 
 class ResponseParserImpl; // See http.cpp
-
-typedef std::map<std::string, std::string> Headers;
 
 /*!
  * \brief Parse an HTTP response.
@@ -69,11 +64,7 @@ typedef std::map<std::string, std::string> Headers;
  *         parser.feed(data);
  *     });
  */
-class ResponseParser {
-
-  protected:
-    ResponseParserImpl *impl = nullptr;
-
+class ResponseParser : public NonCopyable, public NonMovable {
   public:
     /*!
      * \brief Default constructor.
@@ -81,38 +72,15 @@ class ResponseParser {
     ResponseParser(Logger * = Logger::global());
 
     /*!
-     * \brief Deleted copy constructor.
-     */
-    ResponseParser(ResponseParser &other) = delete;
-
-    /*!
-     * \brief Deleted copy assignment.
-     */
-    ResponseParser &operator=(ResponseParser &other) = delete;
-
-    /*!
-     * \brief Move constructor.
-     */
-    ResponseParser(ResponseParser &&other) { std::swap(impl, other.impl); }
-
-    /*!
-     * \brief Move assignment.
-     */
-    ResponseParser &operator=(ResponseParser &&other) {
-        std::swap(impl, other.impl);
-        return *this;
-    }
-
-    /*!
      * \brief Destructor.
      */
-    ~ResponseParser(void);
+    ~ResponseParser();
 
     /*!
      * \brief Register `begin` event handler.
      * \param fn The `begin` event handler.
      */
-    void on_begin(std::function<void(void)> &&fn);
+    void on_begin(std::function<void()> &&fn);
 
     /*!
      * \brief Register `headers_complete` event handler.
@@ -141,7 +109,7 @@ class ResponseParser {
      * \brief Register `end` event handler.
      * \param fn The `end` event handler.
      */
-    void on_end(std::function<void(void)> &&fn);
+    void on_end(std::function<void()> &&fn);
 
     /*!
      * \brief Feed the parser.
@@ -175,6 +143,9 @@ class ResponseParser {
      *         a class derived from it) on several error conditions.
      */
     void eof();
+
+  protected:
+    ResponseParserImpl *impl = nullptr;
 };
 
 } // namespace http

--- a/src/http/stream.hpp
+++ b/src/http/stream.hpp
@@ -1,30 +1,18 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
-#ifndef MEASUREMENT_KIT_HTTP_STREAM_HPP
-#define MEASUREMENT_KIT_HTTP_STREAM_HPP
-
-#include <measurement_kit/common/settings.hpp>
-#include <measurement_kit/common/logger.hpp>
-#include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/var.hpp>
-
-#include <measurement_kit/net/error.hpp>
-#include <measurement_kit/net/transport.hpp>
+#ifndef SRC_HTTP_STREAM_HPP
+#define SRC_HTTP_STREAM_HPP
 
 #include "src/http/response_parser.hpp"
-
 #include <functional>
-#include <iosfwd>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
 #include <memory>
 #include <string>
 #include <type_traits>
 
 namespace mk {
-
-namespace net { class Buffer; }
-
 namespace http {
 
 /*!
@@ -36,9 +24,8 @@ namespace http {
  * This is a mid-level HTTP abstraction that can be used when a high
  * degree of control is needed over the HTTP protocol.
  */
-class Stream {
-    Var<net::Transport> connection;
-    Var<ResponseParser> parser;
+class Stream : public NonCopyable, public NonMovable {
+
     std::function<void(Error)> error_handler;
     std::function<void()> connect_handler;
 
@@ -62,42 +49,13 @@ class Stream {
         connect_handler();
     }
 
+    Var<net::Transport> connection;
+    Var<ResponseParser> parser;
   public:
-    /*!
-     * \brief Get response parser.
-     * This is useful for writing tests.
-     */
     Var<ResponseParser> get_parser() { return parser; }
 
     Var<net::Transport> get_transport() { return connection; }
 
-    /*!
-     * \brief Deleted copy constructor.
-     * The `this` of this class is bound to lambdas, so it must
-     * not be copied or moved.
-     */
-    Stream(Stream & /*other*/) = delete;
-
-    /*!
-     * \brief Deleted copy assignment.
-     * The `this` of this class is bound to lambdas, so it must
-     * not be copied or moved.
-     */
-    Stream &operator=(Stream & /*other*/) = delete;
-
-    /*!
-     * \brief Deleted move constructor.
-     * The `this` of this class is bound to lambdas, so it must
-     * not be copied or moved.
-     */
-    Stream(Stream && /*other*/) = delete;
-
-    /*!
-     * \brief Deleted move assignment.
-     * The `this` of this class is bound to lambdas, so it must
-     * not be copied or moved.
-     */
-    Stream &operator=(Stream && /*other*/) = delete;
 
     //
     // How do you construct this object:

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -62,7 +62,7 @@ TEST_CASE("We don't leak when we receive a UPGRADE") {
 
 TEST_CASE("The HTTP response parser works as expected") {
     auto data = std::string();
-    auto parser = ResponseParser();
+    ResponseParser parser;
     auto body = std::string();
 
     //


### PR DESCRIPTION
Mainly use less specific includes, reduce excess documentation, and apply simple cosmetic fixes to the code.