### PR TITLE
net_test: add callback to get entry as string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ test/net/transport
 test/ooni/collector_client
 test/ooni/dns_injection
 test/ooni/http_invalid_request_line
+test/ooni/ooni_test
 test/ooni/tcp_connect
 test/ooni/templates
 test/ooni/utils

--- a/include/measurement_kit/common/net_test.hpp
+++ b/include/measurement_kit/common/net_test.hpp
@@ -62,6 +62,10 @@ class NetTest {
         options[key] = value;
         return *this;
     }
+    NetTest &on_entry(Callback<std::string> cb) {
+        entry_cb = cb;
+        return *this;
+    }
 
     virtual Var<NetTest> create_test_() {
         // You must override this in subclasses to create the actual
@@ -77,6 +81,7 @@ class NetTest {
     Settings options;
     std::string input_filepath;
     std::string output_filepath;
+    Callback<std::string> entry_cb;
 };
 
 } // namespace mk

--- a/include/measurement_kit/ooni/ooni_test.hpp
+++ b/include/measurement_kit/ooni/ooni_test.hpp
@@ -31,7 +31,7 @@ class OoniTest : public NetTest, public NonCopyable, public NonMovable {
     OoniTest(std::string f) : OoniTest(f, Settings()) {}
 
     OoniTest(std::string f, Settings o) : NetTest(f, o),
-        test_name("net_test"), test_version("0.0.1") {}
+        test_name("ooni_test"), test_version("0.0.1") {}
 
     void begin(Callback<Error>) override;
     void end(Callback<Error>) override;

--- a/src/ooni/ooni_test.cpp
+++ b/src/ooni/ooni_test.cpp
@@ -51,6 +51,9 @@ void OoniTest::run_next_measurement(Callback<Error> cb) {
             cb(error);
             return;
         }
+        if (entry_cb) {
+            entry_cb(entry.dump());
+        }
         logger->debug("net_test: written entry");
 
         reactor->call_soon([=]() { run_next_measurement(cb); });

--- a/test/ooni/ooni_test.cpp
+++ b/test/ooni/ooni_test.cpp
@@ -1,0 +1,42 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifdef ENABLE_INTEGRATION_TESTS
+
+#define CATCH_CONFIG_MAIN
+
+#include "src/ext/Catch/single_include/catch.hpp"
+#include <measurement_kit/ooni.hpp>
+
+using namespace mk;
+
+TEST_CASE("Make sure that on_entry() works") {
+    ooni::OoniTest test;
+    loop_with_initial_event([&]() {
+        test.on_entry([](std::string s) {
+            nlohmann::json entry = nlohmann::json::parse(s);
+            REQUIRE((entry.at("data_format_version") == "0.2.0"));
+            REQUIRE((entry.at("input") == ""));
+            REQUIRE((entry.at("measurement_start_time") != ""));
+            REQUIRE((entry.at("probe_asn") == "AS0"));
+            REQUIRE((entry.at("probe_cc") == "ZZ"));
+            REQUIRE((entry.at("probe_ip") == "127.0.0.1"));
+            REQUIRE((entry.at("software_name") == "measurement_kit"));
+            REQUIRE((entry.at("software_version") != ""));
+            REQUIRE((entry.at("test_keys") != nullptr));
+            REQUIRE((entry.at("test_name") == "ooni_test"));
+            REQUIRE((static_cast<double>(entry.at("test_runtime")) > 0.0));
+            REQUIRE((entry.at("test_start_time") != ""));
+            REQUIRE((entry.at("test_version") != ""));
+        })
+        .begin([&](Error) {
+            test.end([&](Error) {
+                break_loop();
+            });
+        });
+    });
+}
+
+#else
+int main() {}
+#endif


### PR DESCRIPTION
While there, fix the name of the default OONI test to be `ooni_test`
rather than being just `net_test`.

Closes #729 