### PR TITLE
utils: change split to return a list

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -268,7 +268,7 @@ std::string unreverse_ipv4(std::string s) {
 }
 
 // See <http://stackoverflow.com/questions/9435385/>
-std::vector<std::string> split(std::string s) {
+std::list<std::string> split(std::string s) {
     // passing -1 as the submatch index parameter performs splitting
     std::regex re{"\\s+"};
     std::sregex_token_iterator

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -5,10 +5,10 @@
 #define SRC_COMMON_UTILS_HPP
 
 #include <event2/util.h>
+#include <list>
 #include <stddef.h>
 #include <string>
 #include <unistd.h>
-#include <vector>
 
 struct sockaddr_storage;
 struct timeval;
@@ -36,7 +36,7 @@ std::string random_str_uppercase(size_t length);
 std::string unreverse_ipv6(std::string s);
 std::string unreverse_ipv4(std::string s);
 
-std::vector<std::string> split(std::string s);
+std::list<std::string> split(std::string s);
 
 } // namespace mk
 #endif

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -123,7 +123,7 @@ TEST_CASE("Verify that invalid input is rejected") {
 }
 
 TEST_CASE("split(std::string s) works properly") {
-    REQUIRE((mk::split(" 34    43  17 11 ") == std::vector<std::string>{
+    REQUIRE((mk::split(" 34    43  17 11 ") == std::list<std::string>{
                 {"", "34", "43", "17", "11"}
             }));
 }


### PR DESCRIPTION
A list is more practical given that we are going to remove
from the front of the list inside of NDT code.