### PR TITLE
t/h/request.cpp: adapt test checking for EOF

### DIFF
--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -63,6 +63,10 @@ ErrorOr<Var<Transport>> connect(Settings settings, Logger *lp, Poller *poller) {
 void connect(std::string address, int port,
              std::function<void(Error, Var<Transport>)> callback,
              Settings settings, Logger *logger, Poller *poller) {
+    if (settings.find("dumb_transport") != settings.end()) {
+        callback(NoError(), Var<Transport>(new Emitter(logger)));
+        return;
+    }
     if (settings.find("socks5_proxy") != settings.end()) {
         socks5_connect(address, port, settings, callback, poller, logger);
         return;

--- a/test/http/stream.cpp
+++ b/test/http/stream.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Regression tests for `protocols/http.hpp` and `protocols/http.cpp`.
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
@@ -26,37 +22,8 @@ TEST_CASE("HTTP stream works as expected") {
 }
 
 TEST_CASE("HTTP stream is robust to EOF") {
-
-    // We simulate the receipt of a message terminated by EOF followed by
-    // an EOF so that stream emits in sequence "end" followed by "error(0)"
-    // to check whether the code is prepared for the case in which the
-    // "end" handler deletes the stream.
-
-    auto stream = new Stream(Settings{
-        {"dumb_transport", 1},
-    });
-    stream->on_error([](Error) {
-        /* nothing */
-    });
-    stream->on_end([stream]() { delete stream; });
-
-    auto transport = stream->get_transport();
-
-    stream->on_connect([stream, &transport]() {
-        Buffer data;
-
-        data << "HTTP/1.1 200 Ok\r\n";
-        data << "Content-Type: text/plain\r\n";
-        data << "Connection: close\r\n";
-        data << "Server: Antani/1.0.0.0\r\n";
-        data << "\r\n";
-        data << "1234567";
-
-        transport->emit_data(data);
-        transport->emit_error(EofError());
-    });
-
-    transport->emit_connect();
+    // duplicate of t/h/request.cpp's 'http:request_sendrecv() behaves
+    // correctly when EOF indicates body END'
 }
 
 TEST_CASE("HTTP stream works as expected when using Tor") {


### PR DESCRIPTION
This adapts t/h/request.cpp test checking for EOF to use the
new, rather than the old, request API.

While there, also get rid of the corresponding http/stream.cpp
test, given that http::Stream will be removed soon.