### PR TITLE
By default use testing collector

### DIFF
--- a/include/measurement_kit/ooni/collector_client.hpp
+++ b/include/measurement_kit/ooni/collector_client.hpp
@@ -16,8 +16,10 @@ namespace collector {
 */
 
 #define MK_OONI_DEFAULT_COLLECTOR_URL "https://a.collector.ooni.io:4441"
+#define MK_OONI_TESTING_COLLECTOR_URL "https://a.collector.test.ooni.io"
 
 std::string default_collector_url();
+std::string testing_collector_url();
 
 void submit_report(std::string filepath, std::string collector_base_url,
                    Callback<Error> callback, Settings conf = {},

--- a/src/ooni/collector_client.cpp
+++ b/src/ooni/collector_client.cpp
@@ -106,6 +106,10 @@ std::string default_collector_url() {
     return MK_OONI_DEFAULT_COLLECTOR_URL;
 }
 
+std::string testing_collector_url() {
+    return MK_OONI_TESTING_COLLECTOR_URL;
+}
+
 } // namespace collector
 } // namespace mk
 } // namespace ooni

--- a/src/ooni/ooni_test.cpp
+++ b/src/ooni/ooni_test.cpp
@@ -165,7 +165,12 @@ void OoniTest::end(Callback<> cb) {
     file_report.close();
     collector::submit_report(
         output_filepath,
-        options.get("collector_base_url", collector::default_collector_url()),
+        options.get(
+            // Note: by default we use the testing collector URL because otherwise
+            // testing runs would be collected creating noise and using resources
+            "collector_base_url",
+            collector::testing_collector_url()
+        ),
         [=](Error) { cb(); }, options, reactor, logger);
 }
 

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -87,7 +87,7 @@ static void fail(Var<Transport>, Settings, Headers, std::string,
 }
 
 const static Settings SETTINGS = {
-    {"collector_base_url", collector::default_collector_url()},
+    {"collector_base_url", collector::testing_collector_url()},
 };
 
 TEST_CASE("collector::post deals with network error") {
@@ -437,7 +437,7 @@ TEST_CASE("submit_report() deals with collector_create_report error") {
 TEST_CASE("The collector client works as expected") {
     loop_with_initial_event([=]() {
         collector::submit_report("test/fixtures/report.json",
-                                 collector::default_collector_url(),
+                                 collector::testing_collector_url(),
                                  [=](Error err) {
                                      REQUIRE(err == NoError());
                                      break_loop();


### PR DESCRIPTION
As pointed out by @hellais in [#732](https://github.com/measurement-kit/measurement-kit/pull/732#issuecomment-236722618), we should not use the default collector for running end-to-end tests on travis. Fix this by using by default the test collector and by allowing users to override this with a function to get the default collector.