### PR TITLE
net_test.hpp: remove identifier()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,9 +95,7 @@ test/ndt/test_meta
 test/ndt/test_s2c
 test/net/buffer
 test/net/connect
-test/net/connect-many
 test/net/connection
-test/net/connection_check_fds
 test/net/emitter
 test/net/evbuffer
 test/net/socks5

--- a/include/measurement_kit/common/net_test.hpp
+++ b/include/measurement_kit/common/net_test.hpp
@@ -41,8 +41,6 @@ class NetTest {
         reactor->call_soon(func);
     }
 
-    unsigned long long identifier() { return (unsigned long long)this; }
-
     NetTest() {}
     NetTest(Settings o) : options(o) {}
     NetTest(std::string i, Settings o) : options(o), input_filepath(i) {}

--- a/test/common/runner.cpp
+++ b/test/common/runner.cpp
@@ -22,7 +22,7 @@ static void run_http_invalid_request_line(Runner &runner) {
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       mk::debug("test complete: %llu", test->identifier());
+                       mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 
@@ -37,7 +37,7 @@ static void run_dns_injection(Runner &runner) {
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       mk::debug("test complete: %llu", test->identifier());
+                       mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 
@@ -52,7 +52,7 @@ static void run_tcp_connect(Runner &runner) {
                        })
                        .create_test_(),
                    [](Var<NetTest> test) {
-                       mk::debug("test complete: %llu", test->identifier());
+                       mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 


### PR DESCRIPTION
We can now run the test in many ways and in some of them what is
actually run is not the test but a dynamically allocated copy.

As such, the notion of a unique identifier may lead to surprises
where the same test has two different identifiers; one when is being
scheduled and the other when it is running.

So, better to remove the functionality.