### PR TITLE
Make dns callback robust to exceptions

### DIFF
--- a/src/dns/query.hpp
+++ b/src/dns/query.hpp
@@ -203,13 +203,17 @@ static void dns_callback(int code, char type, int count, int ttl,
 
     context->message.answers =
             build_answers_evdns(code, type, count, ttl, addresses);
-    if (context->message.error_code != DNS_ERR_NONE) {
-        context->callback(mk::dns::dns_error(context->message.error_code),
-                context->message);
-    } else {
-        context->callback(NoError(), context->message);
+    try {
+        if (context->message.error_code != DNS_ERR_NONE) {
+            context->callback(mk::dns::dns_error(context->message.error_code),
+                    context->message);
+        } else {
+            context->callback(NoError(), context->message);
+        }
+    } catch (const std::exception& e) {
+        delete context;
+        throw;
     }
-
     delete context;
 }
 

--- a/src/dns/query.hpp
+++ b/src/dns/query.hpp
@@ -210,9 +210,9 @@ static void dns_callback(int code, char type, int count, int ttl,
         } else {
             context->callback(NoError(), context->message);
         }
-    } catch (const std::exception& e) {
-        delete context;
-        throw;
+    } catch (const Error& e) {
+        // suppress Error exceptions because we don't want this kind
+        // of exception to terminate the program
     }
     delete context;
 }


### PR DESCRIPTION
As found by @bassosimone, we didn't consider the case a user callback throws an exception. 
I think this should fix the problem and catch all the exception. 

@bassosimone do you know how to test if the context has been really deleted? 

This closes #481