### PR TITLE
net: preparatory changes for #484

### DIFF
--- a/example/net/listen.cpp
+++ b/example/net/listen.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 
     loop_with_initial_event([&addr, &port]() {
         listen4(addr, port, [](bufferevent *bev) {
-            Var<Transport> transport(new Connection(bev));
+            Var<Transport> transport = Connection::make(bev);
             transport->on_data([transport](Buffer data) {
                 transport->write(data);
             });

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -13,15 +13,18 @@
 extern "C" {
 
 static void handle_libevent_read(bufferevent *, void *opaque) {
-    static_cast<mk::net::Connection *>(opaque)->handle_read_();
+    auto conn = static_cast<mk::net::Connection *>(opaque);
+    conn->emit_libevent_read_(conn);
 }
 
 static void handle_libevent_write(bufferevent *, void *opaque) {
-    static_cast<mk::net::Connection *>(opaque)->handle_write_();
+    auto conn = static_cast<mk::net::Connection *>(opaque);
+    conn->emit_libevent_write_(conn);
 }
 
 static void handle_libevent_event(bufferevent *, short what, void *opaque) {
-    static_cast<mk::net::Connection *>(opaque)->handle_event_(what);
+    auto conn = static_cast<mk::net::Connection *>(opaque);
+    conn->emit_libevent_event_(conn, what);
 }
 
 } // extern "C"
@@ -60,8 +63,8 @@ void Connection::handle_event_(short what) {
     emit_error(SocketError());
 }
 
-Connection::Connection(bufferevent *buffev, Logger *logger)
-        : Emitter(logger) {
+Connection::Connection(bufferevent *buffev, Poller *poller, Logger *logger)
+        : Emitter(logger), poller(poller) {
     this->bev.set_bufferevent(buffev);
 
     // The following makes this non copyable and non movable.

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -141,7 +141,8 @@ void socks5_connect(std::string address, int port, Settings settings,
                     callback(r.overall_error, nullptr);
                     return;
                 }
-                Var<Transport> txp(new Connection(r.connected_bev));
+                Var<Transport> txp = Connection::make(r.connected_bev,
+                                                      poller, logger);
                 Var<Transport> socks5(
                         new Socks5(txp, settings, poller, logger));
                 socks5->on_connect([=]() {

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -30,7 +30,7 @@ void connect(std::string address, int port,
             callback(r.overall_error, nullptr);
             return;
         }
-        Var<Transport> txp(new Connection(r.connected_bev, logger));
+        Var<Transport> txp = Connection::make(r.connected_bev, poller, logger);
         txp->set_timeout(timeout);
         callback(NoError(), txp);
     }, timeout, poller, logger);


### PR DESCRIPTION
1) make Connection() private and introduce a factory called make() to
   return a Var<Transport> instead and propagate changes

2) introduce static methods that shall deal with events generated
   by libevent and call existing non static methods

3) introduce safe_upcall() macro to implement said methods, for now
   with a very trivial implementation

4) add Poller * member which will be used soon