### PR TITLE
logger: do not fallthrough with invalid JSON message

### DIFF
--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -19,7 +19,7 @@ Logger::Logger() {
                 s = message.c_str();
             } catch (std::exception &) {
                 fprintf(stderr, "warning: logger cannot parse json message\n");
-                /* suppress */ ;
+                return;
             }
             /* FALLTHROUGH */
         }


### PR DESCRIPTION
We must guarantee that, if we pass the App a JSON message, this is
actually a valid JSON message.