### PR TITLE
readd the tests folder to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
 after_success:
     - if [ "$COVERAGE" = "true" ]; then
         coveralls --gcov /usr/bin/gcov-4.6 --exclude src/ext
-                  --exclude example --exclude test > /dev/null;
+                  --exclude example > /dev/null;
       fi
 
 after_failure:


### PR DESCRIPTION
I'm readding the test folder to the coverall check. I don't know why but without it the coveralls calculation is not correct. 

I think the examples folder should not be included!

[This](https://coveralls.io/builds/5711030/source?filename=include%2Fmeasurement_kit%2Fdns%2Fdns.hpp) is an example of the falsh calculation without the tests example! The code seems not tested, but it is is [test/dns/defines](https://github.com/measurement-kit/measurement-kit/blob/master/test/dns/defines.cpp)