### PR TITLE
Remove redundant declarations

### DIFF
--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -142,11 +142,6 @@ class OoniTestImpl : public mk::NetTest {
         input = nullptr;
     }
 
-    OoniTestImpl(OoniTestImpl &) = delete;
-    OoniTestImpl &operator=(OoniTestImpl &) = delete;
-    OoniTestImpl(OoniTestImpl &&) = default;
-    OoniTestImpl &operator=(OoniTestImpl &&) = default;
-
     OoniTestImpl(std::string input_filepath_)
         : OoniTestImpl(input_filepath_, Settings()) {}
 


### PR DESCRIPTION
[NetTest is already non-copyable and non-movable](https://github.com/measurement-kit/measurement-kit/blob/master/include/measurement_kit/common/net_test.hpp#L18), so it would be redundant to declare it as non-copyable and movable.

Closes #343.