### PR TITLE
error_or: remove unused constructors

### DIFF
--- a/include/measurement_kit/common/error_or.hpp
+++ b/include/measurement_kit/common/error_or.hpp
@@ -10,13 +10,9 @@ namespace mk {
 
 template <typename T> class ErrorOr {
   public:
-    ErrorOr() : error_(NotInitializedError()) {}
-
     ErrorOr(T value) : value_(value) {}
 
     ErrorOr(Error error) : error_(error) {}
-
-    ErrorOr(Error error, T value) : error_(error), value_(value) {}
 
     operator bool() const { return error_ == NoError(); }
 

--- a/test/common/error_or.cpp
+++ b/test/common/error_or.cpp
@@ -34,29 +34,11 @@ TEST_CASE("The ErrorOr template works as expected when there is an error") {
     REQUIRE_THROWS_AS(*eo, Error);
 }
 
-TEST_CASE("The ErrorOr template works as expected when the empty "
-          "constructor is called") {
-    ErrorOr<int> eo;
-    REQUIRE(static_cast<bool>(eo) == false);
-    REQUIRE(eo.as_error() == NotInitializedError());
-    REQUIRE_THROWS_AS(*eo, Error);
-}
-
 TEST_CASE("One can use arrow operator to access structure wrapped "
           "by ErrorOr template") {
     ErrorOr<Foobar> eo{Foobar{}};
     REQUIRE(eo->foo == 17);
     REQUIRE(eo->bar == 3.14);
-}
-
-TEST_CASE("Operator-* throws on error if ErrorOr is not initialized") {
-    ErrorOr<int> eo;
-    REQUIRE_THROWS_AS(*eo, Error);
-}
-
-TEST_CASE("Operator-> throws on error if ErrorOr is not initialized") {
-    ErrorOr<Foobar> eo;
-    REQUIRE_THROWS_AS(eo->foo = 10, Error);
 }
 
 TEST_CASE("Operator-* throws on error if ErrorOr is an error") {


### PR DESCRIPTION
The empty constructor and the constructor with both error and value are
both scarcely if not used. Hence, remove them.