### PR TITLE
http: make sure reactor argument is before logger

### DIFF
--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -89,33 +89,37 @@ void request_cycle(Settings, Headers, std::string, Callback<Error, Var<Response>
         Var<Reactor> = Reactor::global(), Var<Logger> = Logger::global());
 
 inline void request(Settings settings, Callback<Error, Var<Response>> cb, Headers headers = {},
-             std::string body = "", Var<Logger> lp = Logger::global(),
-             Var<Reactor> reactor = Reactor::global()) {
+             std::string body = "",
+             Var<Reactor> reactor = Reactor::global(),
+             Var<Logger> lp = Logger::global()) {
     request_cycle(settings, headers, body, cb, reactor, lp);
 }
 
 inline void request(Settings settings, Headers headers, std::string body,
-        Callback<Error, Var<Response>> cb, Var<Logger> lp = Logger::global(),
-        Var<Reactor> reactor = Reactor::global()) {
-    request(settings, cb, headers, body, lp, reactor);
+        Callback<Error, Var<Response>> cb,
+        Var<Reactor> reactor = Reactor::global(),
+        Var<Logger> lp = Logger::global()) {
+    request(settings, cb, headers, body, reactor, lp);
 }
 
 inline void get(std::string url, Callback<Error, Var<Response>> cb,
                 Headers headers = {}, std::string body = "",
-                Settings settings = {}, Var<Logger> lp = Logger::global(),
-                Var<Reactor> reactor = Reactor::global()) {
+                Settings settings = {},
+                Var<Reactor> reactor = Reactor::global(),
+                Var<Logger> lp = Logger::global()) {
     settings["http/method"] = "GET";
     settings["http/url"] = url;
-    request(settings, cb, headers, body, lp, reactor);
+    request(settings, cb, headers, body, reactor, lp);
 }
 
 inline void request(std::string method, std::string url, Callback<Error, Var<Response>> cb,
                     Headers headers = {}, std::string body = "",
-                    Settings settings = {}, Var<Logger> lp = Logger::global(),
-                    Var<Reactor> reactor = Reactor::global()) {
+                    Settings settings = {},
+                    Var<Reactor> reactor = Reactor::global(),
+                    Var<Logger> lp = Logger::global()) {
     settings["http/method"] = method;
     settings["http/url"] = url;
-    request(settings, cb, headers, body, lp, reactor);
+    request(settings, cb, headers, body, reactor, lp);
 }
 
 } // namespace http

--- a/src/mlabns/mlabns_impl.hpp
+++ b/src/mlabns/mlabns_impl.hpp
@@ -106,7 +106,7 @@ void query_impl(std::string tool, Callback<Error, Reply> callback,
             logger->info("mlabns says to use %s", reply.fqdn.c_str());
             callback(NoError(), reply);
         },
-        {}, "", settings, logger, reactor);
+        {}, "", settings, reactor, logger);
 }
 
 } // namespace mlabns

--- a/src/ooni/utils.hpp
+++ b/src/ooni/utils.hpp
@@ -37,7 +37,7 @@ void ip_lookup(Callback<Error, std::string> callback) {
                 }
                 callback(NoError(), m[1]);
             },
-            {}, "", {}, Logger::global(), Reactor::global());
+            {}, "", {}, Reactor::global(), Logger::global());
 }
 
 ErrorOr<json> geoip(std::string ip, std::string path_country,

--- a/test/mlabns/mlabns.cpp
+++ b/test/mlabns/mlabns.cpp
@@ -120,8 +120,8 @@ TEST_CASE("Make sure that an error is passed to callback with invalid tool "
 }
 
 static void get_debug_error(std::string, Callback<Error, Var<http::Response>> cb,
-                            http::Headers, std::string, Settings, Var<Logger>,
-                            Var<Reactor>) {
+                            http::Headers, std::string, Settings, Var<Reactor>,
+                            Var<Logger>) {
     cb(MockedError(), nullptr);
 }
 
@@ -139,14 +139,15 @@ TEST_CASE(
                                                 REQUIRE(error == MockedError());
                                                 break_loop();
                                             },
-                                            settings, Reactor::global(),
+                                            settings,
+                                            Reactor::global(),
                                             Logger::global());
     });
 }
 
 static void get_debug_invalid_status_code(std::string, Callback<Error, Var<http::Response>> cb,
                                           http::Headers, std::string, Settings,
-                                          Var<Logger>, Var<Reactor>) {
+                                          Var<Reactor>, Var<Logger>) {
     Var<http::Response> response(new http::Response);
     response->status_code = 500;
     cb(NoError(), response);
@@ -173,7 +174,7 @@ TEST_CASE("Make sure that an error is passed to callback if the response "
 
 static void get_debug_invalid_response(std::string, Callback<Error, Var<http::Response>> cb,
                                        http::Headers, std::string, Settings,
-                                       Var<Logger>, Var<Reactor>) {
+                                       Var<Reactor>, Var<Logger>) {
     Var<http::Response> response(new http::Response);
     response->status_code = 200;
     response->body = "alfj9882//234j<<<384982";
@@ -202,8 +203,8 @@ TEST_CASE("Make sure that an error is passed to callback if the response is "
 static void get_debug_invalid_uncomplete_json(std::string,
                                               Callback<Error, Var<http::Response>> cb,
                                               http::Headers, std::string,
-                                              Settings, Var<Logger>,
-                                              Var<Reactor>) {
+                                              Settings, Var<Reactor>,
+                                              Var<Logger>) {
     Var<http::Response> response(new http::Response);
     response->status_code = 200;
     // This json does not contain the country field


### PR DESCRIPTION
From the #consistency dept. Another diff is due to make sure
the same holds in net. But not now.