### PR TITLE
Make sure JSON reports are compliant with spec

### DIFF
--- a/src/ooni/dns_injection_impl.hpp
+++ b/src/ooni/dns_injection_impl.hpp
@@ -23,20 +23,21 @@ class DNSInjectionImpl : public DNSTestImpl {
         test_version = "0.0.1";
 
         validate_input_filepath();
-    };
+    }
 
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb) {
-        entry["injected"] = nullptr;
-        query("A", "IN", input, options["backend"],
-              [this, cb](dns::Message message) {
+        Var<report::Entry> entry(new report::Entry);
+        (*entry)["injected"] = nullptr;
+        query(entry, "A", "IN", input, options["backend"],
+              [=](dns::Message message) {
                   logger->debug("dns_injection: got response");
                   if (message.error_code == DNS_ERR_NONE) {
-                      entry["injected"] = true;
+                      (*entry)["injected"] = true;
                   } else {
-                      entry["injected"] = false;
+                      (*entry)["injected"] = false;
                   }
-                  cb(entry);
+                  cb(*entry);
               }, options);
     }
 };

--- a/src/ooni/dns_test_impl.hpp
+++ b/src/ooni/dns_test_impl.hpp
@@ -23,7 +23,8 @@ class DNSTestImpl : public ooni::OoniTestImpl {
         test_version = "0.0.1";
     };
 
-    void query(dns::QueryType query_type, dns::QueryClass query_class,
+    void query(Var<report::Entry> entry,
+               dns::QueryType query_type, dns::QueryClass query_class,
                std::string query_name, std::string nameserver,
                std::function<void(dns::Message)> cb, Settings options = {}) {
 
@@ -68,7 +69,7 @@ class DNSTestImpl : public ooni::OoniTestImpl {
                 }
                 // TODO add support for bytes received
                 // query_entry["bytes"] = response.get_bytes();
-                entry["queries"].push_back(query_entry);
+                (*entry)["queries"].push_back(query_entry);
                 logger->debug("dns_test: callbacking");
                 cb(message);
                 logger->debug("dns_test: callback called");

--- a/src/ooni/http_invalid_request_line_impl.hpp
+++ b/src/ooni/http_invalid_request_line_impl.hpp
@@ -27,16 +27,17 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
     HTTPInvalidRequestLineImpl(Settings options_) : TCPTestImpl(options_) {
         test_name = "http_invalid_request_line";
         test_version = "0.0.1";
-    };
+    }
 
-    void send_receive_invalid_request_line(http::Url backend_url,
+    void send_receive_invalid_request_line(Var<report::Entry> entry,
+                                           http::Url backend_url,
                                            std::string request_line,
                                            std::function<void()> &&cb,
                                            Settings settings = {}) {
         settings["host"] = backend_url.address;
         settings["port"] = backend_url.port;
         connect(settings,
-                [this, cb, request_line](Error err, Var<net::Transport> txp) {
+                [=](Error err, Var<net::Transport> txp) {
                     if (err) {
                         logger->debug("http_invalid_request_line: error connecting");
                         cb();
@@ -51,41 +52,43 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
                     txp->write(request_line);
 
                     // We assume to have received all the data after a timeout
-                    // of 5
-                    // seconds.
-                    reactor->call_later(timeout, [this, cb, received_data,
-                                                  request_line, txp]() {
+                    // of 5 seconds.
+                    reactor->call_later(timeout, [=]() {
                         if (*received_data != request_line) {
                             logger->info("Tampering detected!");
                             logger->info("%s != %s", received_data->c_str(),
                                          request_line.c_str());
-                            entry["tampering"] = true;
-                        } else if (entry["tampering"] == nullptr) {
+                            (*entry)["tampering"] = true;
+                        } else if ((*entry)["tampering"] == nullptr) {
                             logger->info("Tampering not detected.");
-                            entry["tampering"] = false;
+                            (*entry)["tampering"] = false;
                         }
-                        entry["sent"].push_back(request_line);
-                        entry["received"].push_back(*received_data);
+                        (*entry)["sent"].push_back(request_line);
+                        (*entry)["received"].push_back(*received_data);
                         txp->close([this, cb]() { cb(); });
                     });
                 });
-    };
+    }
 
     void main(Settings options, std::function<void(report::Entry)> &&cb) {
-        entry["tampering"] = nullptr;
+        Var<report::Entry> entry(new report::Entry);
+        (*entry)["tampering"] = nullptr;
+        (*entry)["received"] = report::Entry::array();
+        (*entry)["sent"] = report::Entry::array();
 
-        ErrorOr<http::Url> backend_url = mk::http::parse_url_noexcept(options["backend"]);
+        ErrorOr<http::Url> backend_url =
+            mk::http::parse_url_noexcept(options["backend"]);
 
         if (!backend_url) {
             logger->debug("Invalid backend url.");
-            cb(entry);
+            cb(*entry);
             return;
         }
 
-        auto handle_response = [this, cb]() {
+        auto handle_response = [=]() {
             tests_run += 1;
             if (tests_run == 4) {
-                cb(entry);
+                cb(*entry);
             }
         };
 
@@ -93,8 +96,8 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
         // randomSTR(4) + " / HTTP/1.1\n\r"
         std::string test_random_invalid_method(mk::random_str_uppercase(4));
         test_random_invalid_method += " / HTTP/1.1\n\r";
-        send_receive_invalid_request_line(
-            *backend_url, test_random_invalid_method, handle_response, options);
+        send_receive_invalid_request_line(entry, *backend_url,
+                test_random_invalid_method, handle_response, options);
 
         // test_random_invalid_field_count
         // ' '.join(randomStr(5) for x in range(4)) + '\n\r'
@@ -105,7 +108,7 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
                 " " + mk::random_str_uppercase(5);
         }
         test_random_invalid_field_count += "\n\r";
-        send_receive_invalid_request_line(*backend_url,
+        send_receive_invalid_request_line(entry, *backend_url,
                                           test_random_invalid_field_count,
                                           handle_response, options);
 
@@ -114,7 +117,7 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
         std::string test_random_big_request_method(
             mk::random_str_uppercase(1024));
         test_random_big_request_method += " / HTTP/1.1\n\r";
-        send_receive_invalid_request_line(*backend_url,
+        send_receive_invalid_request_line(entry, *backend_url,
                                           test_random_big_request_method,
                                           handle_response, options);
 
@@ -122,7 +125,7 @@ class HTTPInvalidRequestLineImpl : public TCPTestImpl {
         // 'GET / HTTP/' + randomStr(3)
         std::string test_random_invalid_version_number("GET / HTTP/");
         test_random_invalid_version_number += mk::random_str_uppercase(3);
-        send_receive_invalid_request_line(*backend_url,
+        send_receive_invalid_request_line(entry, *backend_url,
                                           test_random_invalid_version_number,
                                           handle_response, options);
     }

--- a/src/ooni/ooni_test_impl.hpp
+++ b/src/ooni/ooni_test_impl.hpp
@@ -169,7 +169,6 @@ class OoniTestImpl : public mk::NetTest, public mk::NonCopyable,
     }
 
   public:
-    report::Entry entry;
     InputGenerator *input = nullptr;
 
     std::string test_name;
@@ -219,11 +218,18 @@ class OoniTestImpl : public mk::NetTest, public mk::NonCopyable,
                 run_next_measurement(std::move(cb));
             } else {
                 logger->debug("net_test: no input file");
-                report::Entry entry;
-                entry["input"] = "";
+                struct tm measurement_start_time;
+                double start_time;
+                mk::utc_time_now(&measurement_start_time);
+                start_time = mk::time_now();
                 logger->debug("net_test: calling setup");
                 setup();
-                main(options, [=](report::Entry entry) {
+                main(options, [=](report::Entry test_keys) {
+                    report::Entry entry;
+                    entry["test_keys"] = test_keys;
+                    entry["input"] = "";
+                    entry["measurement_start_time"] = *mk::timestamp(&measurement_start_time);
+                    entry["test_runtime"] = mk::time_now() - start_time;
                     logger->debug("net_test: tearing down");
                     teardown();
                     file_report.write_entry(entry);

--- a/src/ooni/tcp_connect_impl.hpp
+++ b/src/ooni/tcp_connect_impl.hpp
@@ -19,20 +19,19 @@ class TCPConnectImpl : public TCPTestImpl {
         test_name = "tcp_connect";
         test_version = "0.0.1";
         validate_input_filepath();
-    };
+    }
 
     void main(std::string input, Settings options,
               std::function<void(report::Entry)> &&cb) {
         options["host"] = input;
-
         connect(options, [this, cb](Error err, Var<net::Transport> txp) {
             logger->debug("tcp_connect: Got response to TCP connect test");
             if (err) {
-                cb(entry);
+                cb(report::Entry{{"connection", err.as_ooni_error()}});
                 return;
             }
             txp->close([this, cb]() {
-                cb(entry);
+                cb(report::Entry{{"connection", "success"}});
             });
         });
     }

--- a/src/ooni/tcp_test_impl.hpp
+++ b/src/ooni/tcp_test_impl.hpp
@@ -26,10 +26,7 @@ class TCPTestImpl : public ooni::OoniTestImpl {
         : ooni::OoniTestImpl(input_filepath_, options_) {
         test_name = "tcp_test";
         test_version = "0.0.1";
-        entry["sent"] = report::Entry::array();
-        entry["received"] = report::Entry::array();
-        entry["failure"] = nullptr;
-    };
+    }
 
     TCPTestImpl(Settings options_) : TCPTestImpl("", options_) {};
 
@@ -43,9 +40,6 @@ class TCPTestImpl : public ooni::OoniTestImpl {
 
         net::connect(options["host"], options["port"].as<int>(),
                 [this, cb](Error error, Var<net::Transport> transport) {
-                    if (error) {
-                        entry["failure"] = error.as_ooni_error();
-                    }
                     cb(error, transport);
                 }, options, logger, reactor);
     }

--- a/src/ooni/utils.cpp
+++ b/src/ooni/utils.cpp
@@ -19,7 +19,7 @@ static Error geoip_resolve_country (std::string ip, std::string path_country, js
     }
 
     const char *result;
-    result = GeoIP_country_code3_by_name_gl(gi, ip.c_str(), &gl);
+    result = GeoIP_country_code_by_name_gl(gi, ip.c_str(), &gl);
     if (result == nullptr) {
         GeoIP_delete(gi);
         return GenericError();

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -21,6 +21,6 @@ TEST_CASE("geoip works") {
         "8.8.8.8", "test/fixtures/GeoIP.dat", "test/fixtures/GeoIPASNum.dat");
     REQUIRE(!!json);
     REQUIRE(((*json)["asn"] == std::string{"AS15169"}));
-    REQUIRE(((*json)["country_code"] == std::string{"USA"}));
+    REQUIRE(((*json)["country_code"] == std::string{"US"}));
     REQUIRE(((*json)["country_name"] == std::string{"United States"}));
 }


### PR DESCRIPTION
1) change lifecycle of `entry` object: rather than keeping it inside
   the measurement class, create it before running a test, pass it to
   test helper and finally pass it back to be inserted into the keys
   of the test into the final entry.

   Judging from the documentation on github, this seems quite the
   right way of proceedings as reports look much more like what they
   oughta be, except for dns-injection for which a real JSON report
   is not provided in github but the result feels right.

2) make sure that tests running with no input receive exactly same
   treatment of tests with input as regards variables that should
   go inside the report (e.g. test runtime)

3) make sure that we use the two digit country names as opposed
   to three digit country names, to follow OONI spec

4) remove some unneeded semi colons

- - -

Given the pull request number, I think some music can help:

[![The number of the beast](https://img.youtube.com/vi/7-iRf9AWoyE/0.jpg)](https://www.youtube.com/watch?v=7-iRf9AWoyE)