### PR TITLE
Fail the configure if the ca-bundle is not found

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -239,8 +239,6 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
             break
           fi
         done
-    else
-      AC_MSG_WARN([skipped the ca-bundle detection when cross-compiling])
     fi
   fi
 
@@ -250,7 +248,8 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
     AC_SUBST(MK_CA_BUNDLE)
     AC_MSG_RESULT([$ca])
   elif test "x$cross_compiling" == "xyes"; then
-    AC_MSG_RESULT([no])
+    AC_MSG_RESULT([skipped (cross compiling)])
+    AC_MSG_WARN([skipped the ca-bundle detection when cross-compiling])
   else
     AC_MSG_ERROR([you should give a ca-bundle location])
   fi

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -251,6 +251,7 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
     AC_MSG_RESULT([skipped (cross compiling)])
     AC_MSG_WARN([skipped the ca-bundle detection when cross-compiling])
   else
+    AC_MSG_RESULT([no])
     AC_MSG_ERROR([you should give a ca-bundle location])
   fi
 ])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -249,8 +249,10 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
     AC_DEFINE_UNQUOTED(MK_CA_BUNDLE, "$ca", [Location of default ca bundle])
     AC_SUBST(MK_CA_BUNDLE)
     AC_MSG_RESULT([$ca])
-  else
+  elif test "x$cross_compiling" == "xyes"; then
     AC_MSG_RESULT([no])
+  else
+    AC_MSG_ERROR([you should give a ca-bundle location])
   fi
 ])
 


### PR DESCRIPTION
As discussed with @bassosimone, we think that the build fase should fail if the configure is not able to find a ca-bundle.

This will not be checked when cross-compiling!

When testing this pull request I noticed that when cross-compiling for iOS we build for different architectures, and when we build for the `iphonesimulator` the system detect it as not cross-compiling, so the ca-bundle will be searched in the default directories of OSX. I think this should not be a problem because the applications should give a local ca-bundle inside the package, and the iphonesimulator will take that, but I think this is a good thing to know in case of future problems! 