### PR TITLE
Big cleanup: remove http/client

### DIFF
--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -68,32 +68,6 @@ typedef std::function<void(Error, Response)> RequestCallback;
 // Forward declaration of internally used class.
 class Request;
 
-/// HTTP client.
-class Client {
-
-  protected:
-    std::set<Request *> pending;
-
-  public:
-    /// Issue HTTP request.
-    void request(Settings settings, Headers headers, std::string body,
-                 RequestCallback callback, Logger *lp = Logger::global(),
-                 Poller *poller = Poller::global());
-
-    /// Get the global HTTP client instance
-    static Var<Client> global() {
-        static Var<Client> singleton(new Client);
-        return singleton;
-    }
-
-    Client() {} ///< Default constructor
-    ~Client();  ///< Destructor
-
-    //
-    // TODO: implement all the fancy methods
-    //
-};
-
 /// Send HTTP request and receive response.
 /// \param settings Settings for HTTP request.
 /// \param cb Callback called when complete or on error.
@@ -101,11 +75,16 @@ class Client {
 /// \param body Optional HTTP request body.
 /// \param lp Optional logger.
 /// \param pol Optional poller.
-/// \param client Optional HTTP client.
 void request(Settings settings, RequestCallback cb, Headers headers = {},
              std::string body = "", Logger *lp = Logger::global(),
-             Poller *pol = Poller::global(),
-             Var<Client> client = Client::global());
+             Poller *pol = Poller::global());
+
+// Signature of the old http::Client ->request method, widely used
+inline void request(Settings settings, Headers headers, std::string body,
+        RequestCallback cb, Logger *lp = Logger::global(),
+        Poller *pol = Poller::global()) {
+    request(settings, cb, headers, body, lp, pol);
+}
 
 /// Represents a URL.
 class Url {
@@ -137,15 +116,13 @@ ErrorOr<Url> parse_url_noexcept(std::string url);
 /// \param body Optional HTTP request body.
 /// \param lp Optional logger.
 /// \param pol Optional poller.
-/// \param client Optional HTTP client.
 inline void get(std::string url, RequestCallback cb,
                 Headers headers = {}, std::string body = "",
                 Settings settings = {}, Logger *lp = Logger::global(),
-                Poller *pol = Poller::global(),
-                Var<Client> client = Client::global()) {
+                Poller *pol = Poller::global()) {
     settings["method"] = "GET";
     settings["url"] = url;
-    request(settings, cb, headers, body, lp, pol, client);
+    request(settings, cb, headers, body, lp, pol);
 }
 
 /// Send HTTP request and receive response.
@@ -157,15 +134,13 @@ inline void get(std::string url, RequestCallback cb,
 /// \param body Optional HTTP request body.
 /// \param lp Optional logger.
 /// \param pol Optional poller.
-/// \param client Optional HTTP client.
 inline void request(std::string method, std::string url, RequestCallback cb,
                     Headers headers = {}, std::string body = "",
                     Settings settings = {}, Logger *lp = Logger::global(),
-                    Poller *pol = Poller::global(),
-                    Var<Client> client = Client::global()) {
+                    Poller *pol = Poller::global()) {
     settings["method"] = method;
     settings["url"] = url;
-    request(settings, cb, headers, body, lp, pol, client);
+    request(settings, cb, headers, body, lp, pol);
 }
 
 } // namespace http

--- a/src/http/client.cpp
+++ b/src/http/client.cpp
@@ -8,29 +8,18 @@
 namespace mk {
 namespace http {
 
-void Client::request(Settings settings, Headers headers, std::string body,
-                     RequestCallback callback, Logger *lp, Poller *po) {
-    auto r = new Request(settings, headers, body, std::move(callback), lp,
-                         po, &pending);
-    pending.insert(r);
-}
-
-Client::~Client() {
-    for (auto &r : pending) {
-        //
-        // This calls the stream destructor which deletes every
-        // proxy object and possibly delayes the deletion of the
-        // real parser and connection, just to avoid running
-        // code over already deleted structures.
-        //
-        delete r;
-    }
-    pending.clear();
-}
-
+// TODO: This function should be probably be moved in src/http/request.cpp
 void request(Settings settings, RequestCallback cb, Headers headers,
-             std::string body, Logger *lp, Poller *po, Var<Client> client) {
-    client->request(settings, headers, body, cb, lp, po);
+             std::string body, Logger *lp, Poller *po) {
+    request_cycle(
+        settings, headers, body, [cb](Error err, Var<Response> re) {
+            // TODO: maybe change RequestCallback to receive a Var<Response>?
+            Response rex;
+            if (re) {
+                rex = *re;
+            }
+            cb(err, rex);
+        }, po, lp);
 }
 
 } // namespace http

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -84,12 +84,12 @@ void request_recv_response(Var<Transport> transport, RequestRecvResponseCb cb,
             *prevent_emit = true;
             parser->eof();
         }
-        cb(err, response);
+        // TODO: make sure we remove all cycles
         transport->on_error(nullptr);
         transport->on_data(nullptr);
         poller->call_soon([=]() {
             logger->debug("request_recv_response: end of closure");
-            // TODO: make sure we remove all cycles
+            cb(err, response);
         });
     });
 }


### PR DESCRIPTION
First pull request in a wave of pull requests for cleaning up MK after recent changes in DNS, net, and HTTP code that improved API safety and ease of usage.

Here we take down the HTTP client, refactor existing tests, and mark with XXX and/or TODO places in the code that need further love.

Before we proceed, it seems there are [memory errors introduced by this cleanup](https://travis-ci.org/measurement-kit/measurement-kit/jobs/122739892#L3075).

- [x] fix memory errors highlighted above
- [x] add todo list regarding how to proceed from now at bottom