### PR TITLE
connection: call close callback in destructor

### DIFF
--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -13,18 +13,15 @@
 extern "C" {
 
 static void handle_libevent_read(bufferevent *, void *opaque) {
-    auto conn = static_cast<mk::net::Connection *>(opaque);
-    conn->emit_libevent_read_(conn);
+    static_cast<mk::net::Connection *>(opaque)->handle_read_();
 }
 
 static void handle_libevent_write(bufferevent *, void *opaque) {
-    auto conn = static_cast<mk::net::Connection *>(opaque);
-    conn->emit_libevent_write_(conn);
+    static_cast<mk::net::Connection *>(opaque)->handle_write_();
 }
 
 static void handle_libevent_event(bufferevent *, short what, void *opaque) {
-    auto conn = static_cast<mk::net::Connection *>(opaque);
-    conn->emit_libevent_event_(conn, what);
+    static_cast<mk::net::Connection *>(opaque)->handle_event_(what);
 }
 
 } // extern "C"

--- a/src/net/connection.cpp
+++ b/src/net/connection.cpp
@@ -85,9 +85,9 @@ void Connection::close(std::function<void()> cb) {
     bufferevent_setcb(bev, nullptr, nullptr, nullptr, nullptr);
     disable_read();
 
+    close_cb = cb;
     poller->call_soon([=]() {
         this->self = nullptr;
-        cb();
     });
 }
 

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -66,21 +66,6 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
     void handle_read_();
     void handle_write_();
 
-#define safe_upcall(ptr_, method_and_args_)                                    \
-    do {                                                                       \
-        ptr_->method_and_args_;                                                \
-    } while (0)
-    static void emit_libevent_event_(Connection *me, short what) {
-        safe_upcall(me, handle_event_(what));
-    }
-    static void emit_libevent_read_(Connection *me) {
-        safe_upcall(me, handle_read_());
-    }
-    static void emit_libevent_write_(Connection *me) {
-        safe_upcall(me, handle_write_());
-    }
-#undef safe_upcall
-
   private:
     Connection(bufferevent *bev, Poller * = Poller::global(),
                Logger * = Logger::global());

--- a/src/net/connection.hpp
+++ b/src/net/connection.hpp
@@ -32,6 +32,9 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
         if (bev != nullptr) {
             bufferevent_free(bev);
         }
+        if (close_cb) {
+            close_cb();
+        }
     }
 
     void set_timeout(double timeout) override {
@@ -86,6 +89,7 @@ class Connection : public Emitter, public NonMovable, public NonCopyable {
     Var<Transport> self;
     Poller *poller = Poller::global();
     bool isclosed = false;
+    std::function<void()> close_cb;
 };
 
 } // namespace net


### PR DESCRIPTION
While there also simplify code by removing some complexity added in #488 that I though was needed to implement #489 but that eventually turned out to be unnecessary because I took a simpler path where garbage collection is not needed :-).