### PR TITLE
Reactor: add background reactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ test/common/error_or
 test/common/funcs
 test/common/log
 test/common/poller
+test/common/reactor
 test/common/settings
 test/common/utils
 test/common/var

--- a/include/measurement_kit/common/reactor.hpp
+++ b/include/measurement_kit/common/reactor.hpp
@@ -14,6 +14,7 @@ namespace mk {
 class Reactor {
   public:
     static Var<Reactor> make();
+    static Var<Reactor> make_detached();
     virtual ~Reactor() {}
 
     virtual void call_soon(std::function<void()> cb) = 0;
@@ -30,6 +31,8 @@ class Reactor {
         static Var<Reactor> singleton = make();
         return singleton;
     }
+
+    static Var<Reactor> global_detached();
 };
 
 inline void loop_with_initial_event(std::function<void()> cb) {

--- a/src/common/reactor.cpp
+++ b/src/common/reactor.cpp
@@ -2,11 +2,42 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#include <measurement_kit/common.hpp>
 #include "src/common/poller.hpp"
+#include <condition_variable>
+#include <measurement_kit/common.hpp>
+#include <mutex>
+#include <thread>
 
 namespace mk {
 
 /*static*/ Var<Reactor> Reactor::make() { return Var<Reactor>(new Poller); }
+
+/*static*/ Var<Reactor> Reactor::make_detached() {
+    Var<Reactor> reactor = make();
+    std::mutex mutex;
+    std::unique_lock<std::mutex> lock(mutex);
+    std::condition_variable condition;
+    debug("starting reactor in background thread...");
+    std::thread thread([&condition, &lock, &mutex, reactor]() {
+        reactor->loop_with_initial_event([&condition]() {
+            debug("starting reactor in background thread... thread running");
+            condition.notify_all();
+        });
+    });
+    condition.wait(lock);
+    thread.detach();
+    debug("starting reactor in background thread... done");
+    return reactor;
+}
+
+/*static*/ Var<Reactor> Reactor::global_detached() {
+    static Var<Reactor> singleton;
+    if (!singleton) {
+        // We only create the detached reactor on first request otherwise
+        // a thread would always be created even if not used at all
+        singleton = make_detached();
+    }
+    return singleton;
+}
 
 } // namespace mk

--- a/test/common/reactor.cpp
+++ b/test/common/reactor.cpp
@@ -73,4 +73,11 @@ TEST_CASE("The detached reactor works") {
     while (count > 0) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
+
+    // Break the loop to terminate background thread and wait one more
+    // second such that the thread actually terminates. Strictly speaking,
+    // this code would not be needed, but not terminating the background
+    // thread properly makes Valgrind complain.
+    reactor->break_loop();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 }

--- a/test/common/reactor.cpp
+++ b/test/common/reactor.cpp
@@ -6,6 +6,7 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include "src/common/check_connectivity.hpp"
+#include <atomic>
 #include <chrono>
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/dns.hpp>

--- a/test/common/reactor.cpp
+++ b/test/common/reactor.cpp
@@ -1,0 +1,75 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "src/ext/Catch/single_include/catch.hpp"
+
+#include "src/common/check_connectivity.hpp"
+#include <chrono>
+#include <measurement_kit/common.hpp>
+#include <measurement_kit/dns.hpp>
+#include <measurement_kit/http.hpp>
+#include <measurement_kit/net.hpp>
+#include <thread>
+
+using namespace mk;
+
+TEST_CASE("The detached reactor works") {
+    if (CheckConnectivity::is_down()) {
+        return;
+    }
+
+    // Here we just do some concurrent networking in the background thread
+    // coupled with some REQUIRE:s to show this can be done.
+
+    set_verbose(1);
+    Var<Reactor> reactor = Reactor::global_detached();
+    std::atomic<int> count{5};
+
+    dns::query("IN", "A", "nexa.polito.it",
+               [&count](Error err, dns::Message msg) {
+                   REQUIRE(!err);
+                   REQUIRE(msg.answers.size() == 1);
+                   REQUIRE(msg.answers[0].ipv4 == "130.192.16.172");
+                   --count;
+               },
+               {}, reactor);
+
+    dns::query("IN", "A", "img.polito.it",
+               [&count](Error err, dns::Message msg) {
+                   REQUIRE(!err);
+                   REQUIRE(msg.answers.size() == 1);
+                   REQUIRE(msg.answers[0].ipv4 == "130.192.225.140");
+                   --count;
+               },
+               {}, reactor);
+
+    dns::query("IN", "A", "www.polito.it",
+               [&count](Error err, dns::Message msg) {
+                   REQUIRE(!err);
+                   REQUIRE(msg.answers.size() == 1);
+                   REQUIRE(msg.answers[0].ipv4 == "130.192.181.193");
+                   --count;
+               },
+               {}, reactor);
+
+    http::get("http://google.com/robots.txt",
+              [&count](Error err, http::Response r) {
+                  REQUIRE(!err);
+                  REQUIRE(r.status_code == 301);
+                  --count;
+              },
+              {}, "", {}, Logger::global(), reactor);
+
+    net::connect("ooni.torproject.org", 80,
+                 [&count](Error err, Var<net::Transport> txp) {
+                     REQUIRE(!err);
+                     txp->close([&count]() { --count; });
+                 },
+                 {}, Logger::global(), reactor);
+
+    while (count > 0) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}


### PR DESCRIPTION
This new functionality should make the code in Async unnecessary
because it provides the same features with less code and complexity.

Here I have just added a test showing how simple it is to run
things in the background. More work needed to replace Async.

- - -

This pull request should be tested and reviewed carefully, because it
contains possible breaking changes.

This pull request supersedes #390, which however I would like to
keep open until we've made progresses with removing Async.