### PR TITLE
Improve logger implementation

### DIFF
--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -4,10 +4,9 @@
 #ifndef MEASUREMENT_KIT_COMMON_LOGGER_HPP
 #define MEASUREMENT_KIT_COMMON_LOGGER_HPP
 
+#include <functional>
 #include <measurement_kit/common/constraints.hpp>
 #include <measurement_kit/common/funcs.hpp>
-
-#include <functional>
 #include <stdarg.h>
 
 namespace mk {
@@ -21,34 +20,13 @@ class Logger : public NonCopyable, public NonMovable {
     void logv(const char *, va_list) __attribute__((format(printf, 2, 0)));
 
     /// Log warning message
-    void warn(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
-        if (verbose_ >= 0) {
-            va_list ap;
-            va_start(ap, fmt);
-            logv(fmt, ap);
-            va_end(ap);
-        }
-    }
+    void warn(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
     /// Log info message
-    void info(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
-        if (verbose_ > 0) {
-            va_list ap;
-            va_start(ap, fmt);
-            logv(fmt, ap);
-            va_end(ap);
-        }
-    }
+    void info(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
     /// Log debug message
-    void debug(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
-        if (verbose_ > 0) {
-            va_list ap;
-            va_start(ap, fmt);
-            logv(fmt, ap);
-            va_end(ap);
-        }
-    }
+    void debug(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
     void set_verbose(int v) { verbose_ = v; } ///< Set logger verbose
 
@@ -69,39 +47,9 @@ class Logger : public NonCopyable, public NonMovable {
     char buffer_[32768];
 };
 
-inline void warn(const char *, ...) __attribute__((format(printf, 1, 2)));
-inline void debug(const char *, ...) __attribute__((format(printf, 1, 2)));
-inline void info(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-inline void warn(const char *fmt, ...) {
-    auto logger = Logger::global();
-    if (logger->get_verbose() >= 0) {
-        va_list ap;
-        va_start(ap, fmt);
-        logger->logv(fmt, ap);
-        va_end(ap);
-    }
-}
-
-inline void info(const char *fmt, ...) {
-    auto logger = Logger::global();
-    if (logger->get_verbose() > 0) {
-        va_list ap;
-        va_start(ap, fmt);
-        logger->logv(fmt, ap);
-        va_end(ap);
-    }
-}
-
-inline void debug(const char *fmt, ...) {
-    auto logger = Logger::global();
-    if (logger->get_verbose() > 0) {
-        va_list ap;
-        va_start(ap, fmt);
-        logger->logv(fmt, ap);
-        va_end(ap);
-    }
-}
+void warn(const char *, ...) __attribute__((format(printf, 1, 2)));
+void debug(const char *, ...) __attribute__((format(printf, 1, 2)));
+void info(const char *, ...) __attribute__((format(printf, 1, 2)));
 
 inline void set_verbose(int v) { Logger::global()->set_verbose(v); }
 

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -3,7 +3,6 @@
 // information on the copying conditions.
 
 #include <measurement_kit/common/logger.hpp>
-
 #include <stdio.h>
 
 namespace mk {
@@ -21,5 +20,23 @@ void Logger::logv(const char *fmt, va_list ap) {
     if (res < 0 || (unsigned int)res >= sizeof(buffer_)) return;
     consumer_(buffer_);
 }
+
+#define XX(_logger_, _level_)                                                  \
+    if (_logger_->get_verbose() >= _level_) {                                  \
+        va_list ap;                                                            \
+        va_start(ap, fmt);                                                     \
+        _logger_->logv(_level_, fmt, ap);                                      \
+        va_end(ap);                                                            \
+    }
+
+void Logger::warn(const char *fmt, ...) { XX(this, 0); }
+void Logger::info(const char *fmt, ...) { XX(this, 1); }
+void Logger::debug(const char *fmt, ...) { XX(this, 1); }
+
+void warn(const char *fmt, ...) { XX(Logger::global(), 0); }
+void info(const char *fmt, ...) { XX(Logger::global(), 1); }
+void debug(const char *fmt, ...) { XX(Logger::global(), 1); }
+
+#undef XX
 
 } // namespace mk

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -25,7 +25,7 @@ void Logger::logv(const char *fmt, va_list ap) {
     if (_logger_->get_verbose() >= _level_) {                                  \
         va_list ap;                                                            \
         va_start(ap, fmt);                                                     \
-        _logger_->logv(_level_, fmt, ap);                                      \
+        _logger_->logv(fmt, ap);                                               \
         va_end(ap);                                                            \
     }
 


### PR DESCRIPTION
1) do not inline log functions because they're not so short

2) use macros to reduce implementation redundancy