### PR TITLE
ndt: write summary at end of test

### DIFF
--- a/src/ndt/internal.hpp
+++ b/src/ndt/internal.hpp
@@ -218,10 +218,8 @@ inline void log_speed(Var<Logger> logger, std::string type,
                       double elapsed, double speed) {
     logger->log(MK_LOG_JSON | MK_LOG_INFO, R"xx({
             "type": "%s",
-            "elapsed": %lf,
-            "elapsed_unit": "s",
-            "speed": %lf,
-            "speed_unit": "kbit/s"
+            "elapsed": [%lf, "s"],
+            "speed": [%lf, "kbit/s"]
         })xx", type.c_str(), elapsed, speed);
 }
 

--- a/src/ndt/ndt_test.cpp
+++ b/src/ndt/ndt_test.cpp
@@ -3,16 +3,53 @@
 // information on the copying conditions.
 
 #include <measurement_kit/ndt.hpp>
+#include <measurement_kit/ext.hpp>
+#include "src/common/utils.hpp"
 
 namespace mk {
 namespace ndt {
 
+using json = nlohmann::json;
 using namespace mk::report;
 
 NdtTest::NdtTest(Settings s) : OoniTest("", s) {
     options["save_real_probe_ip"] = true;
     test_name = "ndt";
     test_version = "0.0.1";
+}
+
+static void log_summary(Var<Logger> logger, Var<Entry> entry_) {
+    try {
+        json entry = json::parse(entry_->dump()); /* XXX */
+        nlohmann::json node{
+            {"type", "summary"},
+        };
+        node["failure"] = entry["failure"];
+        node["ping"] = {
+            entry["web100_data"]["MinRTT"],
+            "ms"
+        };
+        std::vector<double> speeds;
+        for (auto e: entry["receiver_data"]) {
+            speeds.push_back(e[1]);
+        }
+        node["median_speed"] = {
+            percentile(speeds, 0.5),
+            "kbit/s"
+        };
+        node["10_percentile_speed"] = {
+            percentile(speeds, 0.1),
+            "kbit/s"
+        };
+        node["90_percentile_speed"] = {
+            percentile(speeds, 0.9),
+            "kbit/s"
+        };
+        logger->log(MK_LOG_INFO | MK_LOG_JSON, "%s", node.dump().c_str());
+    } catch (const std::exception &e) {
+        logger->warn("could not write NDT test summary: %s", e.what());
+        /* suppress */ ;
+    }
 }
 
 void NdtTest::main(std::string, Settings settings, Callback<Entry> cb) {
@@ -24,6 +61,7 @@ void NdtTest::main(std::string, Settings settings, Callback<Entry> cb) {
         if (error) {
             (*entry)["failure"] = error.as_ooni_error();
         }
+        log_summary(logger, entry);
         // XXX The callback should probably take a Var<Entry>
         cb(*entry);
     }, settings, logger, reactor);


### PR DESCRIPTION
While here, also change the format used to log speed while the test
is in progress to express unit and number in a single entry.

Depends on #725.