### PR TITLE
build/spec/libressl: use latest stable version

### DIFF
--- a/build/spec/libressl
+++ b/build/spec/libressl
@@ -1,2 +1,3 @@
 pkg_name=libressl
 pkg_repository=https://github.com/libressl-portable/portable.git
+pkg_tag=v2.3.4


### PR DESCRIPTION
In general, I'd rather pick and use the latest stable version
rather than master. Starting doing that for libressl.