### PR TITLE
poller: use sigaction() rather than signal()

### DIFF
--- a/src/common/poller.hpp
+++ b/src/common/poller.hpp
@@ -6,6 +6,7 @@
 
 #include "src/common/utils.hpp"
 #include <csignal>
+#include <cstring>
 #include <event2/event.h>
 #include <event2/thread.h>
 #include <functional>


### PR DESCRIPTION
sigaction() is the correct function to invoke, signal() is the obsolete interface