### PR TITLE
Repair build of iOS frameworks

### DIFF
--- a/build/ios/scripts/build_arch.sh
+++ b/build/ios/scripts/build_arch.sh
@@ -12,6 +12,13 @@ ARCH=$2
 
 if [ "$PLATFORM" = "iPhoneOS" ]; then
     EXTRA_CONFIG="--host=arm-apple-darwin14 --target=arm-apple-darwin14"
+elif [ "$ARCH" = "i386" ]; then
+    EXTRA_CONFIG="--host=i386-apple-darwin14 --target=i386-apple-darwin14"
+elif [ "$ARCH" = "x86_64" ]; then
+    EXTRA_CONFIG="--host=x86_64-apple-darwin14 --target=x86_64-apple-darwin14"
+else
+    echo "$0: unsupported configuration" 1>&2
+    exit 1
 fi
 
 ROOTDIR=$(cd $(dirname $0) && pwd -P)
@@ -34,15 +41,25 @@ export CXX="/usr/bin/g++ -arch ${ARCH} -miphoneos-version-min=${MINIOSVERSION}"
 export CPPFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
 export CFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
 export CXXFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
+export LDFLAGS="-isysroot ${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer/SDKs/${PLATFORM}${SDKVERSION}.sdk"
+
+export pkg_configure_flags="$EXTRA_CONFIG"
+export pkg_prefix=$BUILDDIR/build/${PLATFORM}/${ARCH}/
+export pkg_make_flags=-j4
 
 (
     cd $SOURCEDIR
+    ./build/dependency libressl
+    ./build/dependency libevent
+    ./build/dependency jansson
+    ./build/dependency geoip
     test -x ./configure || ./autogen.sh
     ./configure -q --disable-shared \
                 --disable-examples \
-                --with-libevent=builtin \
-                --with-jansson=builtin \
-                --with-geoip=builtin \
+                --with-libevent=$BUILDDIR/build/${PLATFORM}/${ARCH}/ \
+                --with-jansson=$BUILDDIR/build/${PLATFORM}/${ARCH}/ \
+                --with-geoip=$BUILDDIR/build/${PLATFORM}/${ARCH}/ \
+                --with-openssl=$BUILDDIR/build/${PLATFORM}/${ARCH}/ \
                 --prefix=/ \
                 $EXTRA_CONFIG
     make -j4 V=0

--- a/build/ios/scripts/build_frameworks.sh
+++ b/build/ios/scripts/build_frameworks.sh
@@ -2,7 +2,7 @@
 set -e
 
 ROOTDIR=$(cd $(dirname $0) && pwd -P)
-EXTLIBRARIES="libevent libevent_pthreads libjansson geoip"
+EXTLIBRARIES="libevent libevent_pthreads libevent_openssl libjansson libcrypto libssl libGeoIP"
 
 
 (

--- a/build/spec/geoip
+++ b/build/spec/geoip
@@ -1,2 +1,7 @@
 pkg_name=geoip
 pkg_repository=https://github.com/maxmind/geoip-api-c.git
+
+# Fix for the "missing _rpl_malloc() symbol" issue when cross-linking
+# See <http://wiki.buici.com/xwiki/bin/view/Programing+C+and+C%2B%2B/Autoconf+and+RPL_MALLOC>
+export ac_cv_func_malloc_0_nonnull=yes
+export ac_cv_func_realloc_0_nonnull=yes


### PR DESCRIPTION
This is the smallest set of changes from #514 that allow to build all the dependencies, including libressl, for iOS and the iOS emulator. Detail of changes:

1. need to define EXTRA_CONFIG also when using the emulator to ensure dependencies' `./configure` knows we're cross compiling

2. forward `pkg_foo` variables for `./build/dependency`

3. call `./build/dependency` to ensure we have dependencies at the beginning of each build loop

4. tell `./configure` where dependencies are

5. make sure we create all frameworks

6. make sure we can cross compile GeoIP by setting variables that affect its `./configure`