### PR TITLE
Backport changes from NDT branch

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -1,7 +1,6 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
 #ifndef MEASUREMENT_KIT_COMMON_ERROR_HPP
 #define MEASUREMENT_KIT_COMMON_ERROR_HPP
 
@@ -17,6 +16,9 @@ class ErrorContext {};
 /// An error that occurred
 class Error : public std::exception {
   public:
+    Error(int e, std::string ooe, Error c)
+        : child(new Error(c)), error_(e), ooni_error_(ooe) {}
+
     /// Constructor with error code and OONI error
     Error(int e, std::string ooe) : error_(e), ooni_error_(ooe) {}
 
@@ -39,6 +41,7 @@ class Error : public std::exception {
     std::string as_ooni_error() { return ooni_error_; }
 
     Var<ErrorContext> context;
+    Var<Error> child;
 
   private:
     int error_ = 0;
@@ -49,12 +52,16 @@ class Error : public std::exception {
     class _name_ : public Error {                                              \
       public:                                                                  \
         _name_() : Error(_code_, _ooe_) {}                                     \
+        _name_(Error e) : Error(_code_, _ooe_, e) {}                           \
     };
 
 MK_DEFINE_ERR(0, NoError, "")
 MK_DEFINE_ERR(1, GenericError, "unknown_failure 1")
 MK_DEFINE_ERR(2, NotInitializedError, "unknown_failure 2")
 MK_DEFINE_ERR(3, ValueError, "unknown_failure 3")
+MK_DEFINE_ERR(4, MockedError, "unknown_failure 4")
+MK_DEFINE_ERR(5, JsonParseError, "unknown_failure 5")
+MK_DEFINE_ERR(6, JsonKeyError, "unknown_failure 6")
 
 } // namespace mk
 #endif

--- a/include/measurement_kit/common/mock.hpp
+++ b/include/measurement_kit/common/mock.hpp
@@ -4,6 +4,8 @@
 #ifndef MEASUREMENT_KIT_COMMON_MOCK_HPP
 #define MEASUREMENT_KIT_COMMON_MOCK_HPP
 
+#include <measurement_kit/common/error.hpp>
+
 /*
 Simplifies life when you use templates for mocking APIs because
 allows you to write the following:
@@ -20,8 +22,15 @@ Which is arguably faster than writing the following:
 */
 #define MK_MOCK(name_) decltype(name_) name_ = name_
 
+// Same as MK_MOCK but with suffix
+#define MK_MOCK_SUFFIX(name_, suffix_) decltype(name_) name_##_##suffix_ = name_
+
 // Same as MK_MOCK but with namespace
 #define MK_MOCK_NAMESPACE(ns_, name_)                                          \
-    decltype(ns_::name_) ns_ ## _ ## name_ = ns_::name_
+    decltype(ns_::name_) ns_##_##name_ = ns_::name_
+
+// Same as MK_MOCK_NAMESPACE but with suffix
+#define MK_MOCK_NAMESPACE_SUFFIX(ns_, name_, suffix_)                          \
+    decltype(ns_::name_) ns_##_##name_##_##suffix_ = ns_::name_
 
 #endif

--- a/include/measurement_kit/common/mock.hpp
+++ b/include/measurement_kit/common/mock.hpp
@@ -4,8 +4,6 @@
 #ifndef MEASUREMENT_KIT_COMMON_MOCK_HPP
 #define MEASUREMENT_KIT_COMMON_MOCK_HPP
 
-#include <measurement_kit/common/error.hpp>
-
 /*
 Simplifies life when you use templates for mocking APIs because
 allows you to write the following:

--- a/include/measurement_kit/mlabns/mlabns.hpp
+++ b/include/measurement_kit/mlabns/mlabns.hpp
@@ -20,7 +20,6 @@ MK_DEFINE_ERR(5001, InvalidAddressFamilyError, "unknown_failure 5001")
 MK_DEFINE_ERR(5002, InvalidMetroError, "unknown_failure 5002")
 MK_DEFINE_ERR(5003, InvalidToolNameError, "unknown_failure 5003")
 MK_DEFINE_ERR(5004, UnexpectedHttpStatusCodeError, "unknown_failure 5004")
-MK_DEFINE_ERR(5005, JsonParsingError, "unknown_failure 5005")
 
 /// Reply to mlab-ns query.
 class Reply {

--- a/src/mlabns/mlabns.cpp
+++ b/src/mlabns/mlabns.cpp
@@ -101,10 +101,10 @@ void query(std::string tool, Callback<Error, Reply> callback, Settings settings,
                           reply.site = node["site"];
                           reply.country = node["country"];
                       } catch (std::invalid_argument &) {
-                          callback(JsonParsingError(), Reply());
+                          callback(JsonParseError(), Reply());
                           return;
                       } catch (std::out_of_range &) {
-                          callback(JsonParsingError(), Reply());
+                          callback(JsonKeyError(), Reply());
                           return;
                       }
                       logger->info("mlabns says to use %s", reply.fqdn.c_str());


### PR DESCRIPTION
1) allow an error to contain a lower level error

2) define `MockedError`: this is the error value that should be
   used in regress tests when generic failure is mocked

3) add and use json parsing and access errors: those are generic and
   hence they should stay in common

4) allow mock with suffix to mock different invocation of the same
   function within a template

5) propagate changes described in 3) to mlabns code