### PR TITLE
Revert "configure: add -pthread to flags only when needed (#607)"

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -212,6 +212,7 @@ CXXFLAGS="$measurement_kit_saved_cxxflags $measurement_kit_cxx_stdlib_flags"
 AC_LANG_POP([C++])
 ])
 
+
 AC_DEFUN([MK_CHECK_CA_BUNDLE], [
   AC_MSG_CHECKING([CA bundle path])
 
@@ -256,44 +257,6 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
   fi
 ])
 
-AC_DEFUN([MK_AM_PTHREAD_COMPILE], [
-  AC_MSG_CHECKING([whether we can omit -pthread when compiling threaded code])
-  AC_COMPILE_IFELSE([
-    AC_LANG_SOURCE([
-      #include <pthread.h>
-      int main() {
-        pthread_mutex_t mutex;
-        pthread_mutex_create(&mutex, 0);
-        return 0;
-      }
-    ])
-  ],
-  [AC_MSG_RESULT([no])],
-  [
-    AC_MSG_RESULT([yes])
-    CFLAGS="$CFLAGS -pthread"
-    CXXFLAGS="$CXXFLAGS -pthread"
-  ])
-])
-
-AC_DEFUN([MK_AM_PTHREAD_LINK], [
-  AC_MSG_CHECKING([whether we can omit -pthread when linking threaded code])
-  AC_LINK_IFELSE([
-    AC_LANG_SOURCE([
-      #include <pthread.h>
-      int main() {
-        pthread_mutex_t mutex;
-        pthread_mutex_create(&mutex, 0);
-        return 0;
-      }
-    ])
-  ],
-  [AC_MSG_RESULT([no])],
-  [
-    AC_MSG_RESULT([yes])
-    LDFLAGS="$LDFLAGS -pthread"
-  ])
-])
 
 AC_DEFUN([MK_AM_CXXFLAGS_ADD_WARNINGS], [
   AC_MSG_CHECKING([whether compiler is clang to add clang specific warnings])

--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,9 @@ MK_AM_ENABLE_EXAMPLES
 # checks for libraries
 
 # Must set -pthread before testing for -levent_pthreads
-MK_AM_PTHREAD_COMPILE
-MK_AM_PTHREAD_LINK
+CFLAGS="$CFLAGS -pthread"
+CXXFLAGS="$CXXFLAGS -pthread"
+LDFLAGS="$LDFLAGS -pthread"
 
 echo ""
 MK_AM_OPENSSL


### PR DESCRIPTION
This reverts commit 6ceb9e875741b1cd18f92cf520a6e9ab82e749d8 because it
was the wrong way to address the issue, unfortunately.

The warning was still present. Then, I further investigated and understood
that the way in which clang for OSX deals with -pthread is different from the
way in which the same flag is dealt with on Linux systems.

Given than the matter is more complex than I thought and that the warning
for the -pthread flag only provides some annoyance, I am reverting to before
pull request #607. We will perhaps give another stab at it, but for now
let's ignore the problem, because it's not so important.