### PR TITLE
connect: use slightly more specific errors

### DIFF
--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -39,10 +39,10 @@ class ConnectFailedError : public Error {
 };
 
 /// DNS generic error
-class DNSGenericError : public Error {
+class DnsGenericError : public Error {
   public:
     /// Default constructor
-    DNSGenericError() : Error(1004, "unknown_failure 1004") {}
+    DnsGenericError() : Error(1004, "unknown_failure 1004") {}
 };
 
 /// Bad SOCKS version error

--- a/src/net/connect.cpp
+++ b/src/net/connect.cpp
@@ -120,7 +120,7 @@ void connect(std::string hostname, int port, ConnectCb cb, double timeo,
 
                 result->resolve_result = r;
                 if (result->resolve_result.addresses.size() <= 0) {
-                    result->overall_error = GenericError();
+                    result->overall_error = DnsGenericError();
                     cb(*result);
                     return;
                 }
@@ -128,7 +128,7 @@ void connect(std::string hostname, int port, ConnectCb cb, double timeo,
                 connect_first_of(result->resolve_result.addresses, port,
                         [=](std::vector<Error> e, bufferevent *b) {
                             if (!b) {
-                                result->overall_error = GenericError();
+                                result->overall_error = ConnectFailedError();
                             }
                             result->connect_result = e;
                             result->connected_bev = b;

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -287,7 +287,7 @@ void Connection::resolve() {
     }
     if (!ok) {
         connecting = 0;
-        emit_error(DNSGenericError());
+        emit_error(DnsGenericError());
         return;
     }
 


### PR DESCRIPTION
I need this in master to improve error checking when tor is not running in #451. While at it, rename `DNSGenericError()` to `DnsGenericError()` which is more readable.