### PR TITLE
http: remove excess documentation

### DIFF
--- a/doc/private/http/response_parser.md
+++ b/doc/private/http/response_parser.md
@@ -1,0 +1,52 @@
+# NAME
+ResponseParser -- http response parser
+
+# SYNOPSIS
+```C++
+#include "src/http/response_parser.hpp"
+
+auto parser = measurement_kit::http::ResponseParser();
+
+parser.on_begin([](void) {
+    std::clog << "Begin of the response" << std::endl;
+});
+
+parser.on_headers_complete([](unsigned short major, unsigned short minor,
+        unsigned int code, std::string& reason, std::map<std::string,
+        std::string>&& headers) {
+    std::clog << "HTTP/" << major << "." << minor
+              << code << " " << reason << std::endl;
+    for (auto pair : headers) {
+        std::clog << pair.first << ": " << pair.second;
+    }
+    std::clog << "=== BEGIN BODY ===" << std::endl;
+});
+
+parser.on_body([](std::string&& part) {
+    std::clog << "body part: " << part << std::endl;
+});
+
+parser.on_end([](void) {
+    std::clog << "=== END BODY ===" << std::endl;
+}
+
+...
+
+auto connection = measurement_kit::net::connect(...);
+
+connection.on_data([&](SharedPointer<Buffer> data) {
+    parser.feed(data);
+});
+```
+
+# DESCRIPTION
+
+This class implements an event-style HTTP response parser. The following
+events are raised: `begin` when the response begins; `headers_complete`
+when the HTTP headers were received; `body` when a piece of the body was
+received; `end` when the response body was full received. Multiple
+responses could be handled by the same parser.
+
+# HISTORY
+
+The `ResponseParser` class appeared in MeasurementKit 0.1.0.

--- a/src/http/request_serializer.hpp
+++ b/src/http/request_serializer.hpp
@@ -1,48 +1,37 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
+#ifndef SRC_HTTP_REQUEST_SERIALIZER_HPP
+#define SRC_HTTP_REQUEST_SERIALIZER_HPP
 
-#ifndef MEASUREMENT_KIT_HTTP_REQUEST_SERIALIZER_HPP
-#define MEASUREMENT_KIT_HTTP_REQUEST_SERIALIZER_HPP
-
-#include <measurement_kit/common/settings.hpp>
-
-#include <measurement_kit/net/buffer.hpp>
-
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/net.hpp>
 #include <measurement_kit/http.hpp>
-
-#include <iosfwd>
 #include <string>
 #include <utility>
 
 namespace mk {
 namespace http {
 
-/*!
- * \brief HTTP request serializer.
- */
-struct RequestSerializer {
-
-    std::string method;    /*!< Request method */
-    Url url;               /*!< Request URL */
-    std::string protocol;  /*!< Request protocol */
-    Headers headers;       /*!< Request headers */
-    std::string body;      /*!< Request body */
+class RequestSerializer {
+  public:
+    std::string method;
+    Url url;
+    std::string protocol;
+    Headers headers;
+    std::string body;
 
     /*!
-     * \brief Constructor.
-     * \param settings A std::map with key values of the options supported:
+     * For settings the following options are supported:
      *
-     *             {
-     *                 "follow_redirects": "yes|no",
-     *                 "url": std::string,
-     *                 "ignore_body": "yes|no",
-     *                 "method": "GET|DELETE|PUT|POST|HEAD|...",
-     *                 "http_version": "HTTP/1.1",
-     *                 "path": by default is taken from the url
-     *             }
-     * \param hdrs HTTP headers (moved for efficiency).
-     * \param bd Request body (moved for efficiency).
+     *     {
+     *       "follow_redirects": "yes|no",
+     *       "url": std::string,
+     *       "ignore_body": "yes|no",
+     *       "method": "GET|DELETE|PUT|POST|HEAD|...",
+     *       "http_version": "HTTP/1.1",
+     *       "path": by default is taken from the url
+     *     }
      */
     RequestSerializer(Settings settings, Headers hdrs, std::string bd) {
         headers = hdrs;
@@ -52,14 +41,8 @@ struct RequestSerializer {
         method = settings.get("method", std::string("GET"));
     }
 
-    RequestSerializer() {
-        // nothing
-    }
+    RequestSerializer() {}
 
-    /*!
-     * \brief Serialize request.
-     * \param buff Buffer where to serialize request.
-     */
     void serialize(net::Buffer &buff) {
         buff << method << " " << url.pathquery << " " << protocol << "\r\n";
         for (auto &kv : headers) {

--- a/src/http/response_parser.hpp
+++ b/src/http/response_parser.hpp
@@ -18,130 +18,30 @@
 namespace mk {
 namespace http {
 
-class ResponseParserImpl; // See http.cpp
+class ResponseParserImpl; // Forward declaration
 
-/*!
- * \brief Parse an HTTP response.
- *
- * This class implements an event-style HTTP response parser. The following
- * events are raised: `begin` when the response begins; `headers_complete`
- * when the HTTP headers were received; `body` when a piece of the body was
- * received; `end` when the response body was full received. Multiple
- * responses could be handled by the same parser.
- *
- * Example usage:
- *
- *     auto parser = measurement_kit::http::ResponseParser();
- *
- *     parser.on_begin([](void) {
- *         std::clog << "Begin of the response" << std::endl;
- *     });
- *
- *     parser.on_headers_complete([](unsigned short major, unsigned short minor,
- *             unsigned int code, std::string& reason, std::map<std::string,
- *             std::string>&& headers) {
- *         std::clog << "HTTP/" << major << "." << minor
- *                   << code << " " << reason << std::endl;
- *         for (auto pair : headers) {
- *             std::clog << pair.first << ": " << pair.second;
- *         }
- *         std::clog << "=== BEGIN BODY ===" << std::endl;
- *     });
- *
- *     parser.on_body([](std::string&& part) {
- *         std::clog << "body part: " << part << std::endl;
- *     });
- *
- *     parser.on_end([](void) {
- *         std::clog << "=== END BODY ===" << std::endl;
- *     }
- *
- *     ...
- *
- *     auto connection = measurement_kit::net::connect(...);
- *
- *     connection.on_data([&](SharedPointer<Buffer> data) {
- *         parser.feed(data);
- *     });
- */
 class ResponseParser : public NonCopyable, public NonMovable {
   public:
-    /*!
-     * \brief Default constructor.
-     */
     ResponseParser(Logger * = Logger::global());
-
-    /*!
-     * \brief Destructor.
-     */
     ~ResponseParser();
 
-    /*!
-     * \brief Register `begin` event handler.
-     * \param fn The `begin` event handler.
-     */
     void on_begin(std::function<void()> &&fn);
 
-    /*!
-     * \brief Register `headers_complete` event handler.
-     * \param fn The `headers_complete` event handler.
-     * \remark The parameters received by the event handler are, respectively,
-     *         the HTTP major version number, the HTTP minor version number,
-     *         the status code, the reason string, and a map containing the
-     *         HTTP headers.
-     */
     void on_headers_complete(
         std::function<void(unsigned short http_major, unsigned short http_minor,
                            unsigned int status_code, std::string &&reason,
                            Headers &&headers)> &&fn);
 
-    /*!
-     * \brief Register `body` event handler.
-     * \param fn The `body` event handler.
-     * \remark The parameter received by the event handler is the received
-     *         piece of body.
-     * \remark By default this event handler is unset, meaning that the
-     *         received body is ignored.
-     */
     void on_body(std::function<void(std::string &&)> &&fn);
 
-    /*!
-     * \brief Register `end` event handler.
-     * \param fn The `end` event handler.
-     */
     void on_end(std::function<void()> &&fn);
 
-    /*!
-     * \brief Feed the parser.
-     * \param data Evbuffer containing the received data.
-     * \throws std::runtime_error This method throws std::runtime_error (or
-     *         a class derived from it) on several error conditions.
-     */
     void feed(net::Buffer &data);
 
-    /*!
-     * \brief Feed the parser.
-     * \param data String containing the received data.
-     * \throws std::runtime_error This method throws std::runtime_error (or
-     *         a class derived from it) on several error conditions.
-     */
     void feed(std::string data);
 
-    /*!
-     * \brief Feed the parser.
-     * \param c Character containing the received data.
-     * \remark This function is used for testing.
-     * \throws std::runtime_error This method throws std::runtime_error (or
-     *         a class derived from it) on several error conditions.
-     */
     void feed(char c);
 
-    /*!
-     * \brief Tell the parser we hit EOF.
-     * \remark This allows us to implement the body-ends-at-EOF semantic.
-     * \throws std::runtime_error This method throws std::runtime_error (or
-     *         a class derived from it) on several error conditions.
-     */
     void eof();
 
   protected:


### PR DESCRIPTION
HTTP code was overdocumented. Start removing some excess documentation and make sure that we end up with good bits below `docs/`.