### PR TITLE
configure: add -pthread to flags only when needed

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -212,7 +212,6 @@ CXXFLAGS="$measurement_kit_saved_cxxflags $measurement_kit_cxx_stdlib_flags"
 AC_LANG_POP([C++])
 ])
 
-
 AC_DEFUN([MK_CHECK_CA_BUNDLE], [
   AC_MSG_CHECKING([CA bundle path])
 
@@ -255,6 +254,44 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
   fi
 ])
 
+AC_DEFUN([MK_AM_PTHREAD_COMPILE], [
+  AC_MSG_CHECKING([whether we can omit -pthread when compiling threaded code])
+  AC_COMPILE_IFELSE([
+    AC_LANG_SOURCE([
+      #include <pthread.h>
+      int main() {
+        pthread_mutex_t mutex;
+        pthread_mutex_create(&mutex, 0);
+        return 0;
+      }
+    ])
+  ],
+  [AC_MSG_RESULT([no])],
+  [
+    AC_MSG_RESULT([yes])
+    CFLAGS="$CFLAGS -pthread"
+    CXXFLAGS="$CXXFLAGS -pthread"
+  ])
+])
+
+AC_DEFUN([MK_AM_PTHREAD_LINK], [
+  AC_MSG_CHECKING([whether we can omit -pthread when linking threaded code])
+  AC_LINK_IFELSE([
+    AC_LANG_SOURCE([
+      #include <pthread.h>
+      int main() {
+        pthread_mutex_t mutex;
+        pthread_mutex_create(&mutex, 0);
+        return 0;
+      }
+    ])
+  ],
+  [AC_MSG_RESULT([no])],
+  [
+    AC_MSG_RESULT([yes])
+    LDFLAGS="$LDFLAGS -pthread"
+  ])
+])
 
 AC_DEFUN([MK_AM_CXXFLAGS_ADD_WARNINGS], [
   AC_MSG_CHECKING([whether compiler is clang to add clang specific warnings])

--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,8 @@ MK_AM_ENABLE_EXAMPLES
 # checks for libraries
 
 # Must set -pthread before testing for -levent_pthreads
-CFLAGS="$CFLAGS -pthread"
-CXXFLAGS="$CXXFLAGS -pthread"
-LDFLAGS="$LDFLAGS -pthread"
+MK_AM_PTHREAD_COMPILE
+MK_AM_PTHREAD_LINK
 
 echo ""
 MK_AM_OPENSSL


### PR DESCRIPTION
Prodded by @AntonioLangiu.

I have omitted the action to be performed when cross compiling, under the assumption that omitting the action leads to executing the main action specified by the macro also when cross compiling.

If my assumption is wrong, then perhaps this diff is broken. I shall now check whether this works by cross-compiling MK for iOS and then update on that in a short while.

- - - 

Update: the assumption was OK. Cross compiling for iOS went straight on.