### PR TITLE
Prevent excessive, O(N) stack consumption

### DIFF
--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -90,10 +90,12 @@ void connect_many(std::string address, int port, int num,
 
 void write(Var<Transport> txp, Buffer buf, Callback<Error> cb);
 
-void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb);
+void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
+           Var<Reactor> reactor = Reactor::global());
 
-inline void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback) {
-    readn(t, buff, 1, callback);
+inline void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback,
+                 Var<Reactor> reactor = Reactor::global()) {
+    readn(t, buff, 1, callback, reactor);
 }
 
 } // namespace net

--- a/src/ndt/internal.hpp
+++ b/src/ndt/internal.hpp
@@ -102,9 +102,12 @@ struct Context {
 */
 namespace messages {
 
-void read_ll(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback);
-void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback);
-void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback);
+void read_ll(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback,
+             Var<Reactor> reactor = Reactor::global());
+void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
+               Var<Reactor> reactor = Reactor::global());
+void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback,
+              Var<Reactor> reactor = Reactor::global());
 
 ErrorOr<Buffer> format_msg_extended_login(unsigned char tests);
 ErrorOr<Buffer> format_test_msg(std::string s);

--- a/src/ndt/messages.cpp
+++ b/src/ndt/messages.cpp
@@ -9,16 +9,19 @@ namespace ndt {
 namespace messages {
 
 void read_ll(Var<Context> ctx,
-             mk::Callback<Error, uint8_t, std::string> callback) {
-    read_ll_impl(ctx, callback);
+             mk::Callback<Error, uint8_t, std::string> callback,
+             Var<Reactor> reactor) {
+    read_ll_impl(ctx, callback, reactor);
 }
 
-void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback) {
-    read_json_impl(ctx, callback);
+void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
+               Var<Reactor> reactor) {
+    read_json_impl(ctx, callback, reactor);
 }
 
-void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> cb) {
-    read_msg_impl(ctx, cb);
+void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> cb,
+              Var<Reactor> reactor) {
+    read_msg_impl(ctx, cb, reactor);
 }
 
 ErrorOr<Buffer> format_msg_extended_login(unsigned char tests) {

--- a/src/ndt/protocol_impl.hpp
+++ b/src/ndt/protocol_impl.hpp
@@ -66,7 +66,7 @@ void recv_and_ignore_kickoff_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->info("Got legacy KICKOFF message (ignored)");
         callback(NoError());
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE(messages, read_msg)>
@@ -94,7 +94,7 @@ void wait_in_queue_impl(Var<Context> ctx, Callback<Error> callback) {
             return;
         }
         callback(NoError());
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE(messages, read_msg)>
@@ -113,7 +113,7 @@ void recv_version_impl(Var<Context> ctx, Callback<Error> callback) {
         ctx->logger->info("Got server version: %s", s.c_str());
         // TODO: validate the server version?
         callback(NoError());
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE(messages, read_msg)>
@@ -132,7 +132,7 @@ void recv_tests_id_impl(Var<Context> ctx, Callback<Error> callback) {
         ctx->logger->info("Authorized tests: %s", s.c_str());
         ctx->granted_suite = split(s);
         callback(NoError());
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE(test_c2s, run), MK_MOCK_NAMESPACE(test_meta, run),
@@ -215,7 +215,7 @@ void recv_results_and_logout_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->info("Got LOGOUT");
         callback(NoError());
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE(net, read)>
@@ -243,7 +243,7 @@ void wait_close_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->debug("ndt: got extra data: %s", buffer->read().c_str());
         callback(DataAfterLogoutError());
-    });
+    }, ctx->reactor);
 }
 
 static inline void disconnect_and_callback_impl(Var<Context> ctx, Error err) {

--- a/src/ndt/test_c2s_impl.hpp
+++ b/src/ndt/test_c2s_impl.hpp
@@ -177,13 +177,13 @@ void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
                                     // The C2S phase is now finished
                                     callback(NoError());
-                                });
-                        });
+                                }, ctx->reactor);
+                        }, ctx->reactor);
                     });
-                });
+                }, ctx->reactor);
             },
             ctx->timeout, ctx->settings, ctx->logger, ctx->reactor);
-    });
+    }, ctx->reactor);
 }
 
 } // namespace test_c2s

--- a/src/ndt/test_meta_impl.hpp
+++ b/src/ndt/test_meta_impl.hpp
@@ -105,10 +105,10 @@ void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
                             // We're done
                             callback(NoError());
-                        });
+                        }, ctx->reactor);
                 });
-            });
-    });
+            }, ctx->reactor);
+    }, ctx->reactor);
 }
 
 } // namespace test_meta

--- a/src/ndt/test_s2c_impl.hpp
+++ b/src/ndt/test_s2c_impl.hpp
@@ -105,7 +105,7 @@ void finalizing_test_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         // XXX: Here we can loop forever
         finalizing_test_impl<messages_read_msg>(ctx, callback);
-    });
+    }, ctx->reactor);
 }
 
 template <MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, first),
@@ -204,12 +204,12 @@ void run_impl(Var<Context> ctx, Callback<Error> callback) {
                                 // We enter into the final state of this test
                                 finalizing_test(ctx, callback);
                             });
-                        });
+                        }, ctx->reactor);
                     });
-                });
+                }, ctx->reactor);
             },
             ctx->timeout, ctx->settings, ctx->logger, ctx->reactor);
-    });
+    }, ctx->reactor);
 }
 
 } // namespace test_s2c

--- a/src/net/transport.cpp
+++ b/src/net/transport.cpp
@@ -80,10 +80,14 @@ void write(Var<Transport> txp, Buffer buf, Callback<Error> cb) {
     txp->write(buf);
 }
 
-void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb) {
+void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
+           Var<Reactor> reactor) {
     if (buff->length() >= n) {
-        // Shortcut that simplifies coding a great deal
-        cb(NoError());
+        // Shortcut that simplifies coding a great deal - yet, do not callback
+        // immediately to avoid O(N) stack consumption
+        reactor->call_soon([=]() {
+            cb(NoError());
+        });
         return;
     }
     txp->on_data([=](Buffer d) {

--- a/test/ndt/protocol.cpp
+++ b/test/ndt/protocol.cpp
@@ -48,7 +48,8 @@ TEST_CASE("send_extended_login() deals with write error") {
     });
 }
 
-static void fail(Var<Transport>, Var<Buffer>, size_t, Callback<Error> cb) {
+static void fail(Var<Transport>, Var<Buffer>, size_t, Callback<Error> cb,
+                 Var<Reactor> = Reactor::global()) {
     cb(MockedError());
 }
 
@@ -59,7 +60,7 @@ TEST_CASE("recv_and_ignore_kickoff() deals with readn() error") {
 }
 
 static void invalid(Var<Transport>, Var<Buffer> buff, size_t n,
-                    Callback<Error> cb) {
+                    Callback<Error> cb, Var<Reactor> = Reactor::global()) {
     std::string s(n, 'a');
     buff->write(s);
     cb(NoError());
@@ -71,7 +72,8 @@ TEST_CASE("recv_and_ignore_kickoff() deals with invalid kickoff message") {
         ctx, [](Error err) { REQUIRE(err == InvalidKickoffMessageError()); });
 }
 
-static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                 Var<Reactor> = Reactor::global()) {
     cb(MockedError(), 0, "");
 }
 
@@ -81,7 +83,8 @@ TEST_CASE("wait_in_queue() deals with read() error") {
         ctx, [](Error err) { REQUIRE(err == ReadingSrvQueueMessageError()); });
 }
 
-static void unexpected(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void unexpected(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                       Var<Reactor> = Reactor::global()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -91,7 +94,8 @@ TEST_CASE("wait_in_queue() deals with unexpected message error") {
         ctx, [](Error err) { REQUIRE(err == NotSrvQueueMessageError()); });
 }
 
-static void bad_time(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void bad_time(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                     Var<Reactor> = Reactor::global()) {
     cb(NoError(), SRV_QUEUE, "xo");
 }
 
@@ -101,7 +105,8 @@ TEST_CASE("wait_in_queue() deals with invalid wait time") {
         ctx, [](Error err) { REQUIRE(err == InvalidSrvQueueMessageError()); });
 }
 
-static void nonzero(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void nonzero(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(NoError(), SRV_QUEUE, "1");
 }
 
@@ -172,7 +177,8 @@ TEST_CASE("recv_results_and_logout() deals with unexpected message error") {
         ctx, [](Error err) { REQUIRE(err == NotResultsOrLogoutError()); });
 }
 
-static void eof_error(Var<Transport>, Var<Buffer>, Callback<Error> cb) {
+static void eof_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
+                      Var<Reactor> = Reactor::global()) {
     cb(EofError());
 }
 
@@ -183,7 +189,8 @@ TEST_CASE("wait_close() deals with EofError") {
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
 
-static void timeout_error(Var<Transport>, Var<Buffer>, Callback<Error> cb) {
+static void timeout_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
+                          Var<Reactor> = Reactor::global()) {
     cb(TimeoutError());
 }
 
@@ -194,7 +201,8 @@ TEST_CASE("wait_close() deals with TimeoutError") {
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
 
-static void mocked_error(Var<Transport>, Var<Buffer>, Callback<Error> cb) {
+static void mocked_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(MockedError());
 }
 
@@ -205,7 +213,8 @@ TEST_CASE("wait_close() deals with an error") {
         ctx, [](Error err) { REQUIRE(err == WaitingCloseError()); });
 }
 
-static void no_error(Var<Transport>, Var<Buffer>, Callback<Error> cb) {
+static void no_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
+                     Var<Reactor> = Reactor::global()) {
     cb(NoError());
 }
 

--- a/test/ndt/test_c2s.cpp
+++ b/test/ndt/test_c2s.cpp
@@ -24,11 +24,13 @@ TEST_CASE("coroutine() is robust to connect error") {
         2.0, {}, Logger::global(), Reactor::global());
 }
 
-static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                 Var<Reactor> = Reactor::global()) {
     cb(MockedError(), 0, "");
 }
 
-static void invalid(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void invalid(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -45,7 +47,8 @@ TEST_CASE("run() deals with receiving message different from PREPARE") {
 }
 
 static void invalid_port(Var<Context>,
-                         Callback<Error, uint8_t, std::string> cb) {
+                         Callback<Error, uint8_t, std::string> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "foobar");
 }
 
@@ -55,7 +58,8 @@ TEST_CASE("run() deals with receiving invalid port") {
         ctx, [](Error err) { REQUIRE(err == InvalidPortError()); });
 }
 
-static void too_large(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void too_large(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                      Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "65536");
 }
 
@@ -65,7 +69,8 @@ TEST_CASE("run() deals with receiving too large port") {
         ctx, [](Error err) { REQUIRE(err == InvalidPortError()); });
 }
 
-static void too_small(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void too_small(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                      Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "-1");
 }
 
@@ -76,7 +81,8 @@ TEST_CASE("run() deals with receiving too small port") {
 }
 
 static void test_prepare(Var<Context>,
-                         Callback<Error, uint8_t, std::string> cb) {
+                         Callback<Error, uint8_t, std::string> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -113,7 +119,8 @@ TEST_CASE("run() deals with unexpected message instead of TEST_START") {
         ctx, [](Error err) { REQUIRE(err == NotTestStartError()); });
 }
 
-static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                       Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_START, "");
 }
 
@@ -141,7 +148,8 @@ TEST_CASE("run() deals with unexpected message instead of TEST_MSG") {
         ctx, [](Error err) { REQUIRE(err == NotTestMsgError()); });
 }
 
-static void test_msg(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void test_msg(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                     Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_MSG, "");
 }
 

--- a/test/ndt/test_meta.cpp
+++ b/test/ndt/test_meta.cpp
@@ -14,7 +14,8 @@ using namespace mk::ndt;
 using namespace mk::net;
 using json = nlohmann::json;
 
-static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void fail(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                 Var<Reactor> = Reactor::global()) {
     cb(MockedError(), 0, "");
 }
 
@@ -24,7 +25,8 @@ TEST_CASE("run() deals with read() error") {
         ctx, [](Error err) { REQUIRE(err == ReadingTestPrepareError()); });
 }
 
-static void unexpected(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void unexpected(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                       Var<Reactor> = Reactor::global()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -35,7 +37,8 @@ TEST_CASE("run() deals with unexpected message type") {
 }
 
 static void test_prepare(Var<Context>,
-                         Callback<Error, uint8_t, std::string> cb) {
+                         Callback<Error, uint8_t, std::string> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "");
 }
 
@@ -59,7 +62,8 @@ static ErrorOr<Buffer> success(std::string s) {
     return buff;
 }
 
-static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                       Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_START, "");
 }
 

--- a/test/ndt/test_s2c.cpp
+++ b/test/ndt/test_s2c.cpp
@@ -26,7 +26,8 @@ TEST_CASE("coroutine() is robust to connect error") {
         2.0, {}, Logger::global(), Reactor::global());
 }
 
-static void failure(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void failure(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(MockedError(), 0, "");
 }
 
@@ -36,7 +37,8 @@ TEST_CASE("finalizing_test() deals with read_msg() error") {
         ctx, [](Error err) { REQUIRE(err == ReadingTestMsgError()); });
 }
 
-static void invalid(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void invalid(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -47,7 +49,8 @@ TEST_CASE("finalizing_test() deals with receiving invalid message") {
 }
 
 // XXX: static test function with a state is not good
-static void empty(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void empty(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                  Var<Reactor> = Reactor::global()) {
     static int count = 0;
     if (count++ == 0) {
         cb(NoError(), TEST_MSG, "");
@@ -75,7 +78,8 @@ TEST_CASE("run() deals with receiving message different from PREPARE") {
 }
 
 static void invalid_port(Var<Context>,
-                         Callback<Error, uint8_t, std::string> cb) {
+                         Callback<Error, uint8_t, std::string> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "foobar");
 }
 
@@ -85,7 +89,8 @@ TEST_CASE("run() deals with receiving invalid port") {
         ctx, [](Error err) { REQUIRE(err == InvalidPortError()); });
 }
 
-static void too_large(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void too_large(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                      Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "65536");
 }
 
@@ -95,7 +100,8 @@ TEST_CASE("run() deals with receiving too large port") {
         ctx, [](Error err) { REQUIRE(err == InvalidPortError()); });
 }
 
-static void too_small(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void too_small(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                      Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "-1");
 }
 
@@ -105,7 +111,8 @@ TEST_CASE("run() deals with receiving too small port") {
         ctx, [](Error err) { REQUIRE(err == InvalidPortError()); });
 }
 
-static void success(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void success(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -124,7 +131,8 @@ TEST_CASE("run() deals with coroutine failure") {
 }
 
 static void test_prepare(Var<Context>,
-                         Callback<Error, uint8_t, std::string> cb) {
+                         Callback<Error, uint8_t, std::string> cb,
+                         Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -147,7 +155,8 @@ TEST_CASE("run() deals with unexpected message instead of TEST_START") {
         ctx, [](Error err) { REQUIRE(err == NotTestStartError()); });
 }
 
-static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb) {
+static void test_start(Var<Context>, Callback<Error, uint8_t, std::string> cb,
+                       Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_START, "");
 }
 
@@ -163,7 +172,8 @@ static void coro_ok(std::string, int,
     cb(NoError(), [](Callback<Error, double> cb) { cb(NoError(), 0.0); });
 }
 
-static void failure(Var<Context>, Callback<Error, uint8_t, json> cb) {
+static void failure(Var<Context>, Callback<Error, uint8_t, json> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(MockedError(), 0, {});
 }
 
@@ -173,7 +183,8 @@ TEST_CASE("run() deals with error when reading TEST_MSG") {
         ctx, [](Error err) { REQUIRE(err == ReadingTestMsgError()); });
 }
 
-static void invalid(Var<Context>, Callback<Error, uint8_t, json> cb) {
+static void invalid(Var<Context>, Callback<Error, uint8_t, json> cb,
+                    Var<Reactor> = Reactor::global()) {
     cb(NoError(), MSG_ERROR, {});
 }
 
@@ -183,7 +194,8 @@ TEST_CASE("run() deals with unexpected message instead of TEST_MSG") {
         ctx, [](Error err) { REQUIRE(err == NotTestMsgError()); });
 }
 
-static void msg_test(Var<Context>, Callback<Error, uint8_t, json> cb) {
+static void msg_test(Var<Context>, Callback<Error, uint8_t, json> cb,
+                     Var<Reactor> = Reactor::global()) {
     cb(NoError(), TEST_MSG, {});
 }
 


### PR DESCRIPTION
Testing on device, I noticed that readn() calling its callback immediately
leads to excessive stack usage and, in the case of receiving Web100 variables
after a NDT test, could exhaust the stack of iOS devices.

Fix this by scheduling a callback for soon even when the buffer already
contains enough data to fullfill the readn() request. Testing on iOS devices
shows that this fix is enough to avoid stack exhaustion and crash.