### PR TITLE
Cleanup report implementation

### DIFF
--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -56,7 +56,7 @@ class OoniTestImpl : public mk::NetTest {
                     logger->debug("net_test: tearing down");
                     teardown();
 
-                    file_report.writeEntry(entry);
+                    file_report.write_entry(entry);
                     logger->debug("net_test: written entry");
 
                     logger->debug("net_test: increased");
@@ -198,7 +198,7 @@ class OoniTestImpl : public mk::NetTest {
             main(options, [=](json entry) {
                 logger->debug("net_test: tearing down");
                 teardown();
-                file_report.writeEntry(entry);
+                file_report.write_entry(entry);
                 logger->debug("net_test: written entry");
                 logger->debug("net_test: reached end of input");
                 cb();

--- a/src/report/base_reporter.cpp
+++ b/src/report/base_reporter.cpp
@@ -7,13 +7,13 @@
 namespace mk {
 namespace report {
 
-void BaseReporter::open() { openned = true; }
+void BaseReporter::open() { openned_ = true; }
 
-void BaseReporter::writeEntry(json &entry) {
-    if (!openned) {
+void BaseReporter::write_entry(json &entry) {
+    if (!openned_) {
         throw new std::runtime_error("The report is not open.");
     }
-    if (closed) {
+    if (closed_) {
         throw new std::runtime_error("The report has already been closed.");
     }
     entry["test_name"] = test_name;
@@ -29,8 +29,8 @@ void BaseReporter::writeEntry(json &entry) {
 }
 
 void BaseReporter::close() {
-    openned = false;
-    closed = true;
+    openned_ = false;
+    closed_ = true;
 }
 
 } // namespace report

--- a/src/report/base_reporter.hpp
+++ b/src/report/base_reporter.hpp
@@ -1,16 +1,13 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
-
-#ifndef MEASUREMENT_KIT_REPORT_BASE_REPORTER_HPP
-#define MEASUREMENT_KIT_REPORT_BASE_REPORTER_HPP
+#ifndef SRC_REPORT_BASE_REPORTER_HPP
+#define SRC_REPORT_BASE_REPORTER_HPP
 
 #include <ctime>
-#include <measurement_kit/common/error.hpp>
-#include <measurement_kit/common/settings.hpp>
-#include <measurement_kit/common/version.hpp>
+#include <measurement_kit/common.hpp>
 #include "src/common/utils.hpp"
-#include "src/ext/json/src/json.hpp"                // for json
+#include "src/ext/json/src/json.hpp"
 
 using json = nlohmann::json;
 
@@ -19,42 +16,44 @@ namespace report {
 
 class BaseReporter {
   public:
+    const std::string software_name = "measurement_kit";
+    const std::string software_version = MEASUREMENT_KIT_VERSION;
+    const std::string data_format_version = "0.2.0";
+
     std::string test_name;
     std::string test_version;
-    std::string probe_ip;
 
+    std::string probe_ip;
     std::string probe_asn;
     std::string probe_cc;
 
-    struct tm test_start_time;
+    tm test_start_time;
 
     Settings options;
 
-    BaseReporter(){};
+    BaseReporter() {}
 
-    virtual ~BaseReporter(){};
+    virtual ~BaseReporter() {}
 
     virtual void open();
 
-    virtual void writeEntry(json &entry);
+    virtual void write_entry(json &entry);
 
     virtual void close();
 
-    void on_error(std::function<void(Error)> func) { error_fn_ = func; }
+    void on_error(Delegate<void(Error)> func) { error_fn_ = func; }
 
     void emit_error(Error err) {
-        if (!error_fn_) throw err;
+        if (!error_fn_) {
+            throw err;
+        }
         error_fn_(err);
     }
 
   private:
-    std::function<void(Error)> error_fn_;
-    bool closed = false;
-    bool openned = false;
-
-    const std::string software_name = "measurement_kit";
-    const std::string software_version = MEASUREMENT_KIT_VERSION;
-    const std::string data_format_version = "0.2.0";
+    Delegate<void(Error)> error_fn_;
+    bool closed_ = false;
+    bool openned_ = false;
 };
 
 } // namespace report

--- a/src/report/file_reporter.cpp
+++ b/src/report/file_reporter.cpp
@@ -16,8 +16,8 @@ void FileReporter::open() {
     }
 }
 
-void FileReporter::writeEntry(json &entry) {
-    BaseReporter::writeEntry(entry);
+void FileReporter::write_entry(json &entry) {
+    BaseReporter::write_entry(entry);
     try {
         file << entry.dump() << std::endl;
     } catch (...) {

--- a/src/report/file_reporter.hpp
+++ b/src/report/file_reporter.hpp
@@ -1,13 +1,10 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
+#ifndef SRC_REPORT_FILE_REPORTER_HPP
+#define SRC_REPORT_FILE_REPORTER_HPP
 
-#ifndef MEASUREMENT_KIT_REPORT_FILE_REPORTER_HPP
-#define MEASUREMENT_KIT_REPORT_FILE_REPORTER_HPP
-
-#include <iostream>
 #include <fstream>
-
 #include "src/report/base_reporter.hpp"
 
 namespace mk {
@@ -16,8 +13,9 @@ namespace report {
 class FileReporter : public BaseReporter {
   public:
     std::string filename;
+
     void open() override;
-    void writeEntry(json &entry) override;
+    void write_entry(json &entry) override;
     void close() override;
 
   private:

--- a/test/report/file.cpp
+++ b/test/report/file.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Report lifecycle", "[BaseReport]") {
         entry["input"] = input;
         entry["antani"] = "fuffa";
         reporter.open();
-        reporter.writeEntry(entry);
+        reporter.write_entry(entry);
         reporter.close();
 
         std::ifstream infile(reporter.filename);


### PR DESCRIPTION
0) recognize that it's not easily possible to make the report public
   without adding nlohmann/json to the public API [*]

1) give headers private include guards since they are private

2) rename writeEntry as write_entry for consistency

[*] This does not appear in the diff. But think about the changes you do
not see in this diff. They are because of that.