### PR TITLE
transport: now close takes a callback

### DIFF
--- a/example/net/listen.cpp
+++ b/example/net/listen.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
             transport->on_error([transport](Error) {
                 transport->on_error(nullptr);
                 transport->on_data(nullptr);
-                transport->close();
+                transport->close([](){});
             });
         });
     });

--- a/example/net/transport.cpp
+++ b/example/net/transport.cpp
@@ -81,8 +81,9 @@ int main(int argc, char **argv) {
                 } else {
                     debug("* EOF");
                 }
-                tx->close();
-                break_loop();
+                tx->close([]() {
+                    break_loop();
+                });
             });
             tx->on_data([=](Buffer data) {
                 *incoming << data;

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -46,7 +46,7 @@ class Transport {
     virtual void write(std::string) = 0;
     virtual void write(Buffer) = 0;
 
-    virtual void close() = 0;
+    virtual void close(std::function<void()>) = 0;
 
     virtual std::string socks5_address() = 0;
     virtual std::string socks5_port() = 0;

--- a/src/http/request.cpp
+++ b/src/http/request.cpp
@@ -89,7 +89,14 @@ void request_cycle(Settings settings, Headers headers, std::string body,
             callback(err, nullptr);
             return;
         }
-        request_sendrecv(transport, settings, headers, body, callback,
+        request_sendrecv(transport, settings, headers, body,
+                [callback, transport](Error error, Var<Response> response) {
+                    // XXX must pass transport to callback to keep it alive
+                    // because transport has no self ownership concept
+                    transport->close([callback, error, response, transport]() {
+                        callback(error, response);
+                    });
+                },
                 poller, logger);
     }, poller, logger);
 }

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -72,8 +72,15 @@ Connection::Connection(bufferevent *buffev, Poller *poller, Logger *logger)
                       handle_libevent_event, this);
 }
 
-void Connection::close() {
-    this->bev.close();
+void Connection::close(std::function<void()> cb) {
+    if (isclosed) {
+        throw std::runtime_error("already closed");
+    }
+    isclosed = true;
+    poller->call_soon([=]() {
+        this->bev.close();
+        cb();
+    });
 }
 
 } // namespace net

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -55,7 +55,7 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
         }
     }
 
-    void close() override;
+    void close(std::function<void()>) override;
 
     void handle_event_(short);
     void handle_read_();
@@ -82,6 +82,7 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
 
     Bufferevent bev;
     Poller *poller = Poller::global();
+    bool isclosed = false;
 };
 
 } // namespace net

--- a/src/net/emitter.hpp
+++ b/src/net/emitter.hpp
@@ -122,7 +122,7 @@ class Emitter : public Transport {
     // Implements actual send and should be override by subclasses
     virtual void do_send(Buffer) {}
 
-    void close() override { logger->debug("emitter: close"); }
+    void close(std::function<void()>) override {}
 
     std::string socks5_address() override { return ""; }
 

--- a/src/net/socks5.hpp
+++ b/src/net/socks5.hpp
@@ -24,9 +24,9 @@ class Socks5 : public Emitter {
 
     void do_send(Buffer data) override { conn->write(data); }
 
-    void close() override {
+    void close(std::function<void()> callback) override {
         isclosed = true;
-        conn->close();
+        conn->close(callback);
     }
 
     std::string socks5_address() override { return proxy_address; }

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -37,9 +37,13 @@ class TCPConnectImpl : public TCPTestImpl {
               std::function<void(json)> &&cb) {
         options["host"] = input;
 
-        connect(options, [this, cb](Var<net::Transport>) {
+        connect(options, [this, cb](Var<net::Transport> txp) {
             logger.debug("tcp_connect: Got response to TCP connect test");
-            cb(entry);
+            // XXX must pass `txp` to callback to keep it alive; this is
+            // because the transport has no self ownership concept...
+            txp->close([this, cb, txp]() {
+                cb(entry);
+            });
         });
     }
 };

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -19,52 +19,6 @@
 using namespace mk;
 using namespace mk::net;
 
-// TODO: move this test in test/net/transport.cpp
-TEST_CASE("Transport::close() is idempotent") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        connect("nexa.polito.it", 80, [](Error err, Var<Transport> s) {
-            REQUIRE(!err);
-            s->close();
-            // It shall be safe to call close more than once
-            s->close();
-            s->close();
-            break_loop();
-        });
-    });
-}
-
-// TODO: move this test in test/net/transport.cpp
-TEST_CASE("It is safe to manipulate Transport after close") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        connect("nexa.polito.it", 80, [](Error err, Var<Transport> s) {
-            REQUIRE(!err);
-            s->close();
-            // We expect the transport to throw if we call its ->write() method
-            // after close because the underlying Bufferevent becomes empty
-            REQUIRE_THROWS(s->write("foo"));
-            break_loop();
-        });
-    });
-}
-
-// TODO: remove (test not applicable anymore)
-// Disable this unittest since this requires an API change
-/* TEST_CASE("It is safe to close Connection while resolve is in progress") { */
-/*     if (CheckConnectivity::is_down()) { */
-/*         return; */
-/*     } */
-/*     Connection s("PF_INET", "nexa.polito.it", "80"); */
-/*     DelayedCall unsched(0.001, [&s]() { s.close(); }); */
-/*     DelayedCall bail_out(2.0, []() { mk::break_loop(); }); */
-/*     mk::loop(); */
-/* } */
-
 TEST_CASE("connect() iterates over all the available addresses") {
     // TODO: remove
     // Test cancelled because not applicable anymore


### PR DESCRIPTION
This is the starting point to implement #484. Further refinements are making the transport self aware so that one does not need to keep it alive in the close callback, and write post-close unit tests.