### PR TITLE
validate_input_filepath() doesn't need arguments

### DIFF
--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -22,7 +22,7 @@ class DNSInjectionImpl : public DNSTestImpl {
         test_name = "dns_injection";
         test_version = "0.0.1";
 
-        validate_input_filepath(input_filepath_);
+        validate_input_filepath();
     };
 
     void main(std::string input, Settings options,

--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -123,7 +123,7 @@ class OoniTestImpl : public mk::NetTest {
         });
     }
 
-    void validate_input_filepath(std::string input_filepath_) {
+    void validate_input_filepath() {
         if (input_filepath_ == "") {
             throw InputFileRequired("An input file is required!");
         }

--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -124,13 +124,13 @@ class OoniTestImpl : public mk::NetTest {
     }
 
     void validate_input_filepath() {
-        if (input_filepath_ == "") {
+        if (input_filepath == "") {
             throw InputFileRequired("An input file is required!");
         }
 
         struct stat buffer;
-        if (stat(input_filepath_.c_str(), &buffer) != 0) {
-            throw InputFileDoesNotExist(input_filepath_ + " does not exist");
+        if (stat(input_filepath.c_str(), &buffer) != 0) {
+            throw InputFileDoesNotExist(input_filepath + " does not exist");
         }
     }
 

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -20,7 +20,7 @@ class TCPConnectImpl : public TCPTestImpl {
         : TCPTestImpl(input_filepath_, options_) {
         test_name = "tcp_connect";
         test_version = "0.0.1";
-        validate_input_filepath(input_filepath_);
+        validate_input_filepath();
     };
 
     void main(std::string input, Settings options,


### PR DESCRIPTION
Since it is a class method that shall operate on the attribute
called `input_filepath_`, so need to pass such attribute explicitly
as argument, since it can already access it using `this`.