### PR TITLE
Add initial SSL implementation

### DIFF
--- a/example/http/request.cpp
+++ b/example/http/request.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     std::string body;
     char ch;
-    std::string method;
+    std::string method = "GET";
     while ((ch = getopt(argc, argv, "b:m:v")) != -1) {
         switch (ch) {
         case 'b':

--- a/example/net/transport.cpp
+++ b/example/net/transport.cpp
@@ -16,7 +16,7 @@ using namespace mk;
 using namespace mk::net;
 
 static const char *kv_usage =
-        "usage: ./example/net/transport [-v] [-P address:port] url\n";
+        "usage: ./example/net/transport [-Sv] [-P address:port] url\n";
 
 static void print_line(std::string line) {
     std::string s;
@@ -33,10 +33,13 @@ int main(int argc, char **argv) {
 
     Settings settings;
     char ch;
-    while ((ch = getopt(argc, argv, "P:v")) != -1) {
+    while ((ch = getopt(argc, argv, "P:Sv")) != -1) {
         switch (ch) {
         case 'P':
             settings["socks5_proxy"] = optarg;
+            break;
+        case 'S':
+            settings["ssl"] = true;
             break;
         case 'v':
             set_verbose(1);

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -90,14 +90,11 @@ void xfree(void *ptr) {
 }
 
 timeval *timeval_init(timeval *tv, double delta) {
-    debug("utils:timeval_init - enter");
     if (delta < 0) {
-        debug("utils:timeval_init - no init needed");
         return nullptr;
     }
     tv->tv_sec = (time_t)floor(delta);
     tv->tv_usec = (suseconds_t)((delta - floor(delta)) * 1000000);
-    debug("utils:timeval_init - ok");
     return tv;
 }
 

--- a/src/http/parse_url.cpp
+++ b/src/http/parse_url.cpp
@@ -27,6 +27,8 @@ Url parse_url(std::string url) {
                                 url_parser.field_data[UF_HOST].len);
     if ((url_parser.field_set & (1 << UF_PORT)) != 0) {
         retval.port = url_parser.port;
+    } else if (retval.schema == "https") {
+        retval.port = 443;
     }
     if ((url_parser.field_set & (1 << UF_PATH)) != 0) {
         retval.path = url.substr(url_parser.field_data[UF_PATH].off,

--- a/src/http/request.hpp
+++ b/src/http/request.hpp
@@ -47,6 +47,8 @@ void request_connect(Settings settings, RequestConnectCb cb,
         } else if (settings.find("socks5_proxy") == settings.end()) {
             settings["socks5_proxy"] = "127.0.0.1:9050";
         }
+    } else if (url->schema == "https") {
+        settings["ssl"] = true;
     }
     do_connect(url->address, url->port, cb, settings, logger, poller);
 }

--- a/src/mlabns/mlabns.cpp
+++ b/src/mlabns/mlabns.cpp
@@ -72,7 +72,7 @@ void query(std::string tool, std::function<void(Error, Reply)> callback,
         callback(query.as_error(), Reply());
         return;
     }
-    std::string url = "http://mlab-ns.appspot.com/";
+    std::string url = "https://mlab-ns.appspot.com/";
     std::regex valid_tool("^[a-z]+$");
     if (!std::regex_match(tool, valid_tool)) {
         callback(InvalidToolNameError(), Reply());

--- a/src/net/connect.cpp
+++ b/src/net/connect.cpp
@@ -3,6 +3,7 @@
 // information on the copying conditions.
 
 #include "src/net/connect.hpp"
+#include <event2/bufferevent_ssl.h>
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/poller.hpp>
@@ -139,6 +140,27 @@ void connect(std::string hostname, int port, ConnectCb cb, double timeo,
 
             },
             poller, logger);
+}
+
+void connect_ssl(bufferevent *orig_bev, ssl_st *ssl,
+                 std::function<void(Error, bufferevent *)> cb,
+                 Poller *poller, Logger *logger) {
+    logger->debug("connect ssl...");
+
+    auto bev = bufferevent_openssl_filter_new(poller->get_event_base(),
+            orig_bev, ssl, BUFFEREVENT_SSL_CONNECTING,
+            BEV_OPT_CLOSE_ON_FREE);
+    if (bev == nullptr) {
+        bufferevent_free(orig_bev);
+        cb(GenericError(), nullptr);
+        return;
+    }
+
+    bufferevent_setcb(bev, nullptr, nullptr, mk_bufferevent_on_event,
+            new ConnectBaseCb([cb, logger](Error err, bufferevent *bev) {
+                logger->debug("connect ssl... callback");
+                cb(err, bev);
+            }));
 }
 
 } // namespace net

--- a/src/net/connect.hpp
+++ b/src/net/connect.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 struct bufferevent;
+struct ssl_st;
 
 extern "C" {
 void mk_bufferevent_on_event(bufferevent *, short, void *);
@@ -111,6 +112,11 @@ typedef std::function<void(ConnectResult)> ConnectCb;
 
 void connect(std::string hostname, int port, ConnectCb cb, double timeo = 10.0,
         Poller *poller = Poller::global(), Logger *logger = Logger::global());
+
+void connect_ssl(bufferevent *orig_bev, ssl_st *ssl,
+                 std::function<void(Error, bufferevent *)> cb,
+                 Poller * = Poller::global(),
+                 Logger * = Logger::global());
 
 } // namespace mk
 } // namespace net

--- a/src/net/ssl-context.cpp
+++ b/src/net/ssl-context.cpp
@@ -1,0 +1,52 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/ossl_typ.h>
+#include <openssl/ssl.h>
+#include <exception>
+#include "src/net/ssl-context.hpp"
+
+namespace mk {
+namespace net {
+
+SSL_CTX *SslContext::get_client_context() {
+    static SslContext singleton;
+    return singleton.ctx;
+}
+
+SSL *SslContext::get_client_ssl() {
+    SSL *ssl = SSL_new(get_client_context());
+    if (ssl == nullptr) {
+        throw std::exception();
+    }
+    return ssl;
+}
+
+SslContext::SslContext() {
+    // TODO: check return values where applicable
+    SSL_library_init();
+    ERR_load_crypto_strings();
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+
+    // FIXME: the code in here is really simple because we only aim to
+    // smoke test the OpenSSL functionality. What is missing here is at
+    // the minimum code to verify the peer certificate. Also we should
+    // not allow SSLv2 (and probably v3) connections, and we should also
+    // probably set SNI for the other end to respond correctly.
+    ctx = SSL_CTX_new(SSLv23_client_method());
+    if (ctx == nullptr) {
+        throw std::exception();
+    }
+}
+
+SslContext::~SslContext() {
+    SSL_CTX_free(ctx);
+}
+
+} // namespace net
+} // namespace mk
+

--- a/src/net/ssl-context.hpp
+++ b/src/net/ssl-context.hpp
@@ -1,0 +1,29 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifndef SRC_NET_SSL_CONTEXT_HPP
+#define SRC_NET_SSL_CONTEXT_HPP
+
+// Forward declarations
+struct ssl_st;
+struct ssl_ctx_st;
+
+namespace mk {
+namespace net {
+
+class SslContext {
+  public:
+    static ssl_ctx_st *get_client_context();
+
+    static ssl_st *get_client_ssl();
+
+  private:
+    SslContext();
+    ~SslContext();
+
+    ssl_ctx_st *ctx = nullptr;
+};
+
+} // namespace net
+} // namespace mk
+#endif

--- a/src/net/ssl-context.hpp
+++ b/src/net/ssl-context.hpp
@@ -4,6 +4,8 @@
 #ifndef SRC_NET_SSL_CONTEXT_HPP
 #define SRC_NET_SSL_CONTEXT_HPP
 
+#include <measurement_kit/common.hpp>
+
 // Forward declarations
 struct ssl_st;
 struct ssl_ctx_st;
@@ -11,7 +13,7 @@ struct ssl_ctx_st;
 namespace mk {
 namespace net {
 
-class SslContext {
+class SslContext : public NonCopyable, public NonMovable {
   public:
     static ssl_ctx_st *get_client_context();
 

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -51,6 +51,41 @@ TEST_CASE("http::request works as expected") {
     mk::loop();
 }
 
+TEST_CASE("http::request() works using HTTPS") {
+    if (CheckConnectivity::is_down()) {
+        return;
+    }
+    set_verbose(1);
+    loop_with_initial_event([]() {
+        request(
+            {
+                {"url", "https://didattica.polito.it/"},
+                {"method", "GET"},
+                {"http_version", "HTTP/1.1"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [](Error error, Response response) {
+                if (error != 0) {
+                    std::cout << "Error: " << (int)error << "\r\n";
+                    mk::break_loop();
+                    return;
+                }
+                std::cout << "HTTP/" << response.http_major << "."
+                      << response.http_minor << " " << response.status_code
+                      << " " << response.reason << "\r\n";
+                for (auto kv : response.headers) {
+                    std::cout << kv.first << ": " << kv.second << "\r\n";
+                }
+                std::cout << "\r\n";
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                mk::break_loop();
+            });
+    });
+}
+
 TEST_CASE("http::request_recv_response() behaves correctly when EOF "
         "indicates body END") {
     auto called = 0;

--- a/test/net/transport.cpp
+++ b/test/net/transport.cpp
@@ -47,6 +47,20 @@ TEST_CASE("net::connect() can connect to open port") {
     });
 }
 
+TEST_CASE("net::connect() can connect to SSL port") {
+    if (CheckConnectivity::is_down()) {
+        return;
+    }
+    set_verbose(1);
+    loop_with_initial_event([]() {
+        connect("nexa.polito.it", 443, [](Error error, Var<Transport> txp) {
+            REQUIRE(!error);
+            txp->close([]() { break_loop(); });
+        },
+        {{"ssl", true}});
+    });
+}
+
 TEST_CASE("net::connect() works in case of error") {
     if (CheckConnectivity::is_down()) {
         return;


### PR DESCRIPTION
This is very rough. In particular, we do not validate certificates, so
a man in the middle is very possible for now.

But I feel like it's important to have the basic scaffolding such
that things that should go in parallel over SSL can.

<strike>Crossing fingers as for Valgrind. I recall that used to reported
several uninitialized variables in OpenSSL.</strike>