### PR TITLE
Allow logging also on log file

### DIFF
--- a/doc/api/common/logger.md
+++ b/doc/api/common/logger.md
@@ -177,6 +177,11 @@ int main() {
 }
 ```
 
+# BUGS
+
+If the logfile could not be open, or written, the error is silently
+discarded (i.e. no exceptions thrown, no return values).
+
 # HISTORY
 
 The `Logger` class appeared in MeasurementKit 0.1.0.

--- a/doc/api/common/logger.md
+++ b/doc/api/common/logger.md
@@ -17,6 +17,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 #define MK_LOG_DEBUG2 3
 #define MK_LOG_VERBOSITY_MASK 31
 
+#define MK_LOG_JSON 32 ///< log message is a valid JSON document
+
 namespace mk {
 
 class Logger : public NonCopyable, public NonMovable {
@@ -35,6 +37,8 @@ class Logger : public NonCopyable, public NonMovable {
 
     void on_log(Delegate<uint32_t, const char *> fn);
 
+    void set_logfile(std::string path);
+
     static Var<Logger> global();
 };
 
@@ -50,6 +54,8 @@ void increase_verbosity();
 uint32_t get_verbosity();
 
 void on_log(Delegate<uint32_t, const char *> fn);
+
+void set_logfile(std::string path);
 
 }
 ```
@@ -88,16 +94,23 @@ The `on_log` method allow to either set or reset the function called
 for each logging message. Such function is a delegate (i.e. the delegate
 body can safely change the delegate itself) and takes in input the
 verbosity level of the message and the message itself. The default log
-function prints on the standard error output the log level as integer
-enclosed by angular braces, followed by the formatted log message string.
-For example:
+function prints on the standard error output the severity (unless the
+severity is INFO, in which case nothing is printed) followed by the log
+message. For example:
+```
+warning: A warning message
+A info message
+debug: A debug message
+debug: A debug2 message
+```
 
-```
-<0> A warning message
-<1> A info message
-<2> A debug message
-<3> A debug2 message
-```
+To disable the log callback, pass `nullptr` to it.
+
+The `set_logfile` method instructs the logger to write a copy of each log
+message into the specified log file. Setting the logfile has no impact on
+logs written using `on_log` and *viceversa*. By default no log file is
+specified. It is legal (albeit useless) to have a logger not attached to
+any log file and whose `on_log` callback is `nullptr`.
 
 The `global()` factory returns the default logger.
 

--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -5,6 +5,7 @@
 #define MEASUREMENT_KIT_COMMON_LOGGER_HPP
 
 #include <cstdint>
+#include <fstream>
 #include <measurement_kit/common/delegate.hpp>
 #include <measurement_kit/common/non_copyable.hpp>
 #include <measurement_kit/common/non_movable.hpp>
@@ -43,6 +44,8 @@ class Logger : public NonCopyable, public NonMovable {
 
     void on_log(Delegate<uint32_t, const char *> fn) { consumer_ = fn; }
 
+    void set_logfile(std::string fpath);
+
     static Var<Logger> global() {
         static Var<Logger> singleton(new Logger);
         return singleton;
@@ -53,6 +56,7 @@ class Logger : public NonCopyable, public NonMovable {
     uint32_t verbosity_ = MK_LOG_WARNING;
     char buffer_[32768];
     std::mutex mutex_;
+    std::ofstream ofile_;
 
     Logger();
 };
@@ -68,6 +72,10 @@ inline uint32_t get_verbosity() { return Logger::global()->get_verbosity(); }
 
 inline void on_log(Delegate<uint32_t, const char *> fn) {
     Logger::global()->on_log(fn);
+}
+
+inline void set_logfile(std::string path) {
+    Logger::global()->set_logfile(path);
 }
 
 } // namespace mk

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -35,7 +35,7 @@ Logger::Logger() {
 }
 
 void Logger::logv(uint32_t level, const char *fmt, va_list ap) {
-    if (!consumer_) {
+    if (!consumer_ and !ofile_.is_open()) {
         return;
     }
     std::lock_guard<std::mutex> lock(mutex_);
@@ -46,7 +46,13 @@ void Logger::logv(uint32_t level, const char *fmt, va_list ap) {
     if (res < 0 || (unsigned int)res >= sizeof(buffer_)) {
         return;
     }
-    consumer_(level, buffer_);
+    if (consumer_) {
+        consumer_(level, buffer_);
+    }
+    if (ofile_) {
+        ofile_ << buffer_ << "\n";
+        // TODO: suppose here write fails... what do we want to do?
+    }
 }
 
 #define XX(_logger_, _level_)                                                  \
@@ -76,6 +82,11 @@ void Logger::increase_verbosity() {
     if (verbosity_ < MK_LOG_VERBOSITY_MASK) {
         ++verbosity_;
     }
+}
+
+void Logger::set_logfile(std::string path) {
+    ofile_ = std::ofstream(path);
+    // TODO: what to do if we cannot open the logfile? return error?
 }
 
 } // namespace mk

--- a/test/common/logger.cpp
+++ b/test/common/logger.cpp
@@ -9,6 +9,8 @@
 
 #include <string>
 
+using namespace mk;
+
 TEST_CASE("By default the logger is quiet") {
     std::string buffer;
 
@@ -53,4 +55,32 @@ TEST_CASE("Verbosity can be further increased") {
     mk::info("Foo");
 
     REQUIRE(buffer == "Antani\nFoo\n");
+}
+
+TEST_CASE("We can log on a logfile") {
+    {
+        Var<Logger> logger = Logger::make();
+        logger->set_logfile("logfile.log");
+        logger->set_verbosity(MK_LOG_DEBUG);
+        logger->on_log(nullptr);
+        logger->warn("foo");
+        logger->warn("foobar");
+        logger->warn("bar");
+    }
+    std::ifstream file("logfile.log");
+    std::string line;
+    std::string whole_file;
+    while ((std::getline(file, line))) {
+        whole_file += line;
+        whole_file += "\n";
+    }
+    REQUIRE(whole_file == "foo\nfoobar\nbar\n");
+}
+
+TEST_CASE("A logger without file and without callback works") {
+    Var<Logger> logger = Logger::make();
+    logger->set_verbosity(MK_LOG_DEBUG);
+    logger->on_log(nullptr);
+    logger->warn("foo");
+    logger->warn("foobar");
 }


### PR DESCRIPTION
This logging is orthogonal from logging specified through the
`on_log()` method such that both can be employed.

Closes #706.

- - - 

While there, also make sure logger's documentation is up to date.