### PR TITLE
Teach net::connect(..., cb) about custom pollers

### DIFF
--- a/src/net/connect.cpp
+++ b/src/net/connect.cpp
@@ -58,7 +58,8 @@ void connect_first_of(std::vector<std::string> addresses, int port,
 }
 
 void resolve_hostname(
-        std::string hostname, ResolveHostnameCb cb, Logger *logger) {
+        std::string hostname, ResolveHostnameCb cb, Poller *poller,
+        Logger *logger) {
 
     logger->debug("resolve_hostname: %s", hostname.c_str());
 
@@ -107,8 +108,8 @@ void resolve_hostname(
                 }
             }
             cb(*result);
-        });
-    });
+        }, {}, poller);
+    }, {}, poller);
 }
 
 void connect(std::string hostname, int port, ConnectCb cb, double timeo,
@@ -137,7 +138,7 @@ void connect(std::string hostname, int port, ConnectCb cb, double timeo,
                         timeo, poller, logger);
 
             },
-            logger);
+            poller, logger);
 }
 
 } // namespace net

--- a/src/net/connect.hpp
+++ b/src/net/connect.hpp
@@ -98,7 +98,7 @@ struct ResolveHostnameResult {
 typedef std::function<void(ResolveHostnameResult)> ResolveHostnameCb;
 
 void resolve_hostname(std::string hostname, ResolveHostnameCb cb,
-        Logger *logger = Logger::global());
+        Poller *poller = Poller::global(), Logger *logger = Logger::global());
 
 struct ConnectResult {
     ResolveHostnameResult resolve_result;

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -105,12 +105,11 @@ Connection::Connection(const char *family, const char *address,
                                     Libs::global(), poller->get_event_base());
 }
 
-Connection::Connection(bufferevent *buffev) {
+Connection::Connection(bufferevent *buffev, Poller *poller, Logger *logger)
+        : Emitter(logger), poller(poller) {
     this->bev.set_bufferevent(buffev);
 
-    /*
-     * The following makes this non copyable and non movable.
-     */
+    // The following makes this non copyable and non movable.
     bufferevent_setcb(this->bev, handle_libevent_read, handle_libevent_write,
                       handle_libevent_event, this);
 }

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -22,7 +22,8 @@ namespace net {
 
 class Connection : public Emitter, public NonMovable, public NonCopyable {
   public:
-    Connection(bufferevent *bev);
+    Connection(bufferevent *bev, Poller * = Poller::global(),
+            Logger * = Logger::global());
 
     ~Connection() override {}
 


### PR DESCRIPTION
To achieve this goal, I needed to implement the following changes:

1) src/net/connect.cpp: teach resolve_hostname() about the
   possibility of using a custom poller and, when this function,
   is invoked by connect(), forward to resolve_hostname() the
   poller that was passed to connect()

2) src/net/connection.cpp: make sure the constructor that
   receives a bufferevent also allows to set a custom poller
   and a custom logger

3) src/net/transport.cpp: make sure we pass possibly custom
   poller and logger when constructing Connection

4) src/net/transport.cpp: make sure that we set a timeout when
   connecting and also, just in case, after connected

5) test/net/transport.cpp: make sure that the net::connect()
   that takes a callback works with a custom poller