### PR TITLE
connection.hpp: remove unused methods

### DIFF
--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -25,7 +25,6 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     ~Connection() override {}
 
-    template <MK_MOCK(bufferevent_set_timeouts)>
     void set_timeout(double timeout) override {
         timeval tv, *tvp = mk::timeval_init(&tv, timeout);
         if (bufferevent_set_timeouts(this->bev, tvp, tvp) != 0) {
@@ -37,14 +36,12 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     void do_send(Buffer data) override { data >> bufferevent_get_output(bev); }
 
-    template <MK_MOCK(bufferevent_enable)>
     void enable_read() override {
         if (bufferevent_enable(this->bev, EV_READ) != 0) {
             throw std::runtime_error("cannot enable read");
         }
     }
 
-    template <MK_MOCK(bufferevent_disable)>
     void disable_read() override {
         if (bufferevent_disable(this->bev, EV_READ) != 0) {
             throw std::runtime_error("cannot disable read");

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -25,30 +25,26 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     ~Connection() override {}
 
-    evutil_socket_t get_fileno() { return (bufferevent_getfd(this->bev)); }
-
+    template <MK_MOCK(bufferevent_set_timeouts)>
     void set_timeout(double timeout) override {
-        struct timeval tv, *tvp;
-        tvp = mk::timeval_init(&tv, timeout);
+        timeval tv, *tvp = mk::timeval_init(&tv, timeout);
         if (bufferevent_set_timeouts(this->bev, tvp, tvp) != 0) {
             throw std::runtime_error("cannot set timeout");
         }
     }
 
-    void clear_timeout() override { this->set_timeout(-1); }
-
-    void start_tls(unsigned int) {
-        throw std::runtime_error("not implemented");
-    }
+    void clear_timeout() override { set_timeout(-1); }
 
     void do_send(Buffer data) override { data >> bufferevent_get_output(bev); }
 
+    template <MK_MOCK(bufferevent_enable)>
     void enable_read() override {
         if (bufferevent_enable(this->bev, EV_READ) != 0) {
             throw std::runtime_error("cannot enable read");
         }
     }
 
+    template <MK_MOCK(bufferevent_disable)>
     void disable_read() override {
         if (bufferevent_disable(this->bev, EV_READ) != 0) {
             throw std::runtime_error("cannot disable read");


### PR DESCRIPTION
<strike>Use MK_MOCK() to allow to override specific functions of
Connection for debugging purposes.</strike>

Remove some methods that actually are unused.