### PR TITLE
net_test: now begin() and end() get error param

### DIFF
--- a/include/measurement_kit/common/net_test.hpp
+++ b/include/measurement_kit/common/net_test.hpp
@@ -30,15 +30,15 @@ class NetTest {
         return *this;
     }
 
-    virtual void begin(Callback<> func) {
+    virtual void begin(Callback<Error> func) {
         // You must override this on subclasses to actually start
         // running the test you're interested to run
-        reactor->call_soon(func);
+        reactor->call_soon([=]() { func(NoError()); });
     }
-    virtual void end(Callback<> func) {
+    virtual void end(Callback<Error> func) {
         // You must override this on subclasses to actually terminate
         // running the test (i.e. send results to collector)
-        reactor->call_soon(func);
+        reactor->call_soon([=]() { func(NoError()); });
     }
 
     NetTest() {}

--- a/include/measurement_kit/ndt/ndt_test.hpp
+++ b/include/measurement_kit/ndt/ndt_test.hpp
@@ -12,8 +12,8 @@ namespace ndt {
 class NdtTest : public NetTest {
   public:
     using NetTest::NetTest;
-    void begin(Callback<>) override;
-    void end(Callback<>) override;
+    void begin(Callback<Error>) override;
+    void end(Callback<Error>) override;
     Var<NetTest> create_test_() override;
 };
 

--- a/include/measurement_kit/ooni/error.hpp
+++ b/include/measurement_kit/ooni/error.hpp
@@ -9,8 +9,8 @@
 namespace mk {
 namespace ooni {
 
-MK_DEFINE_ERR(MK_ERR_OONI(0), InputFileDoesNotExist, "")
-MK_DEFINE_ERR(MK_ERR_OONI(1), InputFileRequired, "")
+MK_DEFINE_ERR(MK_ERR_OONI(0), CannotOpenInputFileError, "")
+MK_DEFINE_ERR(MK_ERR_OONI(1), MissingRequiredInputFileError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(2), MissingCollectorBaseUrlError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(3), CannotOpenReportError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(4), MissingMandatoryKeyError, "")

--- a/include/measurement_kit/ooni/ooni_test.hpp
+++ b/include/measurement_kit/ooni/ooni_test.hpp
@@ -32,8 +32,8 @@ class OoniTest : public NetTest, public NonCopyable, public NonMovable {
     OoniTest(std::string f, Settings o) : NetTest(f, o),
         test_name("net_test"), test_version("0.0.1") {}
 
-    void begin(Callback<>) override;
-    void end(Callback<>) override;
+    void begin(Callback<Error>) override;
+    void end(Callback<Error>) override;
 
   protected:
     // Functions that derived classes SHOULD override
@@ -48,9 +48,9 @@ class OoniTest : public NetTest, public NonCopyable, public NonMovable {
     tm test_start_time;
     Var<std::istream> input_generator;
 
-    void run_next_measurement(Callback<>);
+    void run_next_measurement(Callback<Error>);
     void geoip_lookup(Callback<>);
-    void open_report();
+    Error open_report() __attribute__((warn_unused_result));
     std::string generate_output_filepath();
 };
 

--- a/src/common/runner.cpp
+++ b/src/common/runner.cpp
@@ -31,9 +31,11 @@ void Runner::run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> fn) {
     debug("runner: scheduling %p", (void *)test.get());
     reactor->call_soon([=]() {
         debug("runner: starting %p", (void *)test.get());
-        test->begin([=]() {
+        test->begin([=](Error) {
+            // TODO: do not ignore the error
             debug("runner: ending %p", (void *)test.get());
-            test->end([=]() {
+            test->end([=](Error) {
+                // TODO: do not ignore the error
                 debug("runner: cleaning-up %p", (void *)test.get());
                 // For robustness, delay the final callback to the beginning of
                 // next I/O cycle to prevent possible user after frees. This

--- a/src/ndt/ndt_test.cpp
+++ b/src/ndt/ndt_test.cpp
@@ -7,11 +7,11 @@
 namespace mk {
 namespace ndt {
 
-void NdtTest::begin(Callback<> cb) {
-    ndt::run([=](Error) { cb(); }, options, logger, reactor);
+void NdtTest::begin(Callback<Error> cb) {
+    ndt::run([=](Error error) { cb(error); }, options, logger, reactor);
 }
 
-void NdtTest::end(Callback<> cb) { cb(); }
+void NdtTest::end(Callback<Error> cb) { cb(NoError()); }
 
 Var<NetTest> NdtTest::create_test_() {
     NdtTest *test = new NdtTest;

--- a/src/ooni/ooni_test.cpp
+++ b/src/ooni/ooni_test.cpp
@@ -9,19 +9,18 @@
 namespace mk {
 namespace ooni {
 
-void OoniTest::run_next_measurement(Callback<> cb) {
+void OoniTest::run_next_measurement(Callback<Error> cb) {
     logger->debug("net_test: running next measurement");
     std::string next_input;
     std::getline(*input_generator, next_input);
     if (input_generator->eof()) {
         logger->debug("net_test: reached end of input");
-        cb();
+        cb(NoError());
         return;
     }
     if (!input_generator->good()) {
         logger->warn("net_test: I/O error reading input");
-        // TODO: allow to pass error to callback
-        cb();
+        cb(FileIoError());
         return;
     }
 
@@ -46,7 +45,11 @@ void OoniTest::run_next_measurement(Callback<> cb) {
         logger->debug("net_test: tearing down");
         teardown(next_input);
 
-        file_report.write_entry(entry);
+        Error error = file_report.write_entry(entry);
+        if (error) {
+            cb(error);
+            return;
+        }
         logger->debug("net_test: written entry");
 
         reactor->call_soon([=]() { run_next_measurement(cb); });
@@ -95,7 +98,7 @@ void OoniTest::geoip_lookup(Callback<> cb) {
         options, reactor, logger);
 }
 
-void OoniTest::open_report() {
+Error OoniTest::open_report() {
     file_report.test_name = test_name;
     file_report.test_version = test_version;
     file_report.test_start_time = test_start_time;
@@ -110,7 +113,7 @@ void OoniTest::open_report() {
         output_filepath = generate_output_filepath();
     }
     file_report.filename = output_filepath;
-    file_report.open();
+    return file_report.open();
 }
 
 std::string OoniTest::generate_output_filepath() {
@@ -126,7 +129,7 @@ std::string OoniTest::generate_output_filepath() {
         filename << timestamp << "-" << idx << ".json";
 
         std::ifstream output_file(filename.str().c_str());
-        // If a file called this way already exists we increase the counter by 1.
+        // If a file called this way already exists we increment the counter
         if (output_file.good()) {
             output_file.close();
             idx++;
@@ -137,21 +140,24 @@ std::string OoniTest::generate_output_filepath() {
     return filename.str();
 }
 
-void OoniTest::begin(Callback<> cb) {
+void OoniTest::begin(Callback<Error> cb) {
     mk::utc_time_now(&test_start_time);
     geoip_lookup([=]() {
-        open_report();
+        Error error = open_report();
+        if (error) {
+            cb(error);
+            return;
+        }
         if (needs_input) {
             if (input_filepath == "") {
-                // TODO: allow to pass error to cb()
                 logger->warn("an input file is required");
-                cb();
+                cb(MissingRequiredInputFileError());
                 return;
             }
             input_generator.reset(new std::ifstream(input_filepath));
             if (!input_generator->good()) {
                 logger->warn("cannot read input file");
-                cb();
+                cb(CannotOpenInputFileError());
                 return;
             }
         } else {
@@ -161,12 +167,16 @@ void OoniTest::begin(Callback<> cb) {
     });
 }
 
-void OoniTest::end(Callback<> cb) {
-    file_report.close();
+void OoniTest::end(Callback<Error> cb) {
+    Error error = file_report.close();
+    if (error) {
+        cb(error);
+        return;
+    }
     collector::submit_report(
         output_filepath,
         options.get("collector_base_url", collector::default_collector_url()),
-        [=](Error) { cb(); }, options, reactor, logger);
+        [=](Error error) { cb(error); }, options, reactor, logger);
 }
 
 } // namespace ooni

--- a/test/ndt/ndt_test.cpp
+++ b/test/ndt/ndt_test.cpp
@@ -24,8 +24,9 @@ TEST_CASE("Running the NDT test using begin / end works") {
     test->reactor = reactor;
     test->set_verbosity(MK_LOG_INFO);
     reactor->loop_with_initial_event([&]() {
-        test->begin([=]() {
-            test->end([=]() {
+        // TODO: do not ignore errors here, perhaps
+        test->begin([=](Error) {
+            test->end([=](Error) {
                 reactor->break_loop();
             });
         });

--- a/test/ooni/dns_injection.cpp
+++ b/test/ooni/dns_injection.cpp
@@ -22,8 +22,9 @@ TEST_CASE(
     options["dns/timeout"] = 0.1;
     ooni::DnsInjection dns_injection("test/fixtures/hosts.txt", options);
     loop_with_initial_event_and_connectivity([&]() {
+        // TODO: handle errors?
         dns_injection.begin(
-            [&]() { dns_injection.end([]() { break_loop(); }); });
+            [&](Error) { dns_injection.end([](Error) { break_loop(); }); });
     });
 }
 

--- a/test/ooni/http_invalid_request_line.cpp
+++ b/test/ooni/http_invalid_request_line.cpp
@@ -20,8 +20,10 @@ TEST_CASE("The HTTP Invalid Request Line test should run") {
     options["backend"] = "http://213.138.109.232/";
     ooni::HttpInvalidRequestLine http_invalid_request_line(options);
     loop_with_initial_event_and_connectivity([&]() {
-        http_invalid_request_line.begin(
-            [&]() { http_invalid_request_line.end([]() { break_loop(); }); });
+        // TODO: handle errors?
+        http_invalid_request_line.begin([&](Error) {
+            http_invalid_request_line.end([](Error) { break_loop(); });
+        });
     });
 }
 
@@ -33,8 +35,8 @@ TEST_CASE(
     options["dns/timeout"] = 0.1;
     ooni::HttpInvalidRequestLine http_invalid_request_line(options);
     loop_with_initial_event_and_connectivity([&]() {
-        http_invalid_request_line.begin([&]() {
-            http_invalid_request_line.end([]() { break_loop(); });
+        http_invalid_request_line.begin([&](Error) {
+            http_invalid_request_line.end([](Error) { break_loop(); });
         });
     });
 }

--- a/test/ooni/tcp_connect.cpp
+++ b/test/ooni/tcp_connect.cpp
@@ -23,7 +23,9 @@ TEST_CASE(
                                    {"port", "80"},
                                });
     loop_with_initial_event_and_connectivity([&]() {
-        tcp_connect.begin([&]() { tcp_connect.end([]() { break_loop(); }); });
+        tcp_connect.begin([&](Error) {
+            tcp_connect.end([](Error) { break_loop(); });
+        });
     });
 }
 
@@ -35,7 +37,9 @@ TEST_CASE("The TCP connect test should fail with an invalid dns resolver") {
                                 {"dns/attempts", 1},
                                 {"dns/timeout", 0.0001}});
     loop_with_initial_event([&]() {
-        tcp_connect.begin([&]() { tcp_connect.end([]() { break_loop(); }); });
+        tcp_connect.begin([&](Error) {
+            tcp_connect.end([](Error) { break_loop(); });
+        });
     });
 }
 


### PR DESCRIPTION
This allows us to pass information about errors to caller to inform it
of errors such as "we cannot open the report file".