### PR TITLE
Make sure we copy on_entry()

### DIFF
--- a/src/ndt/ndt_test.cpp
+++ b/src/ndt/ndt_test.cpp
@@ -74,6 +74,7 @@ Var<NetTest> NdtTest::create_test_() {
     test->options = options;
     test->input_filepath = input_filepath;
     test->output_filepath = output_filepath;
+    test->entry_cb = entry_cb;
     return Var<NetTest>(test);
 }
 

--- a/src/ooni/dns_injection.cpp
+++ b/src/ooni/dns_injection.cpp
@@ -35,6 +35,7 @@ Var<NetTest> DnsInjection::create_test_() {
     test->logger = logger;
     test->reactor = reactor;
     test->output_filepath = output_filepath;
+    test->entry_cb = entry_cb;
     return Var<NetTest>(test);
 }
 

--- a/src/ooni/http_invalid_request_line.cpp
+++ b/src/ooni/http_invalid_request_line.cpp
@@ -119,6 +119,7 @@ Var<NetTest> HttpInvalidRequestLine::create_test_() {
     test->logger = logger;
     test->reactor = reactor;
     test->output_filepath = output_filepath;
+    test->entry_cb = entry_cb;
     return Var<NetTest>(test);
 }
 

--- a/src/ooni/tcp_connect.cpp
+++ b/src/ooni/tcp_connect.cpp
@@ -34,6 +34,7 @@ Var<NetTest> TcpConnect::create_test_() {
     test->logger = logger;
     test->reactor = reactor;
     test->output_filepath = output_filepath;
+    test->entry_cb = entry_cb;
     return Var<NetTest>(test);
 }
 

--- a/src/ooni/web_connectivity.cpp
+++ b/src/ooni/web_connectivity.cpp
@@ -609,6 +609,7 @@ Var<NetTest> WebConnectivity::create_test_() {
   test->logger = logger;
   test->reactor = reactor;
   test->output_filepath = output_filepath;
+  test->entry_cb = entry_cb;
   return Var<NetTest>(test);
 }
 


### PR DESCRIPTION
For now this patch will do but we'd better properly use copy
construction to avoid losing pieces when we copy.

Also, it would probably make sense to second think the current
approach where we schedule a Var copy of the original object to
see whether there is a better approach for doing the same.