### PR TITLE
Use macros to define errors

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -51,7 +51,7 @@ class Error : public std::exception {
         _name_() : Error(_code_, _ooe_) {}                                     \
     };
 
-MK_DEFINE_ERR(0, NoError, "success")
+MK_DEFINE_ERR(0, NoError, "")
 MK_DEFINE_ERR(1, GenericError, "unknown_failure 1")
 MK_DEFINE_ERR(2, NotInitializedError, "unknown_failure 2")
 MK_DEFINE_ERR(3, ValueError, "unknown_failure 3")

--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -6,8 +6,8 @@
 #define MEASUREMENT_KIT_COMMON_ERROR_HPP
 
 #include <exception>
-#include <measurement_kit/common/var.hpp>
 #include <iosfwd>
+#include <measurement_kit/common/var.hpp>
 #include <string>
 
 namespace mk {
@@ -45,29 +45,16 @@ class Error : public std::exception {
     std::string ooni_error_;
 };
 
-/// No error
-class NoError : public Error {
-  public:
-    NoError() : Error() {} ///< Default constructor
-};
+#define MK_DEFINE_ERR(_code_, _name_, _ooe_)                                   \
+    class _name_ : public Error {                                              \
+      public:                                                                  \
+        _name_() : Error(_code_, _ooe_) {}                                     \
+    };
 
-/// Generic error
-class GenericError : public Error {
-  public:
-    GenericError() : Error(1, "unknown_failure 1") {} ///< Default constructor
-};
-
-/// Not initialized error
-class NotInitializedError : public Error {
-  public:
-    NotInitializedError() : Error(2, "unknown_failure 2") {}
-};
-
-/// Value error
-class ValueError : public Error {
-  public:
-    ValueError() : Error(3, "unknown_failure 3") {}
-};
+MK_DEFINE_ERR(0, NoError, "success")
+MK_DEFINE_ERR(1, GenericError, "unknown_failure 1")
+MK_DEFINE_ERR(2, NotInitializedError, "unknown_failure 2")
+MK_DEFINE_ERR(3, ValueError, "unknown_failure 3")
 
 } // namespace mk
 #endif

--- a/include/measurement_kit/dns/dns.hpp
+++ b/include/measurement_kit/dns/dns.hpp
@@ -16,113 +16,23 @@ namespace mk {
 
 namespace dns {
 
-/// Format error
-class FormatError : public Error {
-  public:
-    /// Default constructor
-    FormatError() : Error(2000, "dns_lookup_error") {}
-};
-
-/// Server failed error
-class ServerFailedError : public Error {
-  public:
-    /// Default constructor
-    ServerFailedError() : Error(2001, "dns_lookup_error") {}
-};
-
-/// Not exist error
-class NotExistError : public Error {
-  public:
-    /// Default constructor
-    NotExistError() : Error(2002, "dns_lookup_error") {}
-};
-
-/// Not implemented error
-class NotImplementedError : public Error {
-  public:
-    /// Default constructor
-    NotImplementedError() : Error(2003, "dns_lookup_error") {}
-};
-
-/// Refused error
-class RefusedError : public Error {
-  public:
-    /// Default constructor
-    RefusedError() : Error(2004, "dns_lookup_error") {}
-};
-
-/// Truncated error
-class TruncatedError : public Error {
-  public:
-    /// Default constructor
-    TruncatedError() : Error(2005, "dns_lookup_error") {}
-};
-
-/// Uknown error
-class UnknownError : public Error {
-  public:
-    UnknownError() : Error(2006, "unknown_failure 2006") {}
-};
-
-/// Timeout error
-class TimeoutError : public Error {
-  public:
-    TimeoutError() : Error(2007, "generic_timeout_error") {}
-};
-
-/// Shutdown error
-class ShutdownError : public Error {
-  public:
-    ShutdownError() : Error(2008, "unknown_failure 2008") {}
-};
-
-/// Cancel error
-class CancelError : public Error {
-  public:
-    CancelError() : Error(2009, "unknown_failure 2009") {}
-};
-
-/// No data error
-class NoDataError : public Error {
-  public:
-    NoDataError() : Error(2010, "dns_lookup_error") {}
-};
-
-/// Invalid IPv4 error
-class InvalidIPv4AddressError : public Error {
-  public:
-    InvalidIPv4AddressError() : Error(2011, "unknown_failure 2011") {}
-};
-
-/// Invalid IPv6 error
-class InvalidIPv6AddressError : public Error {
-  public:
-    InvalidIPv6AddressError() : Error(2012, "unknown_failure 2012") {}
-};
-
-/// Unsupported class error
-class UnsupportedClassError : public Error {
-  public:
-    UnsupportedClassError() : Error(2013, "unknown_failure 2013") {}
-};
-
-/// Invalid name for PTR query error
-class InvalidNameForPTRError : public Error {
-  public:
-    InvalidNameForPTRError() : Error(2014, "unknown_failure 2014") {}
-};
-
-/// Resolver error
-class ResolverError : public Error {
-  public:
-    ResolverError() : Error(2015, "unknown_failure 2015") {}
-};
-
-/// Unsupported type error
-class UnsupportedTypeError : public Error {
-  public:
-    UnsupportedTypeError() : Error(2016, "unknown_failure 2016") {}
-};
+MK_DEFINE_ERR(2000, FormatError, "dns_lookup_error")
+MK_DEFINE_ERR(2001, ServerFailedError, "dns_lookup_error")
+MK_DEFINE_ERR(2002, NotExistError, "dns_lookup_error")
+MK_DEFINE_ERR(2003, NotImplementedError, "dns_lookup_error")
+MK_DEFINE_ERR(2004, RefusedError, "dns_lookup_error")
+MK_DEFINE_ERR(2005, TruncatedError, "dns_lookup_error")
+MK_DEFINE_ERR(2006, UnknownError, "unknown_failure 2006")
+MK_DEFINE_ERR(2007, TimeoutError, "generic_timeout_error")
+MK_DEFINE_ERR(2008, ShutdownError, "unknown_failure 2008")
+MK_DEFINE_ERR(2009, CancelError, "unknown_failure 2009")
+MK_DEFINE_ERR(2010, NoDataError, "dns_lookup_error")
+MK_DEFINE_ERR(2011, InvalidIPv4AddressError, "unknown_failure 2011")
+MK_DEFINE_ERR(2012, InvalidIPv6AddressError, "unknown_failure 2012")
+MK_DEFINE_ERR(2013, UnsupportedClassError, "unknown_failure 2013")
+MK_DEFINE_ERR(2014, InvalidNameForPTRError, "unknown_failure 2014")
+MK_DEFINE_ERR(2015, ResolverError, "unknown_failure 2015")
+MK_DEFINE_ERR(2016, UnsupportedTypeError, "unknown_failure 2016")
 
 Error dns_error(int code); ///< Map evdns code to proper error
 

--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -14,40 +14,12 @@
 namespace mk {
 namespace http {
 
-/// Received UPGRADE request error.
-class UpgradeError : public Error {
-  public:
-    UpgradeError (): Error(3000, "unknown_error 3000") {};
-};
-
-/// Parse error occurred.
-class ParserError : public Error {
-  public:
-    ParserError() : Error(3001, "unknown_error 3001") {};
-};
-
-/// Url Parse error occurred.
-class UrlParserError : public Error {
-  public:
-    UrlParserError() : Error(3002, "unknown_error 3002") {};
-};
-
-/// Missing Url Schema error occurred.
-class MissingUrlSchemaError : public Error {
-  public:
-    MissingUrlSchemaError() : Error(3003, "unknown_error 3003") {};
-};
-
-/// Missing Url Host error occurred.
-class MissingUrlHostError : public Error {
-  public:
-    MissingUrlHostError() : Error(3004, "unknown_error 3004") {};
-};
-
-class MissingUrlError : public Error {
-  public:
-    MissingUrlError() : Error(3005, "unknown_error 3005") {};
-};
+MK_DEFINE_ERR(3000, UpgradeError, "unknown_error 3000")
+MK_DEFINE_ERR(3001, ParserError, "unknown_error 3001")
+MK_DEFINE_ERR(3002, UrlParserError, "unknown_error 3002")
+MK_DEFINE_ERR(3003, MissingUrlSchemaError, "unknown_error 3003")
+MK_DEFINE_ERR(3004, MissingUrlHostError, "unknown_error 3004")
+MK_DEFINE_ERR(3005, MissingUrlError, "unknown_error 3005")
 
 /// HTTP headers.
 typedef std::map<std::string, std::string> Headers;

--- a/include/measurement_kit/mlabns/mlabns.hpp
+++ b/include/measurement_kit/mlabns/mlabns.hpp
@@ -15,47 +15,12 @@
 namespace mk {
 namespace mlabns {
 
-/// Invalid mlab-ns policy error
-class InvalidPolicyError : public Error {
-  public:
-    /// Default constructor
-    InvalidPolicyError() : Error(5000, "unknown_failure 5000") {}
-};
-
-/// Invalid mlab-ns address-family error
-class InvalidAddressFamilyError : public Error {
-  public:
-    /// Default constructor
-    InvalidAddressFamilyError() : Error(5001, "unknown_failure 5001") {}
-};
-
-/// Invalid mlab-ns metro error
-class InvalidMetroError : public Error {
-  public:
-    /// Default constructor
-    InvalidMetroError() : Error(5002, "unknown_failure 5002") {}
-};
-
-/// Invalid mlab-ns tool name error
-class InvalidToolNameError : public Error {
-  public:
-    /// Default constructor
-    InvalidToolNameError() : Error(5003, "unknown_failure 5003") {}
-};
-
-/// Invalid mlab-ns HTTP status code error
-class UnexpectedHttpStatusCodeError : public Error {
-  public:
-    /// Default constructor
-    UnexpectedHttpStatusCodeError() : Error(5004, "unknown_failure 5004") {}
-};
-
-/// Invalid mlab-ns JSON error
-class JsonParsingError : public Error {
-  public:
-    /// Default constructor
-    JsonParsingError() : Error(5005, "unknown_failure 5005") {}
-};
+MK_DEFINE_ERR(5000, InvalidPolicyError, "unknown_failure 5000")
+MK_DEFINE_ERR(5001, InvalidAddressFamilyError, "unknown_failure 5001")
+MK_DEFINE_ERR(5002, InvalidMetroError, "unknown_failure 5002")
+MK_DEFINE_ERR(5003, InvalidToolNameError, "unknown_failure 5003")
+MK_DEFINE_ERR(5004, UnexpectedHttpStatusCodeError, "unknown_failure 5004")
+MK_DEFINE_ERR(5005, JsonParsingError, "unknown_failure 5005")
 
 /// Reply to mlab-ns query.
 class Reply {

--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -10,149 +10,42 @@
 namespace mk {
 namespace net {
 
-/// EOF error
-class EofError : public Error {
-  public:
-    /// Default constructor
-    EofError() : Error(1000, "unknown_failure 1000") {}
-};
-
-/// Timeout error
-class TimeoutError : public Error {
-  public:
-    /// Default constructor
-    TimeoutError() : Error(1001, "generic_timeout_error") {}
-};
-
-/// Socket error
-class SocketError : public Error {
-  public:
-    /// Default constructor
-    SocketError() : Error(1002, "unknown_failure 1002") {}
-};
-
-/// Connect failed error
-class ConnectFailedError : public Error {
-  public:
-    /// Default constructor
-    ConnectFailedError() : Error(1003, "unknown_failure 1003") {}
-};
-
-/// DNS generic error
-class DnsGenericError : public Error {
-  public:
-    /// Default constructor
-    DnsGenericError() : Error(1004, "unknown_failure 1004") {}
-};
-
-/// Bad SOCKS version error
-class BadSocksVersionError : public Error {
-  public:
-    /// Default constructor
-    BadSocksVersionError() : Error(1005, "socks_error") {}
-};
-
-/// SOCKS address too long
-class SocksAddressTooLongError : public Error {
-  public:
-    SocksAddressTooLongError() : Error(1006, "unknown_failure 1006") {}
-};
-
-/// SOCKS invalid port
-class SocksInvalidPortError : public Error {
-  public:
-    SocksInvalidPortError() : Error(1007, "unknown_failure 1007") {}
-};
-
-/// SOCKS generic error
-class SocksGenericError : public Error {
-  public:
-    SocksGenericError() : Error(1008, "socks_error") {}
-};
-
-/// EOL not found error
-class EOLNotFoundError : public Error {
-  public:
-    EOLNotFoundError() : Error(1009, "unknown_failure 1009") {}
-};
-
-/// Line too long error
-class LineTooLongError : public Error {
-  public:
-    LineTooLongError() : Error(1010, "unknown_failure 1010") {}
-};
-
-/// Generic network error
-class NetworkError : public Error {
-  public:
-    NetworkError() : Error(1011, "unknown_failure 1011") {}
-};
-
-class NoAvailableSocksAuthenticationError : public Error {
-  public:
-    NoAvailableSocksAuthenticationError()
-            : Error(1012, "unknown_failure 1012") {}
-};
-
-class SocksError : public Error {
-  public:
-    SocksError() : Error(1013, "unknown_failure 1013") {}
-};
-
-class BadSocksReservedFieldError : public Error {
-  public:
-    BadSocksReservedFieldError() : Error(1014, "unknown_failure 1014") {}
-};
-
-class BadSocksAtypeValueError : public Error {
-  public:
-    BadSocksAtypeValueError() : Error(1015, "unknown_failure 1015") {}
-};
-
-class EvconnlistenerNewBindError : public Error {
-  public:
-    EvconnlistenerNewBindError() : Error(1016, "unknown_failure 1016") {}
-};
-
-class BuffereventSocketNewError : public Error {
-  public:
-    BuffereventSocketNewError() : Error(1017, "unknown_failure 1017") {}
-};
+MK_DEFINE_ERR(1000, EofError, "unknown_failure 1000")
+MK_DEFINE_ERR(1001, TimeoutError, "generic_timeout_error")
+MK_DEFINE_ERR(1002, SocketError, "unknown_failure 1002")
+MK_DEFINE_ERR(1003, ConnectFailedError, "unknown_failure 1003")
+MK_DEFINE_ERR(1004, DnsGenericError, "unknown_failure 1004")
+MK_DEFINE_ERR(1005, BadSocksVersionError, "socks_error")
+MK_DEFINE_ERR(1006, SocksAddressTooLongError, "unknown_failure 1006")
+MK_DEFINE_ERR(1007, SocksInvalidPortError, "unknown_failure 1007")
+MK_DEFINE_ERR(1008, SocksGenericError, "socks_error")
+MK_DEFINE_ERR(1009, EOLNotFoundError, "unknown_failure 1009")
+MK_DEFINE_ERR(1010, LineTooLongError, "unknown_failure 1010")
+MK_DEFINE_ERR(1011, NetworkError, "unknown_failure 1011")
+MK_DEFINE_ERR(1012, NoAvailableSocksAuthenticationError, "unknown_failure 1012")
+MK_DEFINE_ERR(1013, SocksError, "unknown_failure 1013")
+MK_DEFINE_ERR(1014, BadSocksReservedFieldError, "unknown_failure 1014")
+MK_DEFINE_ERR(1015, BadSocksAtypeValueError, "unknown_failure 1015")
+MK_DEFINE_ERR(1016, EvconnlistenerNewBindError, "unknown_failure 1016")
+MK_DEFINE_ERR(1017, BuffereventSocketNewError, "unknown_failure 1017")
 
 class SSLInvalidCertificateError : public Error {
-    public:
-        SSLInvalidCertificateError(std::string msg) : Error(1018, "ssl_invalid_certificate " + msg) {}
+  public:
+    SSLInvalidCertificateError(std::string msg)
+        : Error(1018, "ssl_invalid_certificate " + msg) {}
 };
 
-class SSLNoCertificateError : public Error {
-    public:
-        SSLNoCertificateError() : Error(1019, "ssl_no_certificate") {}
-};
-
-class SSLInvalidHostnameError : public Error {
-    public:
-        SSLInvalidHostnameError() : Error(1020, "ssl_invalid_hostname") {}
-};
+MK_DEFINE_ERR(1019, SSLNoCertificateError, "ssl_no_certificate")
+MK_DEFINE_ERR(1020, SSLInvalidHostnameError, "ssl_invalid_hostname")
 
 class SSLError : public Error {
-    public:
-        SSLError(std::string msg) : Error(1021, "ssl_error " + msg) {}
+  public:
+    SSLError(std::string msg) : Error(1021, "ssl_error " + msg) {}
 };
 
-class NotEnoughDataError : public Error {
-  public:
-    NotEnoughDataError() : Error(1022, "unknown_failure 1022") {}
-};
-
-class MissingCaBundlePathError : public Error {
-  public:
-    MissingCaBundlePathError() : Error(1023, "unknown_failure 1023") {}
-};
-
-class BrokenPipeError : public Error {
-  public:
-    BrokenPipeError() : Error(1024, "unknown_failure 1024") {}
-};
+MK_DEFINE_ERR(1022, NotEnoughDataError, "unknown_failure 1022")
+MK_DEFINE_ERR(1023, MissingCaBundlePathError, "unknown_failure 1023")
+MK_DEFINE_ERR(1024, BrokenPipeError, "unknown_failure 1024")
 
 } // namespace net
 } // namespace mk

--- a/include/measurement_kit/traceroute/error.hpp
+++ b/include/measurement_kit/traceroute/error.hpp
@@ -10,87 +10,18 @@
 namespace mk {
 namespace traceroute {
 
-/// Socket create error
-class SocketCreateError : public Error {
-  public:
-    /// Default constructor
-    SocketCreateError() : Error(4000, "unknown_failure 4000") {}
-};
-
-/// Setsockopt error
-class SetsockoptError : public Error {
-  public:
-    /// Default constructor
-    SetsockoptError() : Error(4001, "unknown_failure 4001") {}
-};
-
-/// Probe already pending error
-class ProbeAlreadyPendingError : public Error {
-  public:
-    /// Default constructor
-    ProbeAlreadyPendingError() : Error(4002, "unknown_failure 4002") {}
-};
-
-/// Payload too long error
-class PayloadTooLongError : public Error {
-  public:
-    /// Default constructor
-    PayloadTooLongError() : Error(4003, "unknown_failure 4003") {}
-};
-
-/// Storage init error
-class StorageInitError : public Error {
-  public:
-    /// Default constructor
-    StorageInitError() : Error(4004, "unknown_failure 4004") {}
-};
-
-/// Bind error
-class BindError : public Error {
-  public:
-    /// Default constructor
-    BindError() : Error(4005, "unknown_failure 4005") {}
-};
-
-/// Event new error
-class EventNewError : public Error {
-  public:
-    /// Default constructor
-    EventNewError() : Error(4006, "unknown_failure 4006") {}
-};
-
-/// Sendto error
-class SendtoError : public Error {
-  public:
-    /// Default constructor
-    SendtoError() : Error(4007, "unknown_failure 4007") {}
-};
-
-/// No probe pending error
-class NoProbePendingError : public Error {
-  public:
-    /// Default constructor
-    NoProbePendingError() : Error(4008, "unknown_failure 4008") {}
-};
-
-/// Clock gettime error
-class ClockGettimeError : public Error {
-  public:
-    /// Default constructor
-    ClockGettimeError() : Error(4009, "unknown_failure 4009") {}
-};
-
-class EventAddError : public Error {
-  public:
-    /// Default constructor
-    EventAddError() : Error(4010, "unknown_failure 4010") {}
-};
-
-class SocketAlreadyClosedError : public Error {
-  public:
-    /// Default constructor
-    SocketAlreadyClosedError() : Error(4011, "unknown_failure 4011") {}
-};
+MK_DEFINE_ERR(4000, SocketCreateError, "unknown_failure 4000")
+MK_DEFINE_ERR(4001, SetsockoptError, "unknown_failure 4001")
+MK_DEFINE_ERR(4002, ProbeAlreadyPendingError, "unknown_failure 4002")
+MK_DEFINE_ERR(4003, PayloadTooLongError, "unknown_failure 4003")
+MK_DEFINE_ERR(4004, StorageInitError, "unknown_failure 4004")
+MK_DEFINE_ERR(4005, BindError, "unknown_failure 4005")
+MK_DEFINE_ERR(4006, EventNewError, "unknown_failure 4006")
+MK_DEFINE_ERR(4007, SendtoError, "unknown_failure 4007")
+MK_DEFINE_ERR(4008, NoProbePendingError, "unknown_failure 4008")
+MK_DEFINE_ERR(4009, ClockGettimeError, "unknown_failure 4009")
+MK_DEFINE_ERR(4010, EventAddError, "unknown_failure 4010")
+MK_DEFINE_ERR(4011, SocketAlreadyClosedError, "unknown_failure 4011")
 
 } // namespace net
 } // namespace mk


### PR DESCRIPTION
Substitutions mechanically performed with this tool:

```python
import re
import sys

REGEX1 = r"///\s*[A-Za-z0-9 .]+\n+class\s+[A-za-z0-9]+\s*:\s*public\s+Error\s*{\n+\s*public\s*:\n+\s*([A-Za-z0-9]+)\s*\(\)\s*:\s*Error\(([0-9]+)\s*,\s*(\"[A-Za-z0-9_\s]+\")\s*\)\s*{\s*}\s*;?\s*(\s*///<\s*[A-Za-z0-9_\s-]*)?\n\s*};\n"

REGEX2 = r"///\s*[A-Za-z0-9 .]+\n+class\s+[A-za-z0-9]+\s*:\s*public\s+Error\s*{\n+\s*public\s*:\n+\s*///[A-Za-z0-9-\s]+\n\s*([A-Za-z0-9]+)\s*\(\)\s*:\s*Error\(([0-9]+)\s*,\s*(\"[A-Za-z0-9_\s]+\")\s*\)\s*{\s*}\s*;?\s*(\s*///<\s*[A-Za-z0-9_\s-]*)?\n\s*};\n"

REGEX3 = r"class\s+[A-za-z0-9]+\s*:\s*public\s+Error\s*{\n+\s*public\s*:\n+\s*([A-Za-z0-9]+)\s*\(\)\s*:\s*Error\(([0-9]+)\s*,\s*(\"[A-Za-z0-9_\s]+\")\s*\)\s*{\s*}\s*;?\s*(\s*///<\s*[A-Za-z0-9_\s-]*)?\n\s*};\n"

REGEX4 = r"class\s+[A-za-z0-9]+\s*:\s*public\s+Error\s*{\n+\s*public\s*:\n+\s*///[A-Za-z0-9-\s]+\n\s*([A-Za-z0-9]+)\s*\(\)\s*:\s*Error\(([0-9]+)\s*,\s*(\"[A-Za-z0-9_\s]+\")\s*\)\s*{\s*}\s*;?\s*(\s*///<\s*[A-Za-z0-9_\s-]*)?\n\s*};\n"

for arg in sys.argv[1:]:
    data = open(arg, "r").read()
    data = re.sub(REGEX1, r"MK_DEFINE_ERR(\2, \1, \3)", data)
    data = re.sub(REGEX2, r"MK_DEFINE_ERR(\2, \1, \3)", data)
    data = re.sub(REGEX3, r"MK_DEFINE_ERR(\2, \1, \3)", data)
    data = re.sub(REGEX4, r"MK_DEFINE_ERR(\2, \1, \3)", data)
    open(arg, "w").write(data)
```