### PR TITLE
circle.yml: run valgrind-clang test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 
 test:
   override:
-    - ./build/docker/clang
+    - ./build/docker/valgrind-clang


### PR DESCRIPTION
Now that we have set circle-ci up, teach it to run our valgrind-clang
test such that we get a valgrind assessment after each push.

This is super important while developing to make sure that we do
not make mistakes into a feature branch.

- - - 

In parallel with this, I've also promoted the circle-ci check to be
a required check before merging.

So, after this commit is applied, the level of checks we have
for each push is equivalent to before clang stopped working for
us with travis.