### PR TITLE
Revert "error_or: remove unused constructors (#630)"

### DIFF
--- a/include/measurement_kit/common/error_or.hpp
+++ b/include/measurement_kit/common/error_or.hpp
@@ -10,9 +10,13 @@ namespace mk {
 
 template <typename T> class ErrorOr {
   public:
+    ErrorOr() : error_(NotInitializedError()) {}
+
     ErrorOr(T value) : value_(value) {}
 
     ErrorOr(Error error) : error_(error) {}
+
+    ErrorOr(Error error, T value) : error_(error), value_(value) {}
 
     operator bool() const { return error_ == NoError(); }
 

--- a/test/common/error_or.cpp
+++ b/test/common/error_or.cpp
@@ -34,11 +34,29 @@ TEST_CASE("The ErrorOr template works as expected when there is an error") {
     REQUIRE_THROWS_AS(*eo, Error);
 }
 
+TEST_CASE("The ErrorOr template works as expected when the empty "
+          "constructor is called") {
+    ErrorOr<int> eo;
+    REQUIRE(static_cast<bool>(eo) == false);
+    REQUIRE(eo.as_error() == NotInitializedError());
+    REQUIRE_THROWS_AS(*eo, Error);
+}
+
 TEST_CASE("One can use arrow operator to access structure wrapped "
           "by ErrorOr template") {
     ErrorOr<Foobar> eo{Foobar{}};
     REQUIRE(eo->foo == 17);
     REQUIRE(eo->bar == 3.14);
+}
+
+TEST_CASE("Operator-* throws on error if ErrorOr is not initialized") {
+    ErrorOr<int> eo;
+    REQUIRE_THROWS_AS(*eo, Error);
+}
+
+TEST_CASE("Operator-> throws on error if ErrorOr is not initialized") {
+    ErrorOr<Foobar> eo;
+    REQUIRE_THROWS_AS(eo->foo = 10, Error);
 }
 
 TEST_CASE("Operator-* throws on error if ErrorOr is an error") {


### PR DESCRIPTION
This reverts commit 3ab2c8b871749f56fe4f65345b514d9a686c318b because
actually those constructors are used in NDT code.