### PR TITLE
Tweaks developed while working on s/n/connection

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,4 @@
 ---
 BasedOnStyle: LLVM
-IndentWrappedFunctionNames: true
-AlignAfterOpenBracket: DontAlign
 IndentWidth: 4
 ---

--- a/configure.ac
+++ b/configure.ac
@@ -30,8 +30,6 @@ MK_AM_ENABLE_EXAMPLES
 MK_AM_LIBEVENT
 MK_AM_JANSSON
 MK_AM_LIBMAXMINDDB
-MK_AM_BOOST
-MK_AM_YAML_CPP
 
 # checks for header files
 # checks for types


### PR DESCRIPTION
1) .clang-format: undo recent style changes

@DavideAllavena and I recently tried to introduce some style
changes, but after testing them for a while, I come to the
conclusion that the previous style was more readable and clear.

2) remove nonexistent macros from configure.ac

Most likely that those are a leftover of the recent diff by @AntonioLangiu 
that removed from the tree yaml-cpp and boost.