### PR TITLE
Hotfixes backported from #366

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: cpp
 
 install:
-    - if [ "$VER" != ""  ]; then 
-          export CXX="$CXX-$VER" CC="$CC-$VER"; 
+    - if [ "$VER" != ""  ]; then
+          export CXX="$CXX-$VER" CC="$CC-$VER";
       fi;
     - ARG="-q --with-jansson=builtin --with-libmaxminddb=builtin"
     - if [ "$COVERAGE" = "true" ]; then
@@ -27,7 +27,7 @@ script:
       fi
     - if [ "$VALGRIND" = "true" ]; then
         make run-valgrind;
-      elif [ "$BUILD_TYPE" != "ios" ]; then 
+      elif [ "$BUILD_TYPE" != "ios" ]; then
         make -j2 check-am V=0;
       fi
 
@@ -48,7 +48,7 @@ matrix:
 
     - sudo: false
       compiler: clang-3.6
-      env: OS="12.04" VALGRIND=true VER=3.6 
+      env: OS="12.04" VALGRIND=true VER=3.6
       addons:
         apt:
           packages:
@@ -61,7 +61,7 @@ matrix:
 
     - sudo: false
       compiler: clang-3.6
-      env: OS="12.04" COVERAGE=true VER=3.6 
+      env: OS="12.04" COVERAGE=true VER=3.6
       addons:
         apt:
           packages:
@@ -70,10 +70,10 @@ matrix:
           sources:
             - llvm-toolchain-precise-3.6
             - ubuntu-toolchain-r-test
-    
+
     - sudo: false
       compiler: g++-5
-      env: OS="12.04" VER=5 
+      env: OS="12.04" VER=5
       addons:
         apt:
           packages:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ build process) run:
 ### How to build MeasurementKit on Android
 
 To compile MeasurementKit for Android, see the README.md file contained in
-the `mobile/android` directory of this repository.
+the `build/android` directory of this repository.
 
 ### How to build MeasurementKit on iOS
 
@@ -172,7 +172,7 @@ To compile and use MeasurementKit for iOS, do the following on a MacOSX
 system where Xcode and its command line tools have been installed:
 
 ```
-./mobile/ios/scripts/build.sh
+./build/ios/scripts/build.sh
 ```
 
 ### How to add MeasurementKit to an Xcode project.

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -3,12 +3,11 @@ dnl Measurement-kit is free software. See AUTHORS and LICENSE for more
 dnl information on the copying conditions.
 
 AC_DEFUN([MK_AM_ENABLE_EXAMPLES], [
-AC_ARG_ENABLE([examples],
+  AC_ARG_ENABLE([examples],
     AS_HELP_STRING([--disable-examples, skip building of examples programs]),
-        [], [enable_examples=yes])
-AM_CONDITIONAL([BUILD_EXAMPLES], [test "$enable_examples" = "yes"])
+                   [], [enable_examples=yes])
+  AM_CONDITIONAL([BUILD_EXAMPLES], [test "$enable_examples" = "yes"])
 ])
-
 
 AC_DEFUN([MK_AM_LIBEVENT], [
   echo "> checking for dependency: libevent"
@@ -41,7 +40,6 @@ AC_DEFUN([MK_AM_LIBEVENT], [
   echo ""
 ])
 
-
 AC_DEFUN([MK_AM_JANSSON], [
   echo "> checking for dependency: jansson"
 
@@ -69,7 +67,6 @@ AC_DEFUN([MK_AM_JANSSON], [
   echo ""
 ])
 
-
 AC_DEFUN([MK_AM_LIBMAXMINDDB], [
   echo "> checking for dependency: libmaxminddb"
 
@@ -96,7 +93,6 @@ AC_DEFUN([MK_AM_LIBMAXMINDDB], [
   fi
   echo ""
 ])
-
 
 AC_DEFUN([MK_AM_OPENSSL], [
   echo "> checking for dependency: openssl"
@@ -182,33 +178,30 @@ AC_DEFUN([MK_AM_OPENSSL], [
   echo ""
 ])
 
-
 AC_DEFUN([MK_AM_REQUIRE_C99], [
-AC_PROG_CC_C99
-if test x"$ac_cv_prog_cc_c99" = xno; then
+  AC_PROG_CC_C99
+  if test x"$ac_cv_prog_cc_c99" = xno; then
     AC_MSG_ERROR([a C99 compiler is required])
-fi
+  fi
 ])
 
-
 AC_DEFUN([MK_AM_REQUIRE_CXX11], [
-measurement_kit_saved_cxxflags="$CXXFLAGS"
-CXXFLAGS=-std=c++11
-AC_MSG_CHECKING([whether CXX supports -std=c++11])
-AC_LANG_PUSH([C++])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+  mk_saved_cxxflags="$CXXFLAGS"
+  CXXFLAGS=-std=c++11
+  AC_MSG_CHECKING([whether CXX supports -std=c++11])
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
     [AC_MSG_RESULT([yes])]
     [],
     [
      AC_MSG_RESULT([no])
      AC_MSG_ERROR([a C++11 compiler is required])
-    ]
-)
-CXXFLAGS="$measurement_kit_saved_cxxflags -std=c++11"
-AC_LANG_POP([C++])
+    ])
+  CXXFLAGS="$mk_saved_cxxflags -std=c++11"
+  AC_LANG_POP([C++])
 ])
 
-
+dnl This should probably be removed since MacOS 10.8 is now obsolete
 AC_DEFUN([MK_AM_REQUIRE_CXX11_LIBCXX], [
 measurement_kit_saved_cxxflags="$CXXFLAGS"
 CXXFLAGS="-std=c++11"
@@ -245,24 +238,22 @@ CXXFLAGS="$measurement_kit_saved_cxxflags $measurement_kit_cxx_stdlib_flags"
 AC_LANG_POP([C++])
 ])
 
-
 AC_DEFUN([MK_AM_CXXFLAGS_ADD_WARNINGS], [
-AC_MSG_CHECKING([whether the C++ compiler is clang++])
-if test echo | $CXX -dM -E - | grep __clang__ > /dev/null; then
+  AC_MSG_CHECKING([whether compiler is clang to add clang specific warnings])
+  if test echo | $CXX -dM -E - | grep __clang__ > /dev/null; then
     AC_MSG_RESULT([yes])
     CXXFLAGS="$CXXFLAGS -Wmissing-prototypes"
-else
+  else
     AC_MSG_RESULT([yes])
-fi
+  fi
 ])
 
-
 AC_DEFUN([MK_AM_PRINT_SUMMARY], [
-echo "==== configured variables ==="
-echo "CC       : $CC"
-echo "CXX      : $CXX"
-echo "CFLAGS   : $CFLAGS"
-echo "CPPFLAGS : $CPPFLAGS"
-echo "CXXFLAGS : $CXXFLAGS"
-echo "LDFLAGS  : $LDFLAGS"
+  echo "==== configured variables ==="
+  echo "CC       : $CC"
+  echo "CXX      : $CXX"
+  echo "CFLAGS   : $CFLAGS"
+  echo "CPPFLAGS : $CPPFLAGS"
+  echo "CXXFLAGS : $CXXFLAGS"
+  echo "LDFLAGS  : $LDFLAGS"
 ])

--- a/build/spec/all
+++ b/build/spec/all
@@ -2,6 +2,6 @@
 set -e
 pkg_rootdir=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
 cd $pkg_rootdir
-for dependency in Catch http-parser jansson libevent libmaxminddb libressl; do
+for dependency in jansson libevent libmaxminddb libressl; do
     ./build/dependency $dependency
 done

--- a/src/ext/include.am
+++ b/src/ext/include.am
@@ -1,6 +1,3 @@
-DIST_SUBDIRS =
-SUBDIRS =
-
 libmeasurement_kit_la_SOURCES += \
     src/ext/strtonum.c \
     src/ext/http-parser/http_parser.c


### PR DESCRIPTION
Space changes, removal of spaces at EOL, reindents. In particular, remove
from `./build/spec/all` things for which we do not have a spec.