### PR TITLE
big cleanup: convert, remove http test cases

### DIFF
--- a/test/http/client.cpp
+++ b/test/http/client.cpp
@@ -14,6 +14,8 @@ using namespace mk::http;
 // TODO: for now I have just refactored former http::Client tests to use
 // instead the http::request() API, we should now remove duplicates!
 
+// TODO: these tests should go in test/http/request.cpp
+
 TEST_CASE("http::request() works as expected") {
     auto count = 0;
 

--- a/test/http/funcs.cpp
+++ b/test/http/funcs.cpp
@@ -9,6 +9,8 @@
 using namespace mk;
 using namespace mk::http;
 
+// TODO: these tests should go in test/http/request.cpp
+
 TEST_CASE("http::get() works as expected") {
     http::get("http://www.google.com/robots.txt",
         [](Error error, Response &&response) {

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Regression tests for `protocols/http.hpp` and `protocols/http.cpp`.
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
@@ -19,11 +15,14 @@ using namespace mk;
 using namespace mk::net;
 using namespace mk::http;
 
-TEST_CASE("HTTP Request works as expected") {
+// TODO: after refactoring there are probably duplicated tests, we
+// should merge them to avoid testing things twice
+
+TEST_CASE("http::request works as expected") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    Request r(
+    request(
         {
          {"url", "http://www.google.com/robots.txt"},
          {"method", "GET"},
@@ -32,7 +31,7 @@ TEST_CASE("HTTP Request works as expected") {
         {
          {"Accept", "*/*"},
         },
-        "", [&](Error error, Response &&response) {
+        "", [](Error error, Response response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
                 mk::break_loop();
@@ -91,11 +90,11 @@ TEST_CASE("HTTP request behaves correctly when EOF indicates body END") {
     REQUIRE(called == 1);
 }
 
-TEST_CASE("HTTP Request correctly receives errors") {
+TEST_CASE("http::request correctly receives errors") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    Request r(
+    request(
         {
          {"url", "http://nexa.polito.it:81/robots.txt"},
          {"method", "GET"},
@@ -105,7 +104,7 @@ TEST_CASE("HTTP Request correctly receives errors") {
         {
          {"Accept", "*/*"},
         },
-        "", [&](Error error, Response &&response) {
+        "", [](Error error, Response response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
                 mk::break_loop();
@@ -125,11 +124,11 @@ TEST_CASE("HTTP Request correctly receives errors") {
     mk::loop();
 }
 
-TEST_CASE("HTTP Request works as expected over Tor") {
+TEST_CASE("http::request works as expected over Tor") {
     if (CheckConnectivity::is_down()) {
         return;
     }
-    Request r(
+    request(
         {
          {"url", "http://www.google.com/robots.txt"},
          {"method", "GET"},
@@ -139,7 +138,7 @@ TEST_CASE("HTTP Request works as expected over Tor") {
         {
          {"Accept", "*/*"},
         },
-        "", [&](Error error, Response &&response) {
+        "", [](Error error, Response response) {
             if (error != 0) {
                 std::cout << "Error: " << (int)error << "\r\n";
                 mk::break_loop();
@@ -294,11 +293,11 @@ TEST_CASE("Behavior is OK w/o tor_socks_port and socks5_proxy") {
     REQUIRE(r2.socks5_port() == "");
 }
 
-TEST_CASE("The callback is called if input URL parsing fails") {
+TEST_CASE("http::request() callback is called if input URL parsing fails") {
     bool called = false;
-    Request r1({}, {}, "", [&called](Error err, Response) {
+    request({}, {}, "", [&called](Error err, Response) {
         called = true;
-        REQUIRE(err == GenericError());
+        REQUIRE(err == MissingUrlError());
     });
     REQUIRE(called);
 }

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -19,42 +19,10 @@ using namespace mk;
 using namespace mk::net;
 using namespace mk::http;
 
+// TODO: Remove the empty test cases after refactoring / cleanup
+
 TEST_CASE("HTTP stream works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    auto stream = std::make_shared<Stream>(Settings{
-        {"address", "www.google.com"}, {"port", 80},
-    });
-    stream->on_connect([&]() {
-        mk::debug("Connection made... sending request");
-        *stream << "GET /robots.txt HTTP/1.1\r\n"
-                << "Host: www.google.com\r\n"
-                << "Connection: close\r\n"
-                << "\r\n";
-        stream->on_flush([]() {
-            mk::debug("Request sent... waiting for response");
-        });
-        stream->on_headers_complete(
-            [&](unsigned short major, unsigned short minor, unsigned int status,
-                std::string &&reason, Headers &&headers) {
-                std::cout << "HTTP/" << major << "." << minor << " " << status
-                          << " " << reason << "\r\n";
-                for (auto &kv : headers) {
-                    std::cout << kv.first << ": " << kv.second << "\r\n";
-                }
-                std::cout << "\r\n";
-                stream->on_end([&](void) {
-                    std::cout << "\r\n";
-                    stream->close();
-                    mk::break_loop();
-                });
-                stream->on_body([&](std::string && /*chunk*/) {
-                    // std::cout << chunk;
-                });
-            });
-    });
-    mk::loop();
+    // duplicate of t/h/request.cpp's 'http::request works as expected'
 }
 
 TEST_CASE("HTTP stream is robust to EOF") {
@@ -92,63 +60,9 @@ TEST_CASE("HTTP stream is robust to EOF") {
 }
 
 TEST_CASE("HTTP stream works as expected when using Tor") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    auto stream = std::make_shared<Stream>(Settings{
-        {"address", "www.google.com"},
-        {"port", 80},
-        {"socks5_proxy", "127.0.0.1:9050"},
-    });
-    stream->set_timeout(1.0);
-    stream->on_error([&](Error e) {
-        mk::debug("Connection error: %d", (int)e);
-        stream->close();
-        mk::break_loop();
-    });
-    stream->on_connect([&]() {
-        mk::debug("Connection made... sending request");
-        *stream << "GET /robots.txt HTTP/1.1\r\n"
-                << "Host: www.google.com\r\n"
-                << "Connection: close\r\n"
-                << "\r\n";
-        stream->on_flush([]() {
-            mk::debug("Request sent... waiting for response");
-        });
-        stream->on_headers_complete(
-            [&](unsigned short major, unsigned short minor, unsigned int status,
-                std::string &&reason, Headers &&headers) {
-                std::cout << "HTTP/" << major << "." << minor << " " << status
-                          << " " << reason << "\r\n";
-                for (auto &kv : headers) {
-                    std::cout << kv.first << ": " << kv.second << "\r\n";
-                }
-                std::cout << "\r\n";
-                stream->on_end([&](void) {
-                    std::cout << "\r\n";
-                    stream->close();
-                    mk::break_loop();
-                });
-                stream->on_body([&](std::string && /*chunk*/) {
-                    // std::cout << chunk;
-                });
-            });
-    });
-    mk::loop();
+    // duplicate of t/h/request.cpp 'http::request works as expected over Tor'
 }
 
 TEST_CASE("HTTP stream receives connection errors") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    auto stream = std::make_shared<Stream>(Settings{
-        {"address", "nexa.polito.it"}, {"port", "81"},
-    });
-    stream->set_timeout(1.0);
-    stream->on_error([&](Error e) {
-        mk::debug("Connection error: %d", (int)e);
-        stream->close();
-        mk::break_loop();
-    });
-    mk::loop();
+    // duplicate of t/h/request.cpp 'http::request correctly receives errors'
 }


### PR DESCRIPTION
The objective here is to avoid losing coverage but to arrive to
a point where there are no test cases for old HTTP API.

At that point, we can then safely remove such API without causing
any issue to the tree, because no users are left.

- convert Request() test cases to use request(), but skip for now
  the test cases where such conversion is not straightforward

- remove Stream() test cases that duplicate test cases that use
  the request() API (no point in converting them)

- note that there is more work to do