### PR TITLE
Combine loop with initial event and check connectivity

### DIFF
--- a/include/measurement_kit/common/reactor.hpp
+++ b/include/measurement_kit/common/reactor.hpp
@@ -44,6 +44,8 @@ inline void loop_with_initial_event(std::function<void()> cb) {
     Reactor::global()->loop_with_initial_event(cb);
 }
 
+void loop_with_initial_event_and_connectivity(std::function<void()> cb);
+
 inline void loop() { Reactor::global()->loop(); }
 
 inline void loop_once() { Reactor::global()->loop_once(); }

--- a/src/common/reactor.cpp
+++ b/src/common/reactor.cpp
@@ -2,11 +2,20 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-#include <measurement_kit/common.hpp>
+#include "src/common/check_connectivity.hpp"
 #include "src/common/poller.hpp"
+#include <measurement_kit/common.hpp>
 
 namespace mk {
 
 /*static*/ Var<Reactor> Reactor::make() { return Var<Reactor>(new Poller); }
+
+void loop_with_initial_event_and_connectivity(std::function<void()> cb) {
+    if (!CheckConnectivity::is_down()) {
+        loop_with_initial_event(cb);
+    } else {
+        warn("Test skipped because network is down");
+    }
+}
 
 } // namespace mk

--- a/test/common/async.cpp
+++ b/test/common/async.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/common/async.cpp's
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 

--- a/test/common/logger.cpp
+++ b/test/common/logger.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/common/log.cpp
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 

--- a/test/common/poller.cpp
+++ b/test/common/poller.cpp
@@ -6,15 +6,8 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/common.hpp>
-#include "src/common/check_connectivity.hpp"
 #include "src/common/utils.hpp"
 #include "src/common/poller.hpp"
-
-#include <event2/dns.h>
-
-#include <functional>
-#include <new>
-#include <stdexcept>
 
 using namespace mk;
 

--- a/test/common/settings.cpp
+++ b/test/common/settings.cpp
@@ -2,15 +2,10 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for include/measurement_kit/common/settings.hpp
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/common/settings.hpp>
-#include <string>
 
 using namespace mk;
 

--- a/test/common/var.cpp
+++ b/test/common/var.cpp
@@ -2,10 +2,6 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/common/pointer.hpp
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 

--- a/test/dns/defines.cpp
+++ b/test/dns/defines.cpp
@@ -6,7 +6,6 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/dns.hpp>
-#include <measurement_kit/common.hpp>
 
 using namespace mk;
 using namespace mk::dns;

--- a/test/dns/error.cpp
+++ b/test/dns/error.cpp
@@ -6,8 +6,6 @@
 #include "src/ext/Catch/single_include/catch.hpp"
 
 #include <measurement_kit/dns.hpp>
-#include <measurement_kit/common.hpp>
-
 #include <event2/dns.h>
 
 using namespace mk;

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -5,26 +5,25 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/dns.hpp>
-
-#include "src/common/check_connectivity.hpp"
 #include "src/dns/query.hpp"
+#include <measurement_kit/dns.hpp>
 
 using namespace mk;
 using namespace mk::dns;
 
 // Now testing query()
-static evdns_request *null_resolver(
-    evdns_base *, const char *, int, evdns_callback_type, void *) {
+static evdns_request *null_resolver(evdns_base *, const char *, int,
+                                    evdns_callback_type, void *) {
     return (evdns_request *)nullptr;
 }
-static evdns_request *null_resolver_reverse(
-    evdns_base *, const struct in_addr *, int, evdns_callback_type, void *) {
+static evdns_request *null_resolver_reverse(evdns_base *,
+                                            const struct in_addr *, int,
+                                            evdns_callback_type, void *) {
     return (evdns_request *)nullptr;
 }
-static evdns_request *null_resolver_reverse(
-    evdns_base *, const struct in6_addr *, int, evdns_callback_type, void *) {
+static evdns_request *null_resolver_reverse(evdns_base *,
+                                            const struct in6_addr *, int,
+                                            evdns_callback_type, void *) {
     return (evdns_request *)nullptr;
 }
 static int null_inet_pton(int, const char *, void *) { return 0; }
@@ -41,8 +40,8 @@ static int null_evdns_base_nameserver_ip_add(evdns_base *, const char *) {
     return -1;
 }
 
-static int null_evdns_base_set_option_randomize(
-    evdns_base *, const char *, const char *) {
+static int null_evdns_base_set_option_randomize(evdns_base *, const char *,
+                                                const char *) {
     return -1;
 }
 
@@ -68,7 +67,7 @@ TEST_CASE("throw error while fails evdns_base_new") {
 TEST_CASE("throw error while fails evdns_base_nameserver_ip_add") {
     try {
         create_evdns_base<::evdns_base_new, null_evdns_base_nameserver_ip_add,
-            base_free_evdns_base_nameserver_ip_add>(
+                          base_free_evdns_base_nameserver_ip_add>(
             {{"dns/nameserver", "nexa"}}, Reactor::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_base_nameserver_ip_add_flag);
@@ -80,7 +79,7 @@ TEST_CASE("throw error while fails evdns_base_nameserver_ip_add") {
 TEST_CASE("throw error while fails evdns_base_nameserver_ip_add and base_new") {
     try {
         create_evdns_base<null_evdns_base_new,
-            null_evdns_base_nameserver_ip_add>(
+                          null_evdns_base_nameserver_ip_add>(
             {{"dns/nameserver", "nexa"}}, Reactor::global());
     } catch (std::bad_alloc &) {
         return;
@@ -91,7 +90,7 @@ TEST_CASE("throw error while fails evdns_base_nameserver_ip_add and base_new") {
 TEST_CASE("throw error while fails evdns_set_options for attempts") {
     try {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
-            base_free_evdns_set_options_attempts>(
+                          base_free_evdns_set_options_attempts>(
             {{"dns/attempts", "nexa"}}, Reactor::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_attempts_flag);
@@ -103,7 +102,7 @@ TEST_CASE("throw error while fails evdns_set_options for attempts") {
 TEST_CASE("throw error while fails evdns_set_options for negative attempts") {
     try {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
-            base_free_evdns_set_options_attempts_negative>(
+                          base_free_evdns_set_options_attempts_negative>(
             {{"dns/attempts", -1}}, Reactor::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_attempts_negative_flag);
@@ -115,8 +114,8 @@ TEST_CASE("throw error while fails evdns_set_options for negative attempts") {
 TEST_CASE("throw error while fails evdns_set_options for randomize-case") {
     try {
         create_evdns_base<::evdns_base_new, ::evdns_base_nameserver_ip_add,
-            base_free_evdns_set_options_randomize,
-            null_evdns_base_set_option_randomize>(
+                          base_free_evdns_set_options_randomize,
+                          null_evdns_base_set_option_randomize>(
             {{"dns/randomize_case", ""}}, Reactor::global());
     } catch (std::runtime_error &) {
         REQUIRE(base_free_evdns_set_options_randomize_flag);
@@ -127,29 +126,24 @@ TEST_CASE("throw error while fails evdns_set_options for randomize-case") {
 
 TEST_CASE("throw error with too many addresses") {
     REQUIRE_THROWS_AS(build_answers_evdns(DNS_ERR_NONE, DNS_IPv4_A,
-                          (INT_MAX / 4) + 2, 20, nullptr),
-        std::runtime_error);
+                                          (INT_MAX / 4) + 2, 20, nullptr),
+                      std::runtime_error);
 }
 
 TEST_CASE("throw error with ntop conversion error") {
     REQUIRE_THROWS_AS(build_answers_evdns<null_inet_ntop>(
                           DNS_ERR_NONE, DNS_IPv4_A, 1, 20, nullptr),
-        std::runtime_error);
+                      std::runtime_error);
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv4") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    query_debug<::evdns_base_free, null_resolver>("IN", "A", "www.google.com",
+    query_debug<::evdns_base_free, null_resolver>(
+        "IN", "A", "www.google.com",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
         Reactor::global());
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv6") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4, null_resolver>(
         "IN", "AAAA", "github.com",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
@@ -157,57 +151,53 @@ TEST_CASE("dns::query deals with failing evdns_base_resolve_ipv6") {
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
-        ::evdns_base_resolve_ipv6, null_resolver_reverse>("IN", "REVERSE_A",
-        "8.8.8.8", [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
+                ::evdns_base_resolve_ipv6, null_resolver_reverse>(
+        "IN", "REVERSE_A", "8.8.8.8",
+        [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
         Reactor::global());
 }
 
 TEST_CASE("dns::query deals with failing evdns_base_resolve_reverse_ipv6") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
-        ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
-        null_resolver_reverse>("IN", "REVERSE_AAAA", "::1",
+                ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
+                null_resolver_reverse>(
+        "IN", "REVERSE_AAAA", "::1",
         [](Error e, Message) { REQUIRE(e == ResolverError()); }, {},
         Reactor::global());
 }
 
 TEST_CASE("dns::query deals with inet_pton returning 0") {
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
-        ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
-        ::evdns_base_resolve_reverse_ipv6, null_inet_pton>("IN", "REVERSE_A",
-        "8.8.8.8",
+                ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
+                ::evdns_base_resolve_reverse_ipv6, null_inet_pton>(
+        "IN", "REVERSE_A", "8.8.8.8",
         [](Error e, Message) { REQUIRE(e == InvalidIPv4AddressError()); }, {},
         Reactor::global());
 
     query_debug<::evdns_base_free, ::evdns_base_resolve_ipv4,
-        ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
-        ::evdns_base_resolve_reverse_ipv6, null_inet_pton>("IN", "REVERSE_AAAA",
-        "::1",
+                ::evdns_base_resolve_ipv6, ::evdns_base_resolve_reverse,
+                ::evdns_base_resolve_reverse_ipv6, null_inet_pton>(
+        "IN", "REVERSE_AAAA", "::1",
         [](Error e, Message) { REQUIRE(e == InvalidIPv6AddressError()); }, {},
         Reactor::global());
 }
 
 TEST_CASE("dns::query raises if the query is unsupported") {
     query("IN", "MX", "www.neubot.org",
-        [](Error e, Message) { REQUIRE(e == UnsupportedTypeError()); });
+          [](Error e, Message) { REQUIRE(e == UnsupportedTypeError()); });
 }
 
 TEST_CASE("dns::query raises if the class is unsupported") {
     query("CS", "A", "www.neubot.org",
-        [](Error e, Message) { REQUIRE(e == UnsupportedClassError()); });
+          [](Error e, Message) { REQUIRE(e == UnsupportedClassError()); });
 }
 
 TEST_CASE("dns::query deals with invalid PTR name") {
     // This should be enough to see the failure, more tests for the
     // parser for PTR addresses are in test/common/utils.cpp
     query("IN", "PTR", "xx",
-        [](Error e, Message) { REQUIRE(e == InvalidNameForPTRError()); });
+          [](Error e, Message) { REQUIRE(e == InvalidNameForPTRError()); });
 }
 
 // Integration (or regress?) tests for dns::query.
@@ -223,84 +213,88 @@ TEST_CASE("The system resolver works as expected") {
     // response fields from the system resolver.
     //
 
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-
-    query("IN", "A", "www.neubot.org", [&](Error e, Message message) {
-        REQUIRE(!e);
-        REQUIRE(message.error_code == DNS_ERR_NONE);
-        REQUIRE(message.answers.size() == 1);
-        REQUIRE(message.answers[0].ipv4 == "130.192.16.172");
-        REQUIRE(message.rtt > 0.0);
-        REQUIRE(message.answers[0].ttl > 0);
-        mk::break_loop();
+    loop_with_initial_event_and_connectivity([]() {
+        query("IN", "A", "www.neubot.org", [](Error e, Message message) {
+            REQUIRE(!e);
+            REQUIRE(message.error_code == DNS_ERR_NONE);
+            REQUIRE(message.answers.size() == 1);
+            REQUIRE(message.answers[0].ipv4 == "130.192.16.172");
+            REQUIRE(message.rtt > 0.0);
+            REQUIRE(message.answers[0].ttl > 0);
+            break_loop();
+        });
     });
-    mk::loop();
 
-    query("IN", "REVERSE_A", "130.192.16.172", [&](Error e, Message message) {
-        REQUIRE(!e);
-        REQUIRE(message.error_code == DNS_ERR_NONE);
-        REQUIRE(message.answers.size() == 1);
-        REQUIRE(message.answers[0].hostname == "server-nexa.polito.it");
-        REQUIRE(message.rtt > 0.0);
-        REQUIRE(message.answers[0].ttl > 0);
-        mk::break_loop();
+    loop_with_initial_event_and_connectivity([]() {
+        query(
+            "IN", "REVERSE_A", "130.192.16.172", [](Error e, Message message) {
+                REQUIRE(!e);
+                REQUIRE(message.error_code == DNS_ERR_NONE);
+                REQUIRE(message.answers.size() == 1);
+                REQUIRE(message.answers[0].hostname == "server-nexa.polito.it");
+                REQUIRE(message.rtt > 0.0);
+                REQUIRE(message.answers[0].ttl > 0);
+                break_loop();
+            });
     });
-    mk::loop();
 
-    query("IN", "PTR", "172.16.192.130.in-addr.arpa.",
-        [&](Error e, Message message) {
+    loop_with_initial_event_and_connectivity([]() {
+        query("IN", "PTR", "172.16.192.130.in-addr.arpa.", [](Error e,
+                                                              Message message) {
             REQUIRE(!e);
             REQUIRE(message.error_code == DNS_ERR_NONE);
             REQUIRE(message.answers.size() == 1);
             REQUIRE(message.answers[0].hostname == "server-nexa.polito.it");
             REQUIRE(message.rtt > 0.0);
             REQUIRE(message.answers[0].ttl > 0);
-            mk::break_loop();
+            break_loop();
         });
-    mk::loop();
-
-    query("IN", "AAAA", "ooni.torproject.org", [&](Error e, Message message) {
-        REQUIRE(!e);
-        REQUIRE(message.error_code == DNS_ERR_NONE);
-        REQUIRE(message.answers.size() > 0);
-        REQUIRE(message.rtt > 0.0);
-        REQUIRE(message.answers[0].ttl > 0);
-        auto found = false;
-        for (auto answer : message.answers) {
-            if (answer.ipv6 == "2001:858:2:2:aabb::563b:1e28" or
-                answer.ipv6 == "2001:858:2:2:aabb:0:563b:1e28") {
-                found = true;
-            }
-        }
-        REQUIRE(found);
-        mk::break_loop();
     });
-    mk::loop();
 
-    query("IN", "REVERSE_AAAA", "2001:858:2:2:aabb::563b:1e28",
-        [&](Error e, Message message) {
-            REQUIRE(!e);
-            REQUIRE(message.error_code == DNS_ERR_NONE);
-            REQUIRE(message.answers.size() == 1);
-            REQUIRE(message.answers[0].hostname == "nova.torproject.org");
-            REQUIRE(message.rtt > 0.0);
-            REQUIRE(message.answers[0].ttl > 0);
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        query("IN", "AAAA", "ooni.torproject.org",
+              [](Error e, Message message) {
+                  REQUIRE(!e);
+                  REQUIRE(message.error_code == DNS_ERR_NONE);
+                  REQUIRE(message.answers.size() > 0);
+                  REQUIRE(message.rtt > 0.0);
+                  REQUIRE(message.answers[0].ttl > 0);
+                  auto found = false;
+                  for (auto answer : message.answers) {
+                      if (answer.ipv6 == "2001:858:2:2:aabb::563b:1e28" or
+                          answer.ipv6 == "2001:858:2:2:aabb:0:563b:1e28") {
+                          found = true;
+                      }
+                  }
+                  REQUIRE(found);
+                  break_loop();
+              });
+    });
 
-    query("IN", "PTR",
-"8.2.e.1.b.3.6.5.0.0.0.0.b.b.a.a.2.0.0.0.2.0.0.0.8.5.8.0.1.0.0.2.ip6.arpa",
-        [&](Error e, Message message) {
-            REQUIRE(!e);
-            REQUIRE(message.error_code == DNS_ERR_NONE);
-            REQUIRE(message.answers.size() == 1);
-            REQUIRE(message.answers[0].hostname == "nova.torproject.org");
-            REQUIRE(message.rtt > 0.0);
-            REQUIRE(message.answers[0].ttl > 0);
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        query("IN", "REVERSE_AAAA", "2001:858:2:2:aabb::563b:1e28",
+              [](Error e, Message message) {
+                  REQUIRE(!e);
+                  REQUIRE(message.error_code == DNS_ERR_NONE);
+                  REQUIRE(message.answers.size() == 1);
+                  REQUIRE(message.answers[0].hostname == "nova.torproject.org");
+                  REQUIRE(message.rtt > 0.0);
+                  REQUIRE(message.answers[0].ttl > 0);
+                  break_loop();
+              });
+    });
+
+    loop_with_initial_event_and_connectivity([]() {
+        query("IN", "PTR", "8.2.e.1.b.3.6.5.0.0.0.0.b.b.a.a.2.0.0.0.2.0.0.0.8."
+                           "5.8.0.1.0.0.2.ip6.arpa",
+              [](Error e, Message message) {
+                  REQUIRE(!e);
+                  REQUIRE(message.error_code == DNS_ERR_NONE);
+                  REQUIRE(message.answers.size() == 1);
+                  REQUIRE(message.answers[0].hostname == "nova.torproject.org");
+                  REQUIRE(message.rtt > 0.0);
+                  REQUIRE(message.answers[0].ttl > 0);
+                  break_loop();
+              });
+    });
 }

--- a/test/http/client.cpp
+++ b/test/http/client.cpp
@@ -17,147 +17,151 @@ using namespace mk::http;
 // TODO: these tests should go in test/http/request.cpp
 
 TEST_CASE("http::request() works as expected") {
-    auto count = 0;
+    loop_with_initial_event_and_connectivity([]() {
+        auto count = 0;
 
-    request(
-        {
-         {"http/url", "http://www.google.com/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"Connection", "close"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error, Response response) {
-            std::cout << "Google:\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.google.com/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"Connection", "close"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error, Response response) {
+                std::cout << "Google:\r\n";
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    request(
-        {
-         {"http/url", "http://www.neubot.org/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error, Response response) {
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.neubot.org/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error, Response response) {
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    request(
-        {
-         {"http/url", "http://www.torproject.org/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error, Response response) {
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.torproject.org/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error, Response response) {
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    mk::loop();
+    });
 }
 
 TEST_CASE("http::request() works as expected over Tor") {
-    auto count = 0;
+    loop_with_initial_event_and_connectivity([]() {
+        auto count = 0;
 
-    request(
-        {
-         {"http/url", "http://www.google.com/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"Connection", "close"},
-         {"net/socks5_proxy", "127.0.0.1:9050"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error error, Response response) {
-            std::cout << "Error: " << (int)error << std::endl;
-            std::cout << "Google:\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.google.com/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"Connection", "close"},
+                {"net/socks5_proxy", "127.0.0.1:9050"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error error, Response response) {
+                std::cout << "Error: " << (int)error << std::endl;
+                std::cout << "Google:\r\n";
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    request(
-        {
-         {"http/url", "http://www.neubot.org/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"net/socks5_proxy", "127.0.0.1:9050"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error error, Response response) {
-            std::cout << "Error: " << (int)error << std::endl;
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.neubot.org/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"net/socks5_proxy", "127.0.0.1:9050"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error error, Response response) {
+                std::cout << "Error: " << (int)error << std::endl;
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    request(
-        {
-         {"http/url", "http://www.torproject.org/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"net/socks5_proxy", "127.0.0.1:9050"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [&](Error error, Response response) {
-            std::cout << "Error: " << (int)error << std::endl;
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            if (++count >= 3) {
-                mk::break_loop();
-            }
-        });
+        request(
+            {
+                {"http/url", "http://www.torproject.org/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"net/socks5_proxy", "127.0.0.1:9050"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [&](Error error, Response response) {
+                std::cout << "Error: " << (int)error << std::endl;
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                if (++count >= 3) {
+                    break_loop();
+                }
+            });
 
-    mk::loop();
+    });
 }
 
 TEST_CASE("Make sure that we can access OONI's bouncer using httpo://...") {
-    request(
-        {
-         {"http/url", "httpo://nkvphnp3p6agi5qq.onion/bouncer"},
-         {"http/method", "POST"},
-         {"http/http_version", "HTTP/1.1"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "{\"test-helpers\": [\"dns\"]}", [](Error error, Response response) {
-            std::cout << "Error: " << (int)error << std::endl;
-            std::cout << response.body << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request(
+            {
+                {"http/url", "httpo://nkvphnp3p6agi5qq.onion/bouncer"},
+                {"http/method", "POST"},
+                {"http/http_version", "HTTP/1.1"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "{\"test-helpers\": [\"dns\"]}",
+            [](Error error, Response response) {
+                std::cout << "Error: " << (int)error << std::endl;
+                std::cout << response.body << "\r\n";
+                std::cout << "[snip]\r\n";
+                break_loop();
+            });
 
-    mk::loop();
+    });
 }
 
 TEST_CASE("Make sure that settings are not modified") {
@@ -177,21 +181,21 @@ TEST_CASE("Make sure that settings are not modified") {
         {"net/tor_socks_port", 9999},
     };
 
-    request(settings,
-                   {
+    loop_with_initial_event_and_connectivity([&]() {
+        request(settings,
+                {
                     {"Accept", "*/*"},
-                   },
-                   "{\"test-helpers\": [\"dns\"]}",
-                   [](Error error, Response response) {
-                       // XXX: assumes that Tor is not running on port 9999
-                       REQUIRE(error != 0);
-                       std::cout << "Error: " << (int)error << std::endl;
-                       std::cout << response.body << "\r\n";
-                       std::cout << "[snip]\r\n";
-                       mk::break_loop();
-                   });
-
-    mk::loop();
+                },
+                "{\"test-helpers\": [\"dns\"]}",
+                [](Error error, Response response) {
+                    // XXX: assumes that Tor is not running on port 9999
+                    REQUIRE(error != 0);
+                    std::cout << "Error: " << (int)error << std::endl;
+                    std::cout << response.body << "\r\n";
+                    std::cout << "[snip]\r\n";
+                    break_loop();
+                });
+    });
 
     // Make sure that no changes were made
     for (auto &iter : settings) {

--- a/test/http/client.cpp
+++ b/test/http/client.cpp
@@ -17,8 +17,8 @@ using namespace mk::http;
 // TODO: these tests should go in test/http/request.cpp
 
 TEST_CASE("http::request() works as expected") {
-    loop_with_initial_event_and_connectivity([]() {
-        auto count = 0;
+    auto count = 0;
+    loop_with_initial_event_and_connectivity([&]() {
 
         request(
             {
@@ -77,8 +77,8 @@ TEST_CASE("http::request() works as expected") {
 }
 
 TEST_CASE("http::request() works as expected over Tor") {
-    loop_with_initial_event_and_connectivity([]() {
-        auto count = 0;
+    auto count = 0;
+    loop_with_initial_event_and_connectivity([&]() {
 
         request(
             {

--- a/test/http/funcs.cpp
+++ b/test/http/funcs.cpp
@@ -12,23 +12,25 @@ using namespace mk::http;
 // TODO: these tests should go in test/http/request.cpp
 
 TEST_CASE("http::get() works as expected") {
-    http::get("http://www.google.com/robots.txt",
-        [](Error error, Response &&response) {
-            std::cout << "Error: " << (int)error << "\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        http::get("http://www.google.com/robots.txt",
+                  [](Error error, Response &&response) {
+                      std::cout << "Error: " << (int)error << "\r\n";
+                      std::cout << response.body.substr(0, 128) << "\r\n";
+                      std::cout << "[snip]\r\n";
+                      break_loop();
+                  });
+    });
 }
 
 TEST_CASE("http::request() works as expected") {
-    http::request("GET", "http://www.google.com/robots.txt",
-        [](Error error, Response &&response) {
-            std::cout << "Error: " << (int)error << "\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        http::request("GET", "http://www.google.com/robots.txt",
+                      [](Error error, Response &&response) {
+                          std::cout << "Error: " << (int)error << "\r\n";
+                          std::cout << response.body.substr(0, 128) << "\r\n";
+                          std::cout << "[snip]\r\n";
+                          break_loop();
+                      });
+    });
 }

--- a/test/http/parse_url.cpp
+++ b/test/http/parse_url.cpp
@@ -32,13 +32,11 @@ TEST_CASE("Works as expected for more complex case") {
 TEST_CASE("Recognizes wrong ports") {
     SECTION("Negative port") {
         REQUIRE_THROWS_AS(
-                http::parse_url("https://www.kernel.org:-4/abc?foobar"),
-                Error);
+            http::parse_url("https://www.kernel.org:-4/abc?foobar"), Error);
     }
 
     SECTION("Too large port") {
         REQUIRE_THROWS_AS(
-                http::parse_url("https://www.kernel.org:65537/abc?foobar"),
-                Error);
+            http::parse_url("https://www.kernel.org:65537/abc?foobar"), Error);
     }
 }

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -19,50 +19,12 @@ using namespace mk::http;
 // should merge them to avoid testing things twice
 
 TEST_CASE("http::request works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    request(
-        {
-         {"http/url", "http://www.google.com/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [](Error error, Response response) {
-            if (error != 0) {
-                std::cout << "Error: " << (int)error << "\r\n";
-                mk::break_loop();
-                return;
-            }
-            std::cout << "HTTP/" << response.http_major << "."
-                      << response.http_minor << " " << response.status_code
-                      << " " << response.reason << "\r\n";
-            for (auto &kv : response.headers) {
-                std::cout << kv.first << ": " << kv.second << "\r\n";
-            }
-            std::cout << "\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
-    mk::loop();
-}
-
-TEST_CASE("http::request() works using HTTPS") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    set_verbosity(MK_LOG_DEBUG);
-    loop_with_initial_event([]() {
+    loop_with_initial_event_and_connectivity([]() {
         request(
             {
-                {"http/url", "https://didattica.polito.it/"},
+                {"http/url", "http://www.google.com/robots.txt"},
                 {"http/method", "GET"},
                 {"http/http_version", "HTTP/1.1"},
-                {"net/ca_bundle_path", "test/fixtures/certs.pem"}
             },
             {
                 {"Accept", "*/*"},
@@ -70,136 +32,161 @@ TEST_CASE("http::request() works using HTTPS") {
             "", [](Error error, Response response) {
                 if (error != 0) {
                     std::cout << "Error: " << (int)error << "\r\n";
-                    mk::break_loop();
+                    break_loop();
                     return;
                 }
                 std::cout << "HTTP/" << response.http_major << "."
-                      << response.http_minor << " " << response.status_code
-                      << " " << response.reason << "\r\n";
-                for (auto kv : response.headers) {
+                          << response.http_minor << " " << response.status_code
+                          << " " << response.reason << "\r\n";
+                for (auto &kv : response.headers) {
                     std::cout << kv.first << ": " << kv.second << "\r\n";
                 }
                 std::cout << "\r\n";
                 std::cout << response.body.substr(0, 128) << "\r\n";
                 std::cout << "[snip]\r\n";
-                mk::break_loop();
+                break_loop();
             });
     });
 }
 
+TEST_CASE("http::request() works using HTTPS") {
+    loop_with_initial_event_and_connectivity([]() {
+        set_verbosity(MK_LOG_DEBUG);
+        request({{"http/url", "https://didattica.polito.it/"},
+                 {"http/method", "GET"},
+                 {"http/http_version", "HTTP/1.1"},
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}},
+                {
+                    {"Accept", "*/*"},
+                },
+                "", [](Error error, Response response) {
+                    if (error != 0) {
+                        std::cout << "Error: " << (int)error << "\r\n";
+                        break_loop();
+                        return;
+                    }
+                    std::cout << "HTTP/" << response.http_major << "."
+                              << response.http_minor << " "
+                              << response.status_code << " " << response.reason
+                              << "\r\n";
+                    for (auto kv : response.headers) {
+                        std::cout << kv.first << ": " << kv.second << "\r\n";
+                    }
+                    std::cout << "\r\n";
+                    std::cout << response.body.substr(0, 128) << "\r\n";
+                    std::cout << "[snip]\r\n";
+                    break_loop();
+                });
+    });
+}
+
 TEST_CASE("http::request_recv_response() behaves correctly when EOF "
-        "indicates body END") {
+          "indicates body END") {
     auto called = 0;
 
-    loop_with_initial_event([&]() {
+    loop_with_initial_event_and_connectivity([&]() {
         connect("nexa.polito.it", 80,
-            [&](Error err, Var<Transport> transport) {
-                REQUIRE(!err);
+                [&](Error err, Var<Transport> transport) {
+                    REQUIRE(!err);
 
-                request_recv_response(transport,
-                        [&called](Error, Var<Response>) {
-                            ++called;
-                            break_loop();
-                        });
+                    request_recv_response(transport,
+                                          [&called](Error, Var<Response>) {
+                                              ++called;
+                                              break_loop();
+                                          });
 
-                Buffer data;
-                data << "HTTP/1.1 200 Ok\r\n";
-                data << "Content-Type: text/plain\r\n";
-                data << "Connection: close\r\n";
-                data << "Server: Antani/1.0.0.0\r\n";
-                data << "\r\n";
-                data << "1234567";
-                transport->emit_data(data);
-                transport->emit_error(EofError());
-            },
-            {
-              // With this connect() succeeds immediately and the
-              // callback receives a dumb Emitter transport that you
-              // can drive by calling its emit_FOO() methods
-              {"net/dumb_transport", true}
-            });
+                    Buffer data;
+                    data << "HTTP/1.1 200 Ok\r\n";
+                    data << "Content-Type: text/plain\r\n";
+                    data << "Connection: close\r\n";
+                    data << "Server: Antani/1.0.0.0\r\n";
+                    data << "\r\n";
+                    data << "1234567";
+                    transport->emit_data(data);
+                    transport->emit_error(EofError());
+                },
+                {// With this connect() succeeds immediately and the
+                 // callback receives a dumb Emitter transport that you
+                 // can drive by calling its emit_FOO() methods
+                 {"net/dumb_transport", true}});
     });
     REQUIRE(called == 1);
 }
 
 TEST_CASE("http::request correctly receives errors") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    request(
-        {
-         {"http/url", "http://nexa.polito.it:81/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"net/timeout", "3.0"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [](Error error, Response response) {
-            if (error != 0) {
-                std::cout << "Error: " << (int)error << "\r\n";
-                mk::break_loop();
-                return;
-            }
-            std::cout << "HTTP/" << response.http_major << "."
-                      << response.http_minor << " " << response.status_code
-                      << " " << response.reason << "\r\n";
-            for (auto &kv : response.headers) {
-                std::cout << kv.first << ": " << kv.second << "\r\n";
-            }
-            std::cout << "\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        request(
+            {
+                {"http/url", "http://nexa.polito.it:81/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"net/timeout", "3.0"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [](Error error, Response response) {
+                if (error != 0) {
+                    std::cout << "Error: " << (int)error << "\r\n";
+                    break_loop();
+                    return;
+                }
+                std::cout << "HTTP/" << response.http_major << "."
+                          << response.http_minor << " " << response.status_code
+                          << " " << response.reason << "\r\n";
+                for (auto &kv : response.headers) {
+                    std::cout << kv.first << ": " << kv.second << "\r\n";
+                }
+                std::cout << "\r\n";
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                break_loop();
+            });
+    });
 }
 
 TEST_CASE("http::request works as expected over Tor") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    request(
-        {
-         {"http/url", "http://www.google.com/robots.txt"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.1"},
-         {"net/socks5_proxy", "127.0.0.1:9050"},
-        },
-        {
-         {"Accept", "*/*"},
-        },
-        "", [](Error error, Response response) {
-            if (error != 0) {
-                std::cout << "Error: " << (int)error << "\r\n";
-                mk::break_loop();
-                return;
-            }
-            std::cout << "HTTP/" << response.http_major << "."
-                      << response.http_minor << " " << response.status_code
-                      << " " << response.reason << "\r\n";
-            for (auto &kv : response.headers) {
-                std::cout << kv.first << ": " << kv.second << "\r\n";
-            }
-            std::cout << "\r\n";
-            std::cout << response.body.substr(0, 128) << "\r\n";
-            std::cout << "[snip]\r\n";
-            mk::break_loop();
-        });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([]() {
+        request(
+            {
+                {"http/url", "http://www.google.com/robots.txt"},
+                {"http/method", "GET"},
+                {"http/http_version", "HTTP/1.1"},
+                {"net/socks5_proxy", "127.0.0.1:9050"},
+            },
+            {
+                {"Accept", "*/*"},
+            },
+            "", [](Error error, Response response) {
+                if (error != 0) {
+                    std::cout << "Error: " << (int)error << "\r\n";
+                    break_loop();
+                    return;
+                }
+                std::cout << "HTTP/" << response.http_major << "."
+                          << response.http_minor << " " << response.status_code
+                          << " " << response.reason << "\r\n";
+                for (auto &kv : response.headers) {
+                    std::cout << kv.first << ": " << kv.second << "\r\n";
+                }
+                std::cout << "\r\n";
+                std::cout << response.body.substr(0, 128) << "\r\n";
+                std::cout << "[snip]\r\n";
+                break_loop();
+            });
+    });
 }
 
 #define SOCKS_PORT_IS(port)                                                    \
-static void socks_port_is_ ## port(std::string, int,                           \
-        Callback<Error, Var<Transport>>,                            \
-        Settings settings, Var<Logger>, Var<Reactor>) {                               \
-    REQUIRE(settings.at("net/socks5_proxy") == "127.0.0.1:" # port);               \
-}
+    static void socks_port_is_##port(                                          \
+        std::string, int, Callback<Error, Var<Transport>>, Settings settings,  \
+        Var<Logger>, Var<Reactor>) {                                           \
+        REQUIRE(settings.at("net/socks5_proxy") == "127.0.0.1:" #port);        \
+    }
 
 static void socks_port_is_empty(std::string, int,
-        Callback<Error, Var<Transport>>,
-        Settings settings, Var<Logger>, Var<Reactor>) {
+                                Callback<Error, Var<Transport>>,
+                                Settings settings, Var<Logger>, Var<Reactor>) {
     REQUIRE(settings.find("net/socks5_proxy") == settings.end());
 }
 
@@ -274,37 +261,32 @@ TEST_CASE("http::request() callback is called if input URL parsing fails") {
 }
 
 TEST_CASE("http::request_connect_impl() works for normal connections") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/robots.txt"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            REQUIRE(static_cast<bool>(transport));
-            transport->close([]() { break_loop(); });
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl({{"http/url", "http://www.google.com/robots.txt"}},
+                             [](Error error, Var<Transport> transport) {
+                                 REQUIRE(!error);
+                                 REQUIRE(static_cast<bool>(transport));
+                                 transport->close([]() { break_loop(); });
+                             });
     });
 }
 
 TEST_CASE("http::request_send() works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            request_send(transport, {
-                {"http/method", "GET"},
-                {"http/url", "http://www.google.com/"},
-            }, {}, "", [transport](Error error) {
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl(
+            {{"http/url", "http://www.google.com/"}},
+            [](Error error, Var<Transport> transport) {
                 REQUIRE(!error);
-                transport->close([]() { break_loop(); });
+                request_send(transport,
+                             {
+                                 {"http/method", "GET"},
+                                 {"http/url", "http://www.google.com/"},
+                             },
+                             {}, "", [transport](Error error) {
+                                 REQUIRE(!error);
+                                 transport->close([]() { break_loop(); });
+                             });
             });
-        });
     });
 }
 
@@ -313,97 +295,97 @@ static inline bool status_code_ok(int code) {
 }
 
 TEST_CASE("http::request_recv_response() works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            request_send(transport, {
-                {"http/method", "GET"},
-                {"http/url", "http://www.google.com/"},
-            }, {}, "", [transport](Error error) {
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl(
+            {{"http/url", "http://www.google.com/"}},
+            [](Error error, Var<Transport> transport) {
                 REQUIRE(!error);
-                request_recv_response(transport,
-                        [transport](Error e, Var<Response> r) {
-                    REQUIRE(!e);
-                    REQUIRE(status_code_ok(r->status_code));
-                    REQUIRE(r->body.size() > 0);
-                    transport->close([]() { break_loop(); });
-                });
+                request_send(
+                    transport,
+                    {
+                        {"http/method", "GET"},
+                        {"http/url", "http://www.google.com/"},
+                    },
+                    {}, "", [transport](Error error) {
+                        REQUIRE(!error);
+                        request_recv_response(
+                            transport, [transport](Error e, Var<Response> r) {
+                                REQUIRE(!e);
+                                REQUIRE(status_code_ok(r->status_code));
+                                REQUIRE(r->body.size() > 0);
+                                transport->close([]() { break_loop(); });
+                            });
+                    });
             });
-        });
     });
 }
 
 TEST_CASE("http::request_sendrecv() works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            request_sendrecv(transport, {
-                {"http/method", "GET"},
-                {"http/url", "http://www.google.com/"},
-            }, {}, "", [transport](Error error, Var<Response> r) {
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl(
+            {{"http/url", "http://www.google.com/"}},
+            [](Error error, Var<Transport> transport) {
                 REQUIRE(!error);
-                REQUIRE(status_code_ok(r->status_code));
-                REQUIRE(r->body.size() > 0);
-                transport->close([]() { break_loop(); });
+                request_sendrecv(transport,
+                                 {
+                                     {"http/method", "GET"},
+                                     {"http/url", "http://www.google.com/"},
+                                 },
+                                 {}, "",
+                                 [transport](Error error, Var<Response> r) {
+                                     REQUIRE(!error);
+                                     REQUIRE(status_code_ok(r->status_code));
+                                     REQUIRE(r->body.size() > 0);
+                                     transport->close([]() { break_loop(); });
+                                 });
             });
-        });
     });
 }
 
 TEST_CASE("http::request_sendrecv() works for multiple requests") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            request_sendrecv(transport, {
-                {"http/method", "GET"},
-                {"http/url", "http://www.google.com/"},
-            }, {}, "", [transport](Error error, Var<Response> r) {
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl(
+            {{"http/url", "http://www.google.com/"}},
+            [](Error error, Var<Transport> transport) {
                 REQUIRE(!error);
-                REQUIRE(status_code_ok(r->status_code));
-                REQUIRE(r->body.size() > 0);
-                request_sendrecv(transport, {
-                    {"http/method", "GET"},
-                    {"http/url", "http://www.google.com/robots.txt"},
-                }, {}, "", [transport](Error error, Var<Response> r) {
-                    REQUIRE(!error);
-                    REQUIRE(r->status_code == 200);
-                    REQUIRE(r->body.size() > 0);
-                    transport->close([]() { break_loop(); });
-                });
+                request_sendrecv(
+                    transport,
+                    {
+                        {"http/method", "GET"},
+                        {"http/url", "http://www.google.com/"},
+                    },
+                    {}, "", [transport](Error error, Var<Response> r) {
+                        REQUIRE(!error);
+                        REQUIRE(status_code_ok(r->status_code));
+                        REQUIRE(r->body.size() > 0);
+                        request_sendrecv(
+                            transport,
+                            {
+                                {"http/method", "GET"},
+                                {"http/url",
+                                 "http://www.google.com/robots.txt"},
+                            },
+                            {}, "", [transport](Error error, Var<Response> r) {
+                                REQUIRE(!error);
+                                REQUIRE(r->status_code == 200);
+                                REQUIRE(r->body.size() > 0);
+                                transport->close([]() { break_loop(); });
+                            });
+                    });
             });
-        });
     });
 }
 
 TEST_CASE("http::request_cycle() works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_cycle({
-            {"http/method", "GET"},
-            {"http/url", "http://www.google.com/robots.txt"}
-        }, {}, "", [](Error error, Var<Response> r) {
-            REQUIRE(!error);
-            REQUIRE(r->status_code == 200);
-            REQUIRE(r->body.size() > 0);
-            break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_cycle({{"http/method", "GET"},
+                       {"http/url", "http://www.google.com/robots.txt"}},
+                      {}, "", [](Error error, Var<Response> r) {
+                          REQUIRE(!error);
+                          REQUIRE(r->status_code == 200);
+                          REQUIRE(r->body.size() > 0);
+                          break_loop();
+                      });
     });
 }
 
@@ -414,49 +396,41 @@ static inline bool check_error_after_tor(Error e) {
 }
 
 TEST_CASE("http::request_cycle() works as expected using httpo URLs") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_cycle({
-            {"http/method", "GET"},
-            {"http/url", "httpo://www.google.com/robots.txt"},
-        }, {}, "", [](Error error, Var<Response> r) {
-            REQUIRE(check_error_after_tor(error));
-            if (!error) {
-                REQUIRE(r->status_code == 200);
-                REQUIRE(r->body.size() > 0);
-            }
-            break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_cycle(
+            {
+                {"http/method", "GET"},
+                {"http/url", "httpo://www.google.com/robots.txt"},
+            },
+            {}, "", [](Error error, Var<Response> r) {
+                REQUIRE(check_error_after_tor(error));
+                if (!error) {
+                    REQUIRE(r->status_code == 200);
+                    REQUIRE(r->body.size() > 0);
+                }
+                break_loop();
+            });
     });
 }
 
 TEST_CASE("http::request_cycle() works as expected using tor_socks_port") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_cycle({
-            {"http/method", "GET"},
-            {"http/url", "http://www.google.com/robots.txt"},
-            {"net/tor_socks_port", "9050"}
-        }, {}, "", [](Error error, Var<Response> r) {
-            REQUIRE(check_error_after_tor(error));
-            if (!error) {
-                REQUIRE(r->status_code == 200);
-                REQUIRE(r->body.size() > 0);
-            }
-            break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_cycle({{"http/method", "GET"},
+                       {"http/url", "http://www.google.com/robots.txt"},
+                       {"net/tor_socks_port", "9050"}},
+                      {}, "", [](Error error, Var<Response> r) {
+                          REQUIRE(check_error_after_tor(error));
+                          if (!error) {
+                              REQUIRE(r->status_code == 200);
+                              REQUIRE(r->body.size() > 0);
+                          }
+                          break_loop();
+                      });
     });
 }
 
 TEST_CASE("http::request_connect_impl fails without an url") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
+    loop_with_initial_event_and_connectivity([]() {
         request_connect_impl({}, [](Error error, Var<Transport>) {
             REQUIRE(error == MissingUrlError());
             break_loop();
@@ -465,45 +439,36 @@ TEST_CASE("http::request_connect_impl fails without an url") {
 }
 
 TEST_CASE("http::request_connect_impl fails with an uncorrect url") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", ">*7\n\n"}}, [](Error error, Var<Transport>) {
-            REQUIRE(error == UrlParserError());
-            break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl({{"http/url", ">*7\n\n"}},
+                             [](Error error, Var<Transport>) {
+                                 REQUIRE(error == UrlParserError());
+                                 break_loop();
+                             });
     });
 }
 
 TEST_CASE("http::request_send fails without url in settings") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_connect_impl({
-            {"http/url", "http://www.google.com/"}
-        }, [](Error error, Var<Transport> transport) {
-            REQUIRE(!error);
-            request_send(transport,
-                {{"http/method", "GET"}}, {}, "", [transport](Error error) {
-                REQUIRE(error == MissingUrlError());
-                transport->close([]() { break_loop(); });
+    loop_with_initial_event_and_connectivity([]() {
+        request_connect_impl(
+            {{"http/url", "http://www.google.com/"}},
+            [](Error error, Var<Transport> transport) {
+                REQUIRE(!error);
+                request_send(transport, {{"http/method", "GET"}}, {}, "",
+                             [transport](Error error) {
+                                 REQUIRE(error == MissingUrlError());
+                                 transport->close([]() { break_loop(); });
+                             });
             });
-        });
     });
 }
 
 TEST_CASE("http::request_cycle() fails if fails request_send()") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        request_cycle({
-            {"http/method", "GET"}}, {}, "", [](Error error, Var<Response>) {
-            REQUIRE(error);
-            break_loop();
-        });
+    loop_with_initial_event_and_connectivity([]() {
+        request_cycle({{"http/method", "GET"}}, {}, "",
+                      [](Error error, Var<Response>) {
+                          REQUIRE(error);
+                          break_loop();
+                      });
     });
 }

--- a/test/http/request_serializer.cpp
+++ b/test/http/request_serializer.cpp
@@ -9,10 +9,8 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/http.hpp>
-
 #include "src/http/request_serializer.hpp"
+#include <measurement_kit/http.hpp>
 
 using namespace mk;
 using namespace mk::net;
@@ -21,14 +19,15 @@ using namespace mk::http;
 TEST_CASE("HTTP Request serializer works as expected") {
     auto serializer = RequestSerializer(
         {
-         {"http/follow_redirects", "yes"},
-         {"http/url", "http://www.example.com/antani?clacsonato=yes#melandri"},
-         {"http/ignore_body", "yes"},
-         {"http/method", "GET"},
-         {"http/http_version", "HTTP/1.0"},
+            {"http/follow_redirects", "yes"},
+            {"http/url",
+             "http://www.example.com/antani?clacsonato=yes#melandri"},
+            {"http/ignore_body", "yes"},
+            {"http/method", "GET"},
+            {"http/http_version", "HTTP/1.0"},
         },
         {
-         {"User-Agent", "Antani/1.0.0.0"},
+            {"User-Agent", "Antani/1.0.0.0"},
         },
         "0123456789");
     Buffer buffer;

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -5,10 +5,8 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/http.hpp>
-
 #include "src/http/response_parser.hpp"
+#include <measurement_kit/http.hpp>
 
 using namespace mk;
 using namespace mk::net;

--- a/test/net/buffer.cpp
+++ b/test/net/buffer.cpp
@@ -2,34 +2,28 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for net/buffer.hpp buffer.
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/net.hpp>
 #include "src/net/evbuffer.hpp"
-
 #include <event2/buffer.h>
+#include <measurement_kit/net.hpp>
 
 using namespace mk;
 using namespace mk::net;
 
-TEST_CASE("The constructor works correctly", "[Buffer]") {
+TEST_CASE("The constructor works correctly") {
     Buffer buffer;
     REQUIRE("" == buffer.read());
 }
 
-TEST_CASE("The constructor with null evbuffer works correctly", "[Buffer]") {
+TEST_CASE("The constructor with null evbuffer works correctly") {
     evbuffer *evbuf = nullptr;
     Buffer buffer(evbuf);
     REQUIRE("" == buffer.read());
 }
 
-TEST_CASE("The constructor with nonnull evbuffer works correctly", "[Buffer]") {
+TEST_CASE("The constructor with nonnull evbuffer works correctly") {
     evbuffer *evbuf = evbuffer_new();
     REQUIRE(evbuf != nullptr);
     REQUIRE(evbuffer_add(evbuf, "foobar", 6) == 0);
@@ -38,12 +32,12 @@ TEST_CASE("The constructor with nonnull evbuffer works correctly", "[Buffer]") {
     evbuffer_free(evbuf);
 }
 
-TEST_CASE("The constructor with C++ string works correctly", "[Buffer]") {
+TEST_CASE("The constructor with C++ string works correctly") {
     Buffer buffer("foobar");
     REQUIRE("foobar" == buffer.read());
 }
 
-TEST_CASE("The constructor with C string works correctly", "[Buffer]") {
+TEST_CASE("The constructor with C string works correctly") {
     Buffer buffer("foobar", 6);
     REQUIRE("foobar" == buffer.read());
 }
@@ -88,7 +82,7 @@ TEST_CASE("Insertion/extraction work correctly for evbuffer") {
     }
 }
 
-TEST_CASE("length() works correctly", "[Buffer]") {
+TEST_CASE("length() works correctly") {
     Buffer buff;
 
     SECTION("Lengh is zero at the beginning") { REQUIRE(buff.length() == 0); }
@@ -106,7 +100,7 @@ TEST_CASE("length() works correctly", "[Buffer]") {
     }
 }
 
-TEST_CASE("Foreach is robust to corner cases and errors", "[Buffer]") {
+TEST_CASE("Foreach is robust to corner cases and errors") {
     Buffer buff;
 
     SECTION("No function is invoked when the buffer is empty") {
@@ -122,7 +116,7 @@ TEST_CASE("Foreach is robust to corner cases and errors", "[Buffer]") {
      */
 }
 
-TEST_CASE("Foreach works correctly", "[Buffer]") {
+TEST_CASE("Foreach works correctly") {
 
     Buffer buff;
     auto counter = 0;
@@ -185,7 +179,7 @@ TEST_CASE("Foreach works correctly", "[Buffer]") {
     }
 }
 
-TEST_CASE("Discard works correctly", "[Buffer]") {
+TEST_CASE("Discard works correctly") {
     Buffer buff;
 
     SECTION("Discard does not misbehave when the buffer is empty") {
@@ -285,7 +279,7 @@ TEST_CASE("Readn works correctly") {
     }
 }
 
-TEST_CASE("Readline works correctly", "[Buffer]") {
+TEST_CASE("Readline works correctly") {
     Buffer buff;
     ErrorOr<std::string> line("");
 
@@ -366,7 +360,7 @@ TEST_CASE("Readline works correctly", "[Buffer]") {
     }
 }
 
-TEST_CASE("Write works correctly", "[Buffer]") {
+TEST_CASE("Write works correctly") {
     Buffer buff;
     auto pc = "0123456789";
     auto str = std::string(pc);
@@ -422,7 +416,8 @@ TEST_CASE("Write works correctly", "[Buffer]") {
             const char *p = (const char *)pp;
             for (size_t i = 0; i < n; ++i) {
                 for (auto j = 0; j < 8; ++j) {
-                    if ((p[i] & (1 << j)) == 0) ++zeroes;
+                    if ((p[i] & (1 << j)) == 0)
+                        ++zeroes;
                     ++total;
                 }
             }
@@ -439,7 +434,7 @@ TEST_CASE("Write works correctly", "[Buffer]") {
     }
 }
 
-TEST_CASE("Write into works correctly", "[Buffer]") {
+TEST_CASE("Write into works correctly") {
     Buffer buff;
 
     SECTION("Typical usage") {

--- a/test/net/connect-many.cpp
+++ b/test/net/connect-many.cpp
@@ -5,9 +5,8 @@
 #define CATCH_CONFIG_MAIN
 
 #include "src/net/connect-many.hpp"
-#include "src/net/emitter.hpp"
-#include "src/common/check_connectivity.hpp"
 #include "src/ext/Catch/single_include/catch.hpp"
+#include "src/net/emitter.hpp"
 #include <measurement_kit/common.hpp>
 using namespace mk;
 using namespace mk::net;
@@ -21,35 +20,35 @@ using namespace mk::net;
 
 */
 
-static void success(std::string, int,
-        Callback<Error, Var<Transport>> cb,
-        Settings, Var<Logger> logger, Var<Reactor>) {
+static void success(std::string, int, Callback<Error, Var<Transport>> cb,
+                    Settings, Var<Logger> logger, Var<Reactor>) {
     cb(NoError(), Var<Transport>(new Emitter(logger)));
 }
 
 TEST_CASE("net::connect_many() correctly handles net::connect() success") {
-    Var<ConnectManyCtx> ctx = connect_many_make("www.google.com", 80, 3,
-            [](Error err, std::vector<Var<Transport>> conns) {
-                REQUIRE(!err);
-                REQUIRE(conns.size() == 3);
-            },
-            {}, Logger::global(), Reactor::global());
+    Var<ConnectManyCtx> ctx =
+        connect_many_make("www.google.com", 80, 3,
+                          [](Error err, std::vector<Var<Transport>> conns) {
+                              REQUIRE(!err);
+                              REQUIRE(conns.size() == 3);
+                          },
+                          {}, Logger::global(), Reactor::global());
     connect_many_<success>(ctx);
 }
 
-static void fail(std::string, int,
-        Callback<Error, Var<Transport>> cb,
-        Settings, Var<Logger>, Var<Reactor>) {
+static void fail(std::string, int, Callback<Error, Var<Transport>> cb, Settings,
+                 Var<Logger>, Var<Reactor>) {
     cb(GenericError(), Var<Transport>(nullptr));
 }
 
 TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
-    Var<ConnectManyCtx> ctx = connect_many_make("www.google.com", 80, 3,
-            [](Error err, std::vector<Var<Transport>> conns) {
-                REQUIRE(err);
-                REQUIRE(conns.size() == 0);
-            },
-            {}, Logger::global(), Reactor::global());
+    Var<ConnectManyCtx> ctx =
+        connect_many_make("www.google.com", 80, 3,
+                          [](Error err, std::vector<Var<Transport>> conns) {
+                              REQUIRE(err);
+                              REQUIRE(conns.size() == 0);
+                          },
+                          {}, Logger::global(), Reactor::global());
     connect_many_<fail>(ctx);
 }
 
@@ -63,23 +62,20 @@ TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
 */
 
 TEST_CASE("net::connect_many() works as expected") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
+    loop_with_initial_event_and_connectivity([]() {
         connect_many("www.google.com", 80, 3,
-                [](Error error, std::vector<Var<Transport>> conns) {
-                    REQUIRE(!error);
-                    REQUIRE(conns.size() == 3);
-                    Var<int> n(new int(0));
-                    for (auto conn : conns) {
-                        REQUIRE(static_cast<bool>(conn));
-                        conn->close([n]() {
-                            if (++(*n) >= 3) {
-                                break_loop();
-                            }
-                        });
-                    }
-                });
+                     [](Error error, std::vector<Var<Transport>> conns) {
+                         REQUIRE(!error);
+                         REQUIRE(conns.size() == 3);
+                         Var<int> n(new int(0));
+                         for (auto conn : conns) {
+                             REQUIRE(static_cast<bool>(conn));
+                             conn->close([n]() {
+                                 if (++(*n) >= 3) {
+                                     break_loop();
+                                 }
+                             });
+                         }
+                     });
     });
 }

--- a/test/net/connection.cpp
+++ b/test/net/connection.cpp
@@ -2,19 +2,11 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/net/connection.h's Connection{State,}
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-
-#include <measurement_kit/net.hpp>
-
 #include "src/net/connection.hpp"
-#include "src/common/check_connectivity.hpp"
+#include <measurement_kit/net.hpp>
 
 using namespace mk;
 using namespace mk::net;

--- a/test/net/connection_check_fds.cpp
+++ b/test/net/connection_check_fds.cpp
@@ -2,18 +2,11 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
-//
-// Tests for src/net/connection.h's Connection{State,}
-//
-
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-
-#include <measurement_kit/net.hpp>
-
 #include "src/net/connection.hpp"
+#include <measurement_kit/net.hpp>
 
 using namespace mk;
 using namespace mk::net;

--- a/test/net/emitter.cpp
+++ b/test/net/emitter.cpp
@@ -5,9 +5,8 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/net.hpp>
 #include "src/net/emitter.hpp"
+#include <measurement_kit/net.hpp>
 
 using namespace mk;
 using namespace mk::net;

--- a/test/net/evbuffer.cpp
+++ b/test/net/evbuffer.cpp
@@ -5,8 +5,8 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
 #include "src/net/evbuffer.hpp"
+#include <measurement_kit/common.hpp>
 
 using namespace mk::net;
 using namespace mk;
@@ -14,9 +14,7 @@ using namespace mk;
 static evbuffer *fail() { return nullptr; }
 
 TEST_CASE("make_shared_evbuffer deals with evbuffer_new() failure") {
-    REQUIRE_THROWS_AS({
-        make_shared_evbuffer<fail>();
-    }, std::bad_alloc);
+    REQUIRE_THROWS_AS({ make_shared_evbuffer<fail>(); }, std::bad_alloc);
 }
 
 static bool ctor_called = false;
@@ -32,12 +30,10 @@ static void dtor(evbuffer *p) {
 }
 
 TEST_CASE("make_shared_evbuffer creates a Var where evbuffer_free is called "
-        "when the last Var is gone") {
+          "when the last Var is gone") {
     REQUIRE(ctor_called == false);
     REQUIRE(dtor_called == false);
-    {
-        make_shared_evbuffer<ctor, dtor>();
-    }
+    { make_shared_evbuffer<ctor, dtor>(); }
     REQUIRE(ctor_called == true);
     REQUIRE(dtor_called == true);
 }

--- a/test/net/socks5.cpp
+++ b/test/net/socks5.cpp
@@ -6,7 +6,6 @@
 
 #include "src/net/socks5.hpp"
 #include "src/ext/Catch/single_include/catch.hpp"
-#include <measurement_kit/common.hpp>
 #include <measurement_kit/net.hpp>
 using namespace mk;
 using namespace mk::net;
@@ -76,8 +75,7 @@ TEST_CASE("format_connect_request() works as expected") {
 
     SECTION("When the port number is negative") {
         ErrorOr<Buffer> rc = socks5_format_connect_request({
-            {"net/address", "130.192.91.211"},
-            {"net/port", -1},
+            {"net/address", "130.192.91.211"}, {"net/port", -1},
         });
         REQUIRE(rc.as_error() == SocksInvalidPortError());
         REQUIRE_THROWS_AS(rc.as_value(), Error);
@@ -85,8 +83,7 @@ TEST_CASE("format_connect_request() works as expected") {
 
     SECTION("When the port number is too large") {
         ErrorOr<Buffer> rc = socks5_format_connect_request({
-            {"net/address", "130.192.91.211"},
-            {"net/port", 65536},
+            {"net/address", "130.192.91.211"}, {"net/port", 65536},
         });
         REQUIRE(rc.as_error() == SocksInvalidPortError());
         REQUIRE_THROWS_AS(rc.as_value(), Error);
@@ -96,8 +93,7 @@ TEST_CASE("format_connect_request() works as expected") {
         std::string address = "130.192.91.211";
         uint16_t orig_port = 8080;
         ErrorOr<Buffer> rc = socks5_format_connect_request({
-            {"net/address", address},
-            {"net/port", orig_port},
+            {"net/address", address}, {"net/port", orig_port},
         });
         REQUIRE(rc.as_error() == NoError());
         std::string msg = rc->read(5 + address.length());
@@ -108,8 +104,8 @@ TEST_CASE("format_connect_request() works as expected") {
         REQUIRE(msg[4] == address.length());
         REQUIRE(msg.substr(5, address.length()) == address);
         // XXX This part of the test is currently not possible:
-        //uint16_t port = rc->read_uint16();
-        //REQUIRE(port == orig_port);
+        // uint16_t port = rc->read_uint16();
+        // REQUIRE(port == orig_port);
     }
 }
 
@@ -230,13 +226,13 @@ TEST_CASE("parse_connect_response() works as expected") {
         input.write_uint8(4);
         // <IPv6>
         input.write_uint8(0), input.write_uint8(0), input.write_uint8(0),
-                input.write_uint8(0);
+            input.write_uint8(0);
         input.write_uint8(0), input.write_uint8(0), input.write_uint8(0),
-                input.write_uint8(0);
+            input.write_uint8(0);
         input.write_uint8(0), input.write_uint8(0), input.write_uint8(0),
-                input.write_uint8(0);
+            input.write_uint8(0);
         input.write_uint8(0), input.write_uint8(0), input.write_uint8(0),
-                input.write_uint8(0);
+            input.write_uint8(0);
         // </IPv6>
         input.write_uint16(8080);
         ErrorOr<bool> rc = socks5_parse_connect_response(input);

--- a/test/net/transport.cpp
+++ b/test/net/transport.cpp
@@ -5,41 +5,34 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/net.hpp>
-
 #include "src/common/check_connectivity.hpp"
-
-#include <iostream>
-
+#include <measurement_kit/net.hpp>
 using namespace mk;
 using namespace mk::net;
 
 TEST_CASE("net::connect() works with a custom reactor") {
     // Note: this is how Portolan uses measurement-kit
-    if (CheckConnectivity::is_down()) {
-        return;
+    if (!CheckConnectivity::is_down()) {
+        set_verbosity(MK_LOG_DEBUG);
+        Var<Reactor> reactor = Reactor::make();
+        auto ok = false;
+        connect("nexa.polito.it", 22,
+                [&](Error error, Var<Transport> txp) {
+                    if (error) {
+                        reactor->break_loop();
+                        return;
+                    }
+                    txp->close([&]() { reactor->break_loop(); });
+                    ok = true;
+                },
+                {}, Logger::global(), reactor);
+        reactor->loop();
+        REQUIRE(ok);
     }
-    set_verbosity(MK_LOG_DEBUG);
-    Var<Reactor> reactor = Reactor::make();
-    auto ok = false;
-    connect("nexa.polito.it", 22, [&](Error error, Var<Transport> txp) {
-        if (error) {
-            reactor->break_loop();
-            return;
-        }
-        txp->close([&]() { reactor->break_loop(); });
-        ok = true;
-    }, {}, Logger::global(), reactor);
-    reactor->loop();
-    REQUIRE(ok);
 }
 
 TEST_CASE("net::connect() can connect to open port") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
+    loop_with_initial_event_and_connectivity([]() {
         connect("www.kernel.org", 80, [](Error error, Var<Transport> txp) {
             REQUIRE(!error);
             Var<ConnectResult> cr = error.context.as<ConnectResult>();
@@ -54,103 +47,98 @@ TEST_CASE("net::connect() can connect to open port") {
 }
 
 TEST_CASE("net::connect() can connect to ssl port") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    set_verbosity(MK_LOG_DEBUG);
-    loop_with_initial_event([]() {
-        connect("nexa.polito.it", 443, [](Error error, Var<Transport> txp) {
-            REQUIRE(!error);
-            Var<ConnectResult> cr = error.context.as<ConnectResult>();
-            REQUIRE(cr);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
-            REQUIRE(cr->resolve_result.addresses.size() > 0);
-            REQUIRE(cr->connected_bev);
-            txp->close([]() { break_loop(); });
-        },
-        {{"net/ssl", true}, {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+    loop_with_initial_event_and_connectivity([]() {
+        set_verbosity(MK_LOG_DEBUG);
+        connect("nexa.polito.it", 443,
+                [](Error error, Var<Transport> txp) {
+                    REQUIRE(!error);
+                    Var<ConnectResult> cr = error.context.as<ConnectResult>();
+                    REQUIRE(cr);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+                    REQUIRE(cr->resolve_result.addresses.size() > 0);
+                    REQUIRE(cr->connected_bev);
+                    txp->close([]() { break_loop(); });
+                },
+                {{"net/ssl", true},
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
     });
 }
 
 TEST_CASE("net::connect() ssl fails when presented an expired certificate") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    set_verbosity(MK_LOG_DEBUG);
-    loop_with_initial_event([]() {
-        connect("expired.badssl.com", 443, [](Error error, Var<Transport> txp) {
-            REQUIRE(error);
-            break_loop();
-        },
-        {{"net/ssl", true}, {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+    loop_with_initial_event_and_connectivity([]() {
+        set_verbosity(MK_LOG_DEBUG);
+        connect("expired.badssl.com", 443,
+                [](Error error, Var<Transport> txp) {
+                    REQUIRE(error);
+                    break_loop();
+                },
+                {{"net/ssl", true},
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
     });
 }
 
-TEST_CASE("net::connect() ssl fails when presented a certificate with the wrong hostname") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    set_verbosity(MK_LOG_DEBUG);
-    loop_with_initial_event([]() {
-        connect("wrong.host.badssl.com", 443, [](Error error, Var<Transport> txp) {
-            REQUIRE(error);
-            break_loop();
-        },
-        {{"net/ssl", true}, {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+TEST_CASE("net::connect() ssl fails when presented a certificate with the "
+          "wrong hostname") {
+    loop_with_initial_event_and_connectivity([]() {
+        set_verbosity(MK_LOG_DEBUG);
+        connect("wrong.host.badssl.com", 443,
+                [](Error error, Var<Transport> txp) {
+                    REQUIRE(error);
+                    break_loop();
+                },
+                {{"net/ssl", true},
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
     });
 }
 
 TEST_CASE("net::connect() ssl works when using SNI") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    set_verbosity(MK_LOG_DEBUG);
-    loop_with_initial_event([]() {
-        connect("sha256.badssl.com", 443, [](Error error, Var<Transport> txp) {
-            REQUIRE(!error);
-            txp->close([]() { break_loop(); });
-        },
-        {{"net/ssl", true}, {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+    loop_with_initial_event_and_connectivity([]() {
+        set_verbosity(MK_LOG_DEBUG);
+        connect("sha256.badssl.com", 443,
+                [](Error error, Var<Transport> txp) {
+                    REQUIRE(!error);
+                    txp->close([]() { break_loop(); });
+                },
+                {{"net/ssl", true},
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
     });
 }
 
-TEST_CASE("net::connect() ssl works when setting ca_bundle_path via global settings") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
+TEST_CASE("net::connect() ssl works when setting ca_bundle_path via global "
+          "settings") {
     set_verbosity(MK_LOG_DEBUG);
     Var<Settings> global_settings = Settings::global();
     (*global_settings)["net/ca_bundle_path"] = "test/fixtures/certs.pem";
-    loop_with_initial_event([]() {
-        connect("nexa.polito.it", 443, [](Error error, Var<Transport> txp) {
-            REQUIRE(!error);
-            Var<ConnectResult> cr = error.context.as<ConnectResult>();
-            REQUIRE(cr);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
-            REQUIRE(cr->resolve_result.addresses.size() > 0);
-            REQUIRE(cr->connected_bev);
-            txp->close([]() { break_loop(); });
-        },
-        {{"net/ssl", true}});
+    loop_with_initial_event_and_connectivity([]() {
+        connect("nexa.polito.it", 443,
+                [](Error error, Var<Transport> txp) {
+                    REQUIRE(!error);
+                    Var<ConnectResult> cr = error.context.as<ConnectResult>();
+                    REQUIRE(cr);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+                    REQUIRE(cr->resolve_result.addresses.size() > 0);
+                    REQUIRE(cr->connected_bev);
+                    txp->close([]() { break_loop(); });
+                },
+                {{"net/ssl", true}});
     });
 }
 
 TEST_CASE("net::connect() works in case of error") {
-    if (CheckConnectivity::is_down()) {
-        return;
-    }
-    loop_with_initial_event([]() {
-        connect("nexa.polito.it", 81, [](Error error, Var<Transport>) {
-            REQUIRE(error);
-            Var<ConnectResult> cr = error.context.as<ConnectResult>();
-            REQUIRE(cr);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv4);
-            REQUIRE(!cr->resolve_result.inet_pton_ipv6);
-            REQUIRE(cr->resolve_result.addresses.size() > 0);
-            REQUIRE(!cr->connected_bev);
-            break_loop();
-        }, {{"net/timeout", 5.0}});
+    loop_with_initial_event_and_connectivity([]() {
+        connect("nexa.polito.it", 81,
+                [](Error error, Var<Transport>) {
+                    REQUIRE(error);
+                    Var<ConnectResult> cr = error.context.as<ConnectResult>();
+                    REQUIRE(cr);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv4);
+                    REQUIRE(!cr->resolve_result.inet_pton_ipv6);
+                    REQUIRE(cr->resolve_result.addresses.size() > 0);
+                    REQUIRE(!cr->connected_bev);
+                    break_loop();
+                },
+                {{"net/timeout", 5.0}});
     });
 }

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -17,9 +17,10 @@ TEST_CASE(
     options["backend"] = "8.8.8.1:53";
     options["dns/timeout"] = 0.1;
     DNSInjectionImpl dns_injection("test/fixtures/hosts.txt", options);
-    dns_injection.begin(
-        [&]() { dns_injection.end([]() { mk::break_loop(); }); });
-    mk::loop();
+    loop_with_initial_event_and_connectivity([&]() {
+        dns_injection.begin(
+            [&]() { dns_injection.end([]() { break_loop(); }); });
+    });
 }
 
 TEST_CASE("The DNS Injection test should throw an exception if an invalid file "

--- a/test/ooni/dns_injection_test.cpp
+++ b/test/ooni/dns_injection_test.cpp
@@ -5,13 +5,13 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "src/ooni/ooni_test_impl.hpp"
 #include <chrono>
 #include <iostream>
 #include <list>
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -23,7 +23,8 @@ TEST_CASE("Synchronous dns-injection test") {
         .set_input_file_path("test/fixtures/hosts.txt")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Asynchronous dns-injection test") {
@@ -38,26 +39,29 @@ TEST_CASE("Asynchronous dns-injection test") {
     do {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     } while (!done);
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Make sure that set_output_path() works") {
     auto instance = ooni::DnsInjectionTest()
-        // Note: must also set valid input file path otherwise the constructor
-        // called inside create_test_() throws an exception
-        .set_input_file_path("test/fixtures/hosts.txt")
-        .set_output_file_path("foo.txt")
-        .create_test_();
+                        // Note: must also set valid input file path otherwise
+                        // the constructor
+                        // called inside create_test_() throws an exception
+                        .set_input_file_path("test/fixtures/hosts.txt")
+                        .set_output_file_path("foo.txt")
+                        .create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
 TEST_CASE("Make sure that default get_output_path() is nonempty") {
     auto instance = ooni::DnsInjectionTest()
-        // Note: must also set valid input file path otherwise the constructor
-        // called inside create_test_() throws an exception
-        .set_input_file_path("test/fixtures/hosts.txt")
-        .create_test_();
+                        // Note: must also set valid input file path otherwise
+                        // the constructor
+                        // called inside create_test_() throws an exception
+                        .set_input_file_path("test/fixtures/hosts.txt")
+                        .create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -15,21 +15,22 @@ TEST_CASE("The HTTP Invalid Request Line test should run") {
     Settings options;
     options["backend"] = "http://213.138.109.232/";
     HTTPInvalidRequestLineImpl http_invalid_request_line(options);
-    http_invalid_request_line.begin([&]() {
-        http_invalid_request_line.end([]() { mk::break_loop(); });
+    loop_with_initial_event_and_connectivity([&]() {
+        http_invalid_request_line.begin(
+            [&]() { http_invalid_request_line.end([]() { break_loop(); }); });
     });
-    mk::loop();
 }
 
-TEST_CASE("The HTTP Invalid Request Line can manage a failure while connecting") {
+TEST_CASE(
+    "The HTTP Invalid Request Line can manage a failure while connecting") {
     Settings options;
     options["backend"] = "http://213.138.109.232/";
     options["dns/nameserver"] = "8.8.8.1";
     options["dns/timeout"] = 0.1;
     HTTPInvalidRequestLineImpl http_invalid_request_line(options);
-    loop_with_initial_event([&]() {
+    loop_with_initial_event_and_connectivity([&]() {
         http_invalid_request_line.begin([&]() {
-            http_invalid_request_line.end([]() { mk::break_loop(); });
+            http_invalid_request_line.end([]() { break_loop(); });
         });
     });
 }

--- a/test/ooni/http_invalid_request_line_test.cpp
+++ b/test/ooni/http_invalid_request_line_test.cpp
@@ -5,13 +5,13 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "src/ooni/ooni_test_impl.hpp"
 #include <chrono>
 #include <iostream>
 #include <list>
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -21,16 +21,19 @@ TEST_CASE("Synchronous http-invalid-request-line test") {
         .set_options("backend", "http://213.138.109.232/")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Synchronous http-invalid-request-line test with HTTP backend") {
     Var<std::list<std::string>> logs(new std::list<std::string>);
     ooni::HttpInvalidRequestLineTest()
-        .set_options("backend", "http://data.neubot.org/") // Let's troll Davide!
+        .set_options("backend",
+                     "http://data.neubot.org/") // Let's troll Davide!
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Asynchronous http-invalid-request-line test") {
@@ -43,20 +46,20 @@ TEST_CASE("Asynchronous http-invalid-request-line test") {
     do {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     } while (!done);
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Make sure that set_output_path() works") {
     auto instance = ooni::HttpInvalidRequestLineTest()
-        .set_output_file_path("foo.txt")
-        .create_test_();
+                        .set_output_file_path("foo.txt")
+                        .create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
 TEST_CASE("Make sure that default get_output_path() is nonempty") {
-    auto instance = ooni::HttpInvalidRequestLineTest()
-        .create_test_();
+    auto instance = ooni::HttpInvalidRequestLineTest().create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }
@@ -70,7 +73,8 @@ TEST_CASE("Make sure that it can pass options to the other levels") {
         .set_options("dns/attempts", "1")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Make sure that the test can deal with an invalid backend") {
@@ -79,5 +83,6 @@ TEST_CASE("Make sure that the test can deal with an invalid backend") {
         .set_options("backend", "nexacenter.org")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }

--- a/test/ooni/net_test.cpp
+++ b/test/ooni/net_test.cpp
@@ -5,13 +5,16 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/common.hpp>
 #include "src/ooni/ooni_test_impl.hpp"
+#include <measurement_kit/common.hpp>
 
 using namespace mk::ooni;
+using namespace mk;
 
 TEST_CASE("The NetTest should callback when it has finished running") {
     mk::ooni::OoniTestImpl test("");
-    test.begin([&]() { test.end([]() { mk::break_loop(); }); });
-    mk::loop();
+    // Note: connectivity not needed here
+    loop_with_initial_event([&]() {
+        test.begin([&]() { test.end([]() { break_loop(); }); });
+    });
 }

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -13,12 +13,13 @@ using namespace mk::ooni;
 
 TEST_CASE(
     "The TCP connect test should run with an input file of DNS hostnames") {
-    TCPConnectImpl tcp_connect("test/fixtures/hosts.txt", {
-                                                       {"port", "80"},
-                                                      });
-    tcp_connect.begin(
-        [&]() { tcp_connect.end([]() { mk::break_loop(); }); });
-    mk::loop();
+    TCPConnectImpl tcp_connect("test/fixtures/hosts.txt",
+                               {
+                                   {"port", "80"},
+                               });
+    loop_with_initial_event_and_connectivity([&]() {
+        tcp_connect.begin([&]() { tcp_connect.end([]() { break_loop(); }); });
+    });
 }
 
 TEST_CASE("The TCP connect test should throw an exception if an invalid file "
@@ -34,14 +35,13 @@ TEST_CASE(
 }
 
 TEST_CASE("The TCP connect test should fail with an invalid dns resolver") {
-    loop_with_initial_event([=]() {
-        TCPConnectImpl tcp_connect("test/fixtures/hosts.txt",
-                                      {{"host", "nexacenter.org"},
-                                       {"port", "80"},
-                                       {"dns/nameserver", "8.8.8.1"},
-                                       {"dns/attempts", 1},
-                                       {"dns/timeout", 0.0001}});
-        tcp_connect.begin(
-            [&]() { tcp_connect.end([]() { mk::break_loop(); }); });
+    TCPConnectImpl tcp_connect("test/fixtures/hosts.txt",
+                               {{"host", "nexacenter.org"},
+                                {"port", "80"},
+                                {"dns/nameserver", "8.8.8.1"},
+                                {"dns/attempts", 1},
+                                {"dns/timeout", 0.0001}});
+    loop_with_initial_event([&]() {
+        tcp_connect.begin([&]() { tcp_connect.end([]() { break_loop(); }); });
     });
 }

--- a/test/ooni/tcp_connect_test.cpp
+++ b/test/ooni/tcp_connect_test.cpp
@@ -5,13 +5,13 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
+#include "src/ooni/ooni_test_impl.hpp"
 #include <chrono>
 #include <iostream>
 #include <list>
 #include <measurement_kit/ooni.hpp>
 #include <string>
 #include <thread>
-#include "src/ooni/ooni_test_impl.hpp"
 
 using namespace mk;
 
@@ -22,7 +22,8 @@ TEST_CASE("Synchronous tcp-connect test") {
         .set_input_file_path("test/fixtures/hosts.txt")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Asynchronous tcp-connect test") {
@@ -36,26 +37,29 @@ TEST_CASE("Asynchronous tcp-connect test") {
     do {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     } while (!done);
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }
 
 TEST_CASE("Make sure that set_output_path() works") {
     auto instance = ooni::TcpConnectTest()
-        // Note: must also set valid input file path otherwise the constructor
-        // called inside create_test_() throws an exception
-        .set_input_file_path("test/fixtures/hosts.txt")
-        .set_output_file_path("foo.txt")
-        .create_test_();
+                        // Note: must also set valid input file path otherwise
+                        // the constructor
+                        // called inside create_test_() throws an exception
+                        .set_input_file_path("test/fixtures/hosts.txt")
+                        .set_output_file_path("foo.txt")
+                        .create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() == "foo.txt");
 }
 
 TEST_CASE("Make sure that default get_output_path() is nonempty") {
     auto instance = ooni::TcpConnectTest()
-        // Note: must also set valid input file path otherwise the constructor
-        // called inside create_test_() throws an exception
-        .set_input_file_path("test/fixtures/hosts.txt")
-        .create_test_();
+                        // Note: must also set valid input file path otherwise
+                        // the constructor
+                        // called inside create_test_() throws an exception
+                        .set_input_file_path("test/fixtures/hosts.txt")
+                        .create_test_();
     auto ptr = static_cast<ooni::OoniTestImpl *>(instance.get());
     REQUIRE(ptr->get_report_filename() != "");
 }
@@ -70,5 +74,6 @@ TEST_CASE("The test should fail with an invalid dns") {
         .set_input_file_path("test/fixtures/hosts.txt")
         .on_log([=](uint32_t, const char *s) { logs->push_back(s); })
         .run();
-    for (auto &s : *logs) std::cout << s << "\n";
+    for (auto &s : *logs)
+        std::cout << s << "\n";
 }

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -5,16 +5,10 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include "src/common/check_connectivity.hpp"
 #include "src/ooni/utils.hpp"
-#include <measurement_kit/common.hpp>
-#include <measurement_kit/http.hpp>
 
 TEST_CASE("ip lookup works") {
-    if (mk::CheckConnectivity::is_down()) {
-        return;
-    }
-    mk::loop_with_initial_event([]() {
+    mk::loop_with_initial_event_and_connectivity([]() {
         mk::ooni::ip_lookup([](mk::Error err, std::string) {
             REQUIRE(err == mk::NoError());
             mk::break_loop();

--- a/test/traceroute/android.cpp
+++ b/test/traceroute/android.cpp
@@ -10,10 +10,8 @@
 #define CATCH_CONFIG_MAIN
 #include "src/ext/Catch/single_include/catch.hpp"
 
-#include <measurement_kit/traceroute.hpp>
-#include <measurement_kit/common.hpp>
-
 #include <iostream>
+#include <measurement_kit/traceroute.hpp>
 
 using namespace mk::traceroute;
 using namespace mk;
@@ -24,35 +22,38 @@ TEST_CASE("Typical IPv4 traceroute usage") {
     auto prober = Prober<AndroidProber>(true, 11829);
     auto ttl = 1;
 
-    prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
-        std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
-        if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
-    });
+    loop_with_initial_event_and_connectivity([&]() {
+        prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
+            std::cout << ttl << " " << r.interface_ip << " " << r.rtt
+                      << " ms\n";
+            if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED ||
+                ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+        });
 
-    prober.on_timeout([&prober, &ttl, &payload]() {
-        std::cout << ttl << " *\n";
-        if (ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
-    });
+        prober.on_timeout([&prober, &ttl, &payload]() {
+            std::cout << ttl << " *\n";
+            if (ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+        });
 
-    prober.on_error([&prober, &ttl, &payload](Error err) {
-        std::cout << ttl << " error: " << err.what() << "\n";
-        if (ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
-    });
+        prober.on_error([&prober, &ttl, &payload](Error err) {
+            std::cout << ttl << " error: " << err.what() << "\n";
+            if (ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("8.8.8.8", 33434, ++ttl, payload, 1.0);
+        });
 
-    prober.send_probe("8.8.8.8", 33434, ttl, payload, 1.0);
-    mk::loop();
+        prober.send_probe("8.8.8.8", 33434, ttl, payload, 1.0);
+    });
 }
 
 TEST_CASE("Check whether it works when destination sends reply") {
@@ -61,35 +62,38 @@ TEST_CASE("Check whether it works when destination sends reply") {
     auto prober = Prober<AndroidProber>(true, 11829);
     auto ttl = 1;
 
-    prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
-        std::cout << ttl << " " << r.interface_ip << " " << r.rtt << " ms\n";
-        if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED || ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
-    });
+    loop_with_initial_event_and_connectivity([&]() {
+        prober.on_result([&prober, &ttl, &payload](ProbeResult r) {
+            std::cout << ttl << " " << r.interface_ip << " " << r.rtt
+                      << " ms\n";
+            if (r.get_meaning() != ProbeResultMeaning::TTL_EXCEEDED ||
+                ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+        });
 
-    prober.on_timeout([&prober, &ttl, &payload]() {
-        std::cout << ttl << " *\n";
-        if (ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
-    });
+        prober.on_timeout([&prober, &ttl, &payload]() {
+            std::cout << ttl << " *\n";
+            if (ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+        });
 
-    prober.on_error([&prober, &ttl, &payload](Error err) {
-        std::cout << ttl << " error: " << err.what() << "\n";
-        if (ttl >= 64) {
-            mk::break_loop();
-            return;
-        }
-        prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
-    });
+        prober.on_error([&prober, &ttl, &payload](Error err) {
+            std::cout << ttl << " error: " << err.what() << "\n";
+            if (ttl >= 64) {
+                break_loop();
+                return;
+            }
+            prober.send_probe("208.67.222.222", 53, ++ttl, payload, 1.0);
+        });
 
-    prober.send_probe("208.67.222.222", 53, ttl, payload, 1.0);
-    mk::loop();
+        prober.send_probe("208.67.222.222", 53, ttl, payload, 1.0);
+    });
 }
 
 #else


### PR DESCRIPTION
The most dangerous error I could have made here is to move variables initialized on the stack inside of the initial event callback. [This happened and had clear impact on regress tests](https://travis-ci.org/measurement-kit/measurement-kit/builds/130248204).