### PR TITLE
build system: set pthreads earliers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-# Makefile.am
-
 # Part of measurement-kit <https://measurement-kit.github.io/>.
 # Measurement-kit is free software. See AUTHORS and LICENSE for more
 # information on the copying conditions.
@@ -12,8 +10,8 @@ LIBMEASUREMENT_KIT_I_FLAGS += -I $(top_srcdir)/src
 LIBMEASUREMENT_KIT_W_FLAGS = -Wall -Wextra -pedantic
 
 VERSION_INFO = -release @VERSION@ -version-info 0
-AM_CFLAGS = -pthread $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
-AM_CXXFLAGS = -pthread $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
+AM_CFLAGS = $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
+AM_CXXFLAGS = $(LIBMEASUREMENT_KIT_W_FLAGS) $(LIBMEASUREMENT_KIT_I_FLAGS)
 
 lib_LTLIBRARIES               = libmeasurement_kit.la
 libmeasurement_kit_la_LDFLAGS = -version-info $(VERSION_INFO)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,3 @@
-# configure.ac
-
 # Part of measurement-kit <https://measurement-kit.github.io/>.
 # Measurement-kit is free software. See AUTHORS and LICENSE for more
 # information on the copying conditions.
@@ -21,11 +19,16 @@ AC_CANONICAL_HOST
 
 # checks for programs
 AC_PROG_INSTALL
-AC_PROG_CXX()
+AC_PROG_CXX
 
 MK_AM_ENABLE_EXAMPLES
 
 # checks for libraries
+
+# Must set -pthread before testing for -levent_pthreads
+CFLAGS="$CFLAGS -pthread"
+CXXFLAGS="$CXXFLAGS -pthread"
+LDFLAGS="$LDFLAGS -pthread"
 
 echo ""
 MK_AM_OPENSSL


### PR DESCRIPTION
I do not exactly recall the precise reason, but I remember that
setting pthreads earliers helped me when working to #366.

Backport this specific part of #366 such that, once this is
merged into master, I can focus on the remainder.