### PR TITLE
poller: remove obsolete code

### DIFF
--- a/include/measurement_kit/common/poller.hpp
+++ b/include/measurement_kit/common/poller.hpp
@@ -1,7 +1,6 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
 #ifndef MEASUREMENT_KIT_COMMON_POLLER_HPP
 #define MEASUREMENT_KIT_COMMON_POLLER_HPP
 
@@ -12,7 +11,6 @@
 #include <functional>
 #include <string>
 
-struct evdns_base;
 struct event_base;
 
 namespace mk {
@@ -23,8 +21,6 @@ class Poller : public NonCopyable, public NonMovable {
     ~Poller();
 
     event_base *get_event_base() { return base_; }
-
-    evdns_base *get_evdns_base() { return dnsbase_; }
 
     /// Call the function at the beginning of next I/O loop.
     /// \param cb The function to be called soon.
@@ -40,28 +36,9 @@ class Poller : public NonCopyable, public NonMovable {
 
     void loop();
 
-    // Deprecated: this function was required to implement src/common/async.cpp
-    // and after async will be rewritten this function could be removed.
     void loop_once();
 
     void break_loop();
-
-    // When /etc/resolv.conf is not found, libevent configures as
-    // resolver 127.0.0.1:53, which unfortunately is not working on
-    // Android. Hence we need the following methods to force the
-    // App to clear existing resolver and use another one:
-
-    /// Clear previosuly configured nameservers
-    void clear_nameservers();
-
-    /// Get number of configured nameservers in default resolver
-    int count_nameservers();
-
-    /// Add nameserver to the list of name-servers of the default resolver
-    /// \param address Address and optionally port (e.g. "8.8.8.8:53")
-    void add_nameserver(std::string address);
-
-    // End methods to set a different resolver on Android
 
     static Poller *global() {
         static Poller singleton;
@@ -75,7 +52,6 @@ class Poller : public NonCopyable, public NonMovable {
 
   private:
     event_base *base_;
-    evdns_base *dnsbase_;
     Libs *libs_ = get_global_libs();
     SafelyOverridableFunc<void(Poller *)> periodic_cb_;
 };
@@ -84,35 +60,15 @@ class Poller : public NonCopyable, public NonMovable {
  * Syntactic sugar:
  */
 
-inline Poller *get_global_poller(void) {
-    return (Poller::global());
-}
-
-inline event_base *get_global_event_base(void) {
-    return (Poller::global()->get_event_base());
-}
-
-inline evdns_base *get_global_evdns_base(void) {
-    return (Poller::global()->get_evdns_base());
-}
-
 inline void loop_with_initial_event(std::function<void()> cb) {
     Poller::global()->loop_with_initial_event(cb);
 }
 
-inline void loop(void) { Poller::global()->loop(); }
+inline void loop() { Poller::global()->loop(); }
 
-inline void loop_once(void) { Poller::global()->loop_once(); }
+inline void loop_once() { Poller::global()->loop_once(); }
 
-inline void break_loop(void) { Poller::global()->break_loop(); }
-
-inline void clear_nameservers() { Poller::global()->clear_nameservers(); }
-
-inline int count_nameservers() { return Poller::global()->count_nameservers(); }
-
-inline void add_nameserver(std::string address) {
-    Poller::global()->add_nameserver(address);
-}
+inline void break_loop() { Poller::global()->break_loop(); }
 
 } // namespace mk
 #endif

--- a/include/measurement_kit/dns/dns.hpp
+++ b/include/measurement_kit/dns/dns.hpp
@@ -303,7 +303,7 @@ class Message {
 void query(QueryClass dns_class, QueryType dns_type, std::string name,
            Callback<Message> func,
            Settings settings = {},
-           Poller *poller = mk::get_global_poller());
+           Poller *poller = Poller::global());
 
 } // namespace dns
 } // namespace mk

--- a/include/measurement_kit/traceroute/android.hpp
+++ b/include/measurement_kit/traceroute/android.hpp
@@ -70,7 +70,7 @@ class AndroidProber : public NonCopyable,
     /// \param evbase Event base to use (optional)
     AndroidProber(
         bool use_ipv4, int port,
-        event_base *evbase = mk::get_global_event_base(),
+        event_base *evbase = Poller::global()->get_event_base(),
         Logger *logger = Logger::global());
 
     /// Destructor

--- a/include/measurement_kit/traceroute/interface.hpp
+++ b/include/measurement_kit/traceroute/interface.hpp
@@ -136,7 +136,7 @@ template <class Impl> class Prober : public ProberInterface {
     /// \param evbase Event base to use (optional)
     /// \throws Exception on error
     Prober(bool use_ipv4, int port,
-           event_base *evbase = mk::get_global_event_base()) {
+           event_base *evbase = Poller::global()->get_event_base()) {
         impl_.reset(new Impl(use_ipv4, port, evbase));
     }
 

--- a/src/dns/query.hpp
+++ b/src/dns/query.hpp
@@ -58,7 +58,7 @@ class QueryContext : public NonMovable, public NonCopyable {
 template <MK_MOCK(evdns_base_new), MK_MOCK(evdns_base_nameserver_ip_add),
         MK_MOCK(evdns_base_free), MK_MOCK(evdns_base_set_option)>
 static inline evdns_base *create_evdns_base(
-        Settings settings, Poller *poller = mk::get_global_poller()) {
+        Settings settings, Poller *poller = Poller::global()) {
 
     evdns_base *base;
     event_base *evb = poller->get_event_base();

--- a/src/net/listen.hpp
+++ b/src/net/listen.hpp
@@ -35,8 +35,8 @@ inline void listen4(std::string address, int port, ListenCb cb) {
     }
 
     auto cbp = new ListenInternalCb([cb](evutil_socket_t so) {
-        bufferevent *bev = bufferevent_socket_new(get_global_event_base(),
-                so, BEV_OPT_CLOSE_ON_FREE);
+        bufferevent *bev = bufferevent_socket_new(
+                Poller::global()->get_event_base(), so, BEV_OPT_CLOSE_ON_FREE);
         if (bev == nullptr) {
             (void)evutil_closesocket(so);
             return;
@@ -46,7 +46,8 @@ inline void listen4(std::string address, int port, ListenCb cb) {
 
     // Note: the listener is never freed and hence Valgrind is probably
     // going to complain that we have a memory leak here.
-    evconnlistener *sl = evconnlistener_new_bind(get_global_event_base(),
+    evconnlistener *sl = evconnlistener_new_bind(
+            Poller::global()->get_event_base(),
             mk_listener_cb, cbp, LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1,
             (sockaddr *)&storage, salen);
     if (sl == nullptr) {

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -62,7 +62,7 @@ BASE_FREE(evdns_set_options_randomize)
 
 TEST_CASE("throw error while fails evdns_base_new") {
     REQUIRE_THROWS_AS(
-        create_evdns_base<null_evdns_base_new>({}, get_global_poller()),
+        create_evdns_base<null_evdns_base_new>({}, Poller::global()),
         std::bad_alloc);
 }
 
@@ -70,7 +70,7 @@ TEST_CASE("throw error while fails evdns_base_nameserver_ip_add") {
     try {
         create_evdns_base<::evdns_base_new, null_evdns_base_nameserver_ip_add,
             base_free_evdns_base_nameserver_ip_add>(
-            {{"dns/nameserver", "nexa"}}, get_global_poller());
+            {{"dns/nameserver", "nexa"}}, Poller::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_base_nameserver_ip_add_flag);
         return;
@@ -82,7 +82,7 @@ TEST_CASE("throw error while fails evdns_base_nameserver_ip_add and base_new") {
     try {
         create_evdns_base<null_evdns_base_new,
             null_evdns_base_nameserver_ip_add>(
-            {{"dns/nameserver", "nexa"}}, get_global_poller());
+            {{"dns/nameserver", "nexa"}}, Poller::global());
     } catch (std::bad_alloc &) {
         return;
     }
@@ -93,7 +93,7 @@ TEST_CASE("throw error while fails evdns_set_options for attempts") {
     try {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
             base_free_evdns_set_options_attempts>(
-            {{"dns/attempts", "nexa"}}, get_global_poller());
+            {{"dns/attempts", "nexa"}}, Poller::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_attempts_flag);
         return;
@@ -105,7 +105,7 @@ TEST_CASE("throw error while fails evdns_set_options for negative attempts") {
     try {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
             base_free_evdns_set_options_attempts_negative>(
-            {{"dns/attempts", -1}}, get_global_poller());
+            {{"dns/attempts", -1}}, Poller::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_attempts_negative_flag);
         return;
@@ -118,7 +118,7 @@ TEST_CASE("throw error while fails evdns_set_options for randomize-case") {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
             base_free_evdns_set_options_randomize,
             null_evdns_base_set_option_randomize>(
-            {{"dns/randomize_case", ""}}, get_global_poller());
+            {{"dns/randomize_case", ""}}, Poller::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_randomize_flag);
         return;
@@ -144,7 +144,7 @@ TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv4") {
     }
     query_debug<::evdns_base_free, null_resolver>("IN", "A", "www.google.com",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
-        get_global_poller());
+        Poller::global());
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv6") {
@@ -154,7 +154,7 @@ TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv6") {
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4, null_resolver>(
         "IN", "AAAA", "github.com",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
-        get_global_poller());
+        Poller::global());
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse") {
@@ -164,7 +164,7 @@ TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse") {
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
         ::evdns_base_resolve_ipv6, null_resolver_reverse>("IN", "REVERSE_A",
         "8.8.8.8", [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
-        get_global_poller());
+        Poller::global());
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse_ipv6") {
@@ -175,7 +175,7 @@ TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse_ipv6") {
         ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
         null_resolver_reverse>("IN", "REVERSE_AAAA", "::1",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
-        get_global_poller());
+        Poller::global());
 }
 
 TEST_CASE("dns::query deals with inet_pton returning 0") {
@@ -184,14 +184,14 @@ TEST_CASE("dns::query deals with inet_pton returning 0") {
         ::evdns_base_resolve_reverse_ipv6, null_inet_pton>("IN", "REVERSE_A",
         "8.8.8.8",
         [](Error e, Message) { REQUIRE(e == InvalidIPv4AddressError()); }, {},
-        get_global_poller());
+        Poller::global());
 
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
         ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
         ::evdns_base_resolve_reverse_ipv6, null_inet_pton>("IN", "REVERSE_AAAA",
         "::1",
         [](Error e, Message) { REQUIRE(e == InvalidIPv6AddressError()); }, {},
-        get_global_poller());
+        Poller::global());
 }
 
 TEST_CASE("dns::query raises if the query is unsupported") {


### PR DESCRIPTION
1) remove get_global_xxx() syntactic sugar

2) remove the evdns_base bound with the poller since now we always
   use a custom evdns_base when we do dns requests

3) undeprecate loop_once(): we are not going to rewrite async
   to use an always on thread anytime soon