### PR TITLE
Remove polling while running synchronous tests

### DIFF
--- a/src/common/net_test_dsl.cpp
+++ b/src/common/net_test_dsl.cpp
@@ -14,10 +14,10 @@ namespace mk {
 void NetTestDsl::run() {
     // XXX Ideally it would be best to run this in the current thread with
     // a dedicated reactor, but the code is not yet ready for that.
-    std::promise<bool> accumulate_promise;
-    std::future<bool> accumulate_future = accumulate_promise.get_future();
-    run([&accumulate_promise]() { accumulate_promise.set_value(true);});
-    accumulate_future.wait();
+    std::promise<bool> promise;
+    std::future<bool> future = promise.get_future();
+    run([&promise]() { promise.set_value(true);});
+    future.wait();
 }
 
 void NetTestDsl::run(std::function<void()> callback) {

--- a/src/common/net_test_dsl.cpp
+++ b/src/common/net_test_dsl.cpp
@@ -14,7 +14,6 @@ namespace mk {
 void NetTestDsl::run() {
     // XXX Ideally it would be best to run this in the current thread with
     // a dedicated reactor, but the code is not yet ready for that.
-    bool done = false;
     std::promise<bool> accumulate_promise;
     std::future<bool> accumulate_future = accumulate_promise.get_future();
     run([&accumulate_promise]() { accumulate_promise.set_value(true);});

--- a/src/common/net_test_dsl.cpp
+++ b/src/common/net_test_dsl.cpp
@@ -7,6 +7,7 @@
 #include <measurement_kit/common.hpp>
 #include <ratio>
 #include <thread>
+#include <future>
 
 namespace mk {
 
@@ -14,10 +15,10 @@ void NetTestDsl::run() {
     // XXX Ideally it would be best to run this in the current thread with
     // a dedicated reactor, but the code is not yet ready for that.
     bool done = false;
-    run([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    std::promise<bool> accumulate_promise;
+    std::future<bool> accumulate_future = accumulate_promise.get_future();
+    run([&accumulate_promise]() { accumulate_promise.set_value(true);});
+    accumulate_future.wait();
 }
 
 void NetTestDsl::run(std::function<void()> callback) {


### PR DESCRIPTION
Instead of blocking the thread usign a sleep, a better solution is to use some thread synchronization methods, like std::promise and std::future. 