### PR TITLE
http: refactor tor_socks_port tests

### DIFF
--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -9,30 +9,6 @@ namespace http {
 
 using namespace mk::net;
 
-void request_connect(Settings settings, RequestConnectCb cb,
-        Poller *poller, Logger *logger) {
-    if (settings.find("url") == settings.end()) {
-        cb(MissingUrlError(), nullptr);
-        return;
-    }
-    ErrorOr<Url> url = parse_url_noexcept(settings.at("url"));
-    if (!url) {
-        cb(url.as_error(), nullptr);
-        return;
-    }
-    if (url->schema == "httpo") {
-        // tor_socks_port takes precedence because it's more specific
-        if (settings.find("tor_socks_port") != settings.end()) {
-            std::string proxy = "127.0.0.1:";
-            proxy += settings["tor_socks_port"];
-            settings["socks5_proxy"] = proxy;
-        } else if (settings.find("socks5_proxy") == settings.end()) {
-            settings["socks5_proxy"] = "127.0.0.1:9050";
-        }
-    }
-    connect(url->address, url->port, cb, settings, logger, poller);
-}
-
 void request_send(Var<Transport> transport, Settings settings, Headers headers,
         std::string body, RequestSendCb callback) {
     RequestSerializer serializer;


### PR DESCRIPTION
Refactor tor_socks_port tests not to depend on the previous
implementation of http::Request. To this end, I needed to move
http::request_connect() is src/http/request.hpp and refactor
it to become a template that we can override for testing.