### PR TITLE
connect: pass to callback info on dns resolution etc

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -6,10 +6,13 @@
 #define MEASUREMENT_KIT_COMMON_ERROR_HPP
 
 #include <exception>
+#include <measurement_kit/common/var.hpp>
 #include <iosfwd>
 #include <string>
 
 namespace mk {
+
+class ErrorContext {};
 
 /// An error that occurred
 class Error : public std::exception {
@@ -34,6 +37,8 @@ class Error : public std::exception {
 
     /// Return error as OONI error
     std::string as_ooni_error() { return ooni_error_; }
+
+    Var<ErrorContext> context;
 
   private:
     int error_ = 0;

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -6,10 +6,14 @@
 
 #include <functional>
 #include <measurement_kit/common.hpp>
+#include <measurement_kit/dns.hpp>
 #include <measurement_kit/net/buffer.hpp>
 #include <stddef.h>
 #include <string>
 #include <vector>
+
+// Forward declaration
+struct bufferevent;
 
 namespace mk {
 
@@ -51,6 +55,24 @@ class Transport {
 
     virtual std::string socks5_address() = 0;
     virtual std::string socks5_port() = 0;
+};
+
+struct ResolveHostnameResult {
+    bool inet_pton_ipv4 = false;
+    bool inet_pton_ipv6 = false;
+
+    Error ipv4_err;
+    dns::Message ipv4_reply;
+    Error ipv6_err;
+    dns::Message ipv6_reply;
+
+    std::vector<std::string> addresses;
+};
+
+struct ConnectResult : public ErrorContext {
+    ResolveHostnameResult resolve_result;
+    std::vector<Error> connect_result;
+    bufferevent *connected_bev = nullptr;
 };
 
 void connect(std::string address, int port,

--- a/src/net/connect.cpp
+++ b/src/net/connect.cpp
@@ -113,7 +113,7 @@ void resolve_hostname(
     }, {}, poller);
 }
 
-void connect(std::string hostname, int port, Callback<Var<ConnectResult>> cb,
+void connect_logic(std::string hostname, int port, Callback<Var<ConnectResult>> cb,
         double timeo, Poller *poller, Logger *logger) {
 
     Var<ConnectResult> result(new ConnectResult);

--- a/src/net/connect.hpp
+++ b/src/net/connect.hpp
@@ -5,8 +5,6 @@
 #define SRC_NET_CONNECT_HPP
 
 #include "event2/util.h"
-#include "measurement_kit/common.hpp"
-#include "measurement_kit/dns.hpp"
 #include "src/common/utils.hpp"
 #include <arpa/inet.h>
 #include <event2/bufferevent.h>
@@ -15,6 +13,7 @@
 #include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/poller.hpp>
+#include <measurement_kit/net.hpp>
 #include <sstream>
 #include <string>
 #include <sys/socket.h>
@@ -82,34 +81,14 @@ void connect_first_of(std::vector<std::string> addresses, int port,
         Poller *poller = Poller::global(), Logger *logger = Logger::global(),
         size_t index = 0, Var<std::vector<Error>> errors = nullptr);
 
-struct ResolveHostnameResult {
-    bool inet_pton_ipv4 = false;
-    bool inet_pton_ipv6 = false;
-
-    Error ipv4_err;
-    dns::Message ipv4_reply;
-    Error ipv6_err;
-    dns::Message ipv6_reply;
-
-    std::vector<std::string> addresses;
-};
-
 typedef std::function<void(ResolveHostnameResult)> ResolveHostnameCb;
 
 void resolve_hostname(std::string hostname, ResolveHostnameCb cb,
         Poller *poller = Poller::global(), Logger *logger = Logger::global());
 
-struct ConnectResult {
-    ResolveHostnameResult resolve_result;
-    std::vector<Error> connect_result;
-    Error overall_error;
-    bufferevent *connected_bev;
-};
-
-typedef std::function<void(ConnectResult)> ConnectCb;
-
-void connect(std::string hostname, int port, ConnectCb cb, double timeo = 10.0,
-        Poller *poller = Poller::global(), Logger *logger = Logger::global());
+void connect(std::string hostname, int port, Callback<Var<ConnectResult>> cb,
+        double timeo = 10.0, Poller *poller = Poller::global(),
+        Logger *logger = Logger::global());
 
 void connect_ssl(bufferevent *orig_bev, ssl_st *ssl,
                  Callback<bufferevent *> cb,

--- a/src/net/connect.hpp
+++ b/src/net/connect.hpp
@@ -86,7 +86,7 @@ typedef std::function<void(ResolveHostnameResult)> ResolveHostnameCb;
 void resolve_hostname(std::string hostname, ResolveHostnameCb cb,
         Poller *poller = Poller::global(), Logger *logger = Logger::global());
 
-void connect(std::string hostname, int port, Callback<Var<ConnectResult>> cb,
+void connect_logic(std::string hostname, int port, Callback<Var<ConnectResult>> cb,
         double timeo = 10.0, Poller *poller = Poller::global(),
         Logger *logger = Logger::global());
 

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -136,23 +136,27 @@ void socks5_connect(std::string address, int port, Settings settings,
     settings["port"] = port;
 
     connect(proxy_address, lexical_cast<int>(proxy_port),
-            [=](ConnectResult r) {
-                if (r.overall_error) {
-                    callback(r.overall_error, nullptr);
+            [=](Error err, Var<ConnectResult> r) {
+                if (err) {
+                    err.context = r;
+                    callback(err, nullptr);
                     return;
                 }
-                Var<Transport> txp = Connection::make(r.connected_bev,
+                Var<Transport> txp = Connection::make(r->connected_bev,
                                                       poller, logger);
                 Var<Transport> socks5(
                         new Socks5(txp, settings, poller, logger));
                 socks5->on_connect([=]() {
                     socks5->on_connect(nullptr);
                     socks5->on_error(nullptr);
-                    callback(NoError(), socks5);
+                    Error error = NoError();
+                    error.context = r;
+                    callback(error, socks5);
                 });
                 socks5->on_error([=](Error error) {
                     socks5->on_connect(nullptr);
                     socks5->on_error(nullptr);
+                    error.context = r;
                     callback(error, nullptr);
                 });
             },

--- a/src/net/socks5.cpp
+++ b/src/net/socks5.cpp
@@ -135,7 +135,7 @@ void socks5_connect(std::string address, int port, Settings settings,
     settings["address"] = address;
     settings["port"] = port;
 
-    connect(proxy_address, lexical_cast<int>(proxy_port),
+    connect_logic(proxy_address, lexical_cast<int>(proxy_port),
             [=](Error err, Var<ConnectResult> r) {
                 if (err) {
                     err.context = r;

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -13,6 +13,7 @@
 namespace mk {
 namespace net {
 
+// TODO: this should be moved into src/net/connect.cpp
 void connect(std::string address, int port,
              Callback<Var<Transport>> callback,
              Settings settings, Logger *logger, Poller *poller) {
@@ -25,7 +26,7 @@ void connect(std::string address, int port,
         return;
     }
     double timeout = settings.get("timeout", 30.0);
-    net::connect(address, port, [=](Error err, Var<ConnectResult> r) {
+    connect_logic(address, port, [=](Error err, Var<ConnectResult> r) {
         if (err) {
             err.context = r;
             callback(err, nullptr);

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -2,6 +2,7 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
+#include <cassert>
 #include <measurement_kit/net.hpp>
 #include "src/net/connect.hpp"
 #include "src/net/connection.hpp"
@@ -24,31 +25,35 @@ void connect(std::string address, int port,
         return;
     }
     double timeout = settings.get("timeout", 30.0);
-    net::connect(address, port, [=](ConnectResult r) {
-        // TODO: it would be nice to pass to this callback a compound error
-        // that also contains info on all what went wrong when connecting
-        if (r.overall_error) {
-            callback(r.overall_error, nullptr);
+    net::connect(address, port, [=](Error err, Var<ConnectResult> r) {
+        if (err) {
+            err.context = r;
+            callback(err, nullptr);
             return;
         }
         if (settings.find("ssl") != settings.end()) {
-            connect_ssl(r.connected_bev, SslContext::get_client_ssl(),
+            connect_ssl(r->connected_bev, SslContext::get_client_ssl(),
                         [=](Error err, bufferevent *bev) {
                             if (err) {
+                                err.context = r;
                                 callback(err, nullptr);
                                 return;
                             }
                             Var<Transport> txp = Connection::make(bev,
                                     poller, logger);
                             txp->set_timeout(timeout);
-                            callback(NoError(), txp);
+                            assert(err == NoError());
+                            err.context = r;
+                            callback(err, txp);
                         },
                         poller, logger);
             return;
         }
-        Var<Transport> txp = Connection::make(r.connected_bev, poller, logger);
+        Var<Transport> txp = Connection::make(r->connected_bev, poller, logger);
         txp->set_timeout(timeout);
-        callback(NoError(), txp);
+        assert(err == NoError());
+        err.context = r;
+        callback(err, txp);
     }, timeout, poller, logger);
 }
 

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -294,7 +294,7 @@ TEST_CASE("connect() works with valid IPv4") {
         return;
     }
     loop_with_initial_event([]() {
-        connect("www.google.com", 80, [](Error e, Var<ConnectResult> r) {
+        connect_logic("www.google.com", 80, [](Error e, Var<ConnectResult> r) {
             REQUIRE(!e);
             REQUIRE(r->connected_bev != nullptr);
             ::bufferevent_free(r->connected_bev);
@@ -308,7 +308,7 @@ TEST_CASE("connect() fails when port is closed or filtered") {
         return;
     }
     loop_with_initial_event([]() {
-        connect("www.google.com", 81, [](Error e, Var<ConnectResult> r) {
+        connect_logic("www.google.com", 81, [](Error e, Var<ConnectResult> r) {
             REQUIRE(e);
             REQUIRE(r->connected_bev == nullptr);
             break_loop();

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -294,10 +294,10 @@ TEST_CASE("connect() works with valid IPv4") {
         return;
     }
     loop_with_initial_event([]() {
-        connect("www.google.com", 80, [](ConnectResult r) {
-            REQUIRE(!r.overall_error);
-            REQUIRE(r.connected_bev != nullptr);
-            ::bufferevent_free(r.connected_bev);
+        connect("www.google.com", 80, [](Error e, Var<ConnectResult> r) {
+            REQUIRE(!e);
+            REQUIRE(r->connected_bev != nullptr);
+            ::bufferevent_free(r->connected_bev);
             break_loop();
         });
     });
@@ -308,9 +308,9 @@ TEST_CASE("connect() fails when port is closed or filtered") {
         return;
     }
     loop_with_initial_event([]() {
-        connect("www.google.com", 81, [](ConnectResult r) {
-            REQUIRE(r.overall_error);
-            REQUIRE(r.connected_bev == nullptr);
+        connect("www.google.com", 81, [](Error e, Var<ConnectResult> r) {
+            REQUIRE(e);
+            REQUIRE(r->connected_bev == nullptr);
             break_loop();
         });
     });

--- a/test/net/transport.cpp
+++ b/test/net/transport.cpp
@@ -42,6 +42,12 @@ TEST_CASE("net::connect() can connect to open port") {
     loop_with_initial_event([]() {
         connect("www.kernel.org", 80, [](Error error, Var<Transport> txp) {
             REQUIRE(!error);
+            Var<ConnectResult> cr = error.context.as<ConnectResult>();
+            REQUIRE(cr);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+            REQUIRE(cr->resolve_result.addresses.size() > 0);
+            REQUIRE(cr->connected_bev);
             txp->close([]() { break_loop(); });
         });
     });
@@ -55,6 +61,12 @@ TEST_CASE("net::connect() can connect to SSL port") {
     loop_with_initial_event([]() {
         connect("nexa.polito.it", 443, [](Error error, Var<Transport> txp) {
             REQUIRE(!error);
+            Var<ConnectResult> cr = error.context.as<ConnectResult>();
+            REQUIRE(cr);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+            REQUIRE(cr->resolve_result.addresses.size() > 0);
+            REQUIRE(cr->connected_bev);
             txp->close([]() { break_loop(); });
         },
         {{"ssl", true}});
@@ -68,6 +80,12 @@ TEST_CASE("net::connect() works in case of error") {
     loop_with_initial_event([]() {
         connect("nexa.polito.it", 81, [](Error error, Var<Transport>) {
             REQUIRE(error);
+            Var<ConnectResult> cr = error.context.as<ConnectResult>();
+            REQUIRE(cr);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+            REQUIRE(cr->resolve_result.addresses.size() > 0);
+            REQUIRE(!cr->connected_bev);
             break_loop();
         }, {{"timeout", 5.0}});
     });


### PR DESCRIPTION
This diff extends the Error class to allow the programmer to add
an error context object to the class, ErrorContext.

Inside the Error, the ErrorContext class is stored using a Var
smart pointer, thus allowing up/downcasting using subclasses.

Then, teach the connect machinery to store a summary of all what
happened during the connection attempt inside the error using
the functionality described above.

Closes #28.

Output of example runs:

```
$ ./example/net/connect -p 81 www.kernel.org
Overall connect result: 1003
input was valid ipv4: 0
input was valid ipv6: 0
ipv4 resolve error: 0
ipv6 resolve error: 0
list of addresses returned:
    - 198.145.20.140
    - 199.204.44.194
    - 149.20.4.69
    - 2001:4f8:1:10:0:1991:8:25
    - 2620:3:c000:a:0:1991:8:25
errors returned by the various connects:
    - 1001
    - 1011
    - 1011
    - 1
    - 1
bufferevent address used internally: 0

$ ./example/net/connect -vp 81 130.192.91.231
Overall connect result: 1003
input was valid ipv4: 1
input was valid ipv6: 0
ipv4 resolve error: 0
ipv6 resolve error: 0
list of addresses returned:
    - 130.192.91.231
errors returned by the various connects:
    - 1011
bufferevent address used internally: 0

$ ./example/net/connect www.youtube.com
Overall connect result: 0
input was valid ipv4: 0
input was valid ipv6: 0
ipv4 resolve error: 0
ipv6 resolve error: 0
list of addresses returned:
    - 216.58.210.206
    - 2a00:1450:4006:803::200e
errors returned by the various connects:
    - 0
bufferevent address used internally: 0x2063990

$ ./example/net/connect www.youtube.cxpo
Overall connect result: 1004
input was valid ipv4: 0
input was valid ipv6: 0
ipv4 resolve error: 2002
ipv6 resolve error: 2002
list of addresses returned:
errors returned by the various connects:
bufferevent address used internally: 0

$ ./example/net/connect shelob.polito.it
Overall connect result: 1003
input was valid ipv4: 0
input was valid ipv6: 0
ipv4 resolve error: 0
ipv6 resolve error: 2010
list of addresses returned:
    - 130.192.91.211
errors returned by the various connects:
    - 1011
bufferevent address used internally: 0
```