### PR TITLE
Error: do not call reason `ooni_error`

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -19,9 +19,9 @@ class Error : public std::exception {
     Error(int e, std::string ooe) : Error(e, ooe, nullptr) {}
 
     Error(int e, std::string ooe, Var<Error> c)
-                : child(c), code(e), ooni_error(ooe) {
-        if (code != 0 && ooni_error == "") {
-            ooni_error = "unknown_failure " + std::to_string(code);
+                : child(c), code(e), reason(ooe) {
+        if (code != 0 && reason == "") {
+            reason = "unknown_failure " + std::to_string(code);
         }
     }
 
@@ -35,12 +35,12 @@ class Error : public std::exception {
     bool operator!=(int n) const { return code != n; }
     bool operator!=(Error e) const { return code != e.code; }
 
-    std::string as_ooni_error() { return ooni_error; }
+    std::string as_ooni_error() { return reason; }
 
     Var<ErrorContext> context;
     Var<Error> child;
     int code = 0;
-    std::string ooni_error;
+    std::string reason;
 };
 
 #define MK_DEFINE_ERR(_code_, _name_, _ooe_)                                   \
@@ -48,8 +48,8 @@ class Error : public std::exception {
       public:                                                                  \
         _name_() : Error(_code_, _ooe_) {}                                     \
         _name_(std::string s) : Error(_code_, _ooe_) {                         \
-            ooni_error += " ";                                                 \
-            ooni_error += s;                                                   \
+            reason += " ";                                                     \
+            reason += s;                                                       \
         }                                                                      \
         _name_(Error e) : Error(_code_, _ooe_, e) {}                           \
     };

--- a/test/common/error.cpp
+++ b/test/common/error.cpp
@@ -15,7 +15,7 @@ TEST_CASE("The default constructed error is true-ish") {
     REQUIRE(!err.context);
     REQUIRE(!err.child);
     REQUIRE(err.code == 0);
-    REQUIRE(err.ooni_error == "");
+    REQUIRE(err.reason == "");
 }
 
 TEST_CASE("Error constructed with error code is correctly initialized") {
@@ -24,7 +24,7 @@ TEST_CASE("Error constructed with error code is correctly initialized") {
     REQUIRE(!err.context);
     REQUIRE(!err.child);
     REQUIRE(err.code == 17);
-    REQUIRE(err.ooni_error == "unknown_failure 17");
+    REQUIRE(err.reason == "unknown_failure 17");
 }
 
 TEST_CASE("Error constructed with error and message is correctly initialized") {
@@ -33,7 +33,7 @@ TEST_CASE("Error constructed with error and message is correctly initialized") {
     REQUIRE(!err.context);
     REQUIRE(!err.child);
     REQUIRE(err.code == 17);
-    REQUIRE(err.ooni_error == "antani");
+    REQUIRE(err.reason == "antani");
 }
 
 TEST_CASE("Constructor with underlying error works correctly") {
@@ -42,7 +42,7 @@ TEST_CASE("Constructor with underlying error works correctly") {
     REQUIRE(!err.context);
     REQUIRE(*err.child == MockedError());
     REQUIRE(err.code == 17);
-    REQUIRE(err.ooni_error == "antani");
+    REQUIRE(err.reason == "antani");
 }
 
 TEST_CASE("Equality works for errors") {
@@ -62,5 +62,5 @@ TEST_CASE("The defined-error constructor with string works") {
     REQUIRE(!!ex);
     REQUIRE(ex.code == 17);
     REQUIRE(ex.as_ooni_error() == "example error antani");
-    REQUIRE(ex.ooni_error == "example error antani");
+    REQUIRE(ex.reason == "example error antani");
 }


### PR DESCRIPTION
Okay, currently we have the reason which is equal to `ooni_error` but
that would not necessarily be the case in future.

So, leave `as_ooni_error()` as the preferred way to know the OONI error
string and use `reason` (more neutral) for the attribute.