### PR TITLE
open database just when needed

### DIFF
--- a/include/measurement_kit/ooni/error.hpp
+++ b/include/measurement_kit/ooni/error.hpp
@@ -17,6 +17,7 @@ MK_DEFINE_ERR(MK_ERR_OONI(4), MissingMandatoryKeyError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(5), InvalidMandatoryValueError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(6), MissingRequiredHostError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(7), MissingRequiredUrlError, "")
+MK_DEFINE_ERR(MK_ERR_OONI(8), InvalidGeoIPDatabase, "")
 
 } // namespace mk
 } // namespace ooni

--- a/include/measurement_kit/ooni/error.hpp
+++ b/include/measurement_kit/ooni/error.hpp
@@ -17,7 +17,8 @@ MK_DEFINE_ERR(MK_ERR_OONI(4), MissingMandatoryKeyError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(5), InvalidMandatoryValueError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(6), MissingRequiredHostError, "")
 MK_DEFINE_ERR(MK_ERR_OONI(7), MissingRequiredUrlError, "")
-MK_DEFINE_ERR(MK_ERR_OONI(8), InvalidGeoIPDatabase, "")
+MK_DEFINE_ERR(MK_ERR_OONI(8), CannotOpenGeoIpCountryDatabase, "")
+MK_DEFINE_ERR(MK_ERR_OONI(8), CannotOpenGeoIpAsnDatabase, "")
 
 } // namespace mk
 } // namespace ooni

--- a/src/ooni/utils.cpp
+++ b/src/ooni/utils.cpp
@@ -23,9 +23,9 @@ void resolver_lookup(Callback<Error, std::string> callback, Settings settings,
     resolver_lookup_impl(callback, settings, reactor, logger);
 }
 
-IPLocation::IPLocation(std::string path_country, std::string path_asn) {
-    _path_asn = path_asn;
-    _path_country = path_country;
+IPLocation::IPLocation(std::string path_country_, std::string path_asn_) {
+    path_asn = path_asn_;
+    path_country = path_country_;
 }
 
 IPLocation::~IPLocation() {
@@ -39,9 +39,9 @@ IPLocation::~IPLocation() {
 
 ErrorOr<std::string> IPLocation::resolve_country_code(std::string ip) {
     if (gi_country == nullptr) {
-        gi_country = GeoIP_open(_path_country.c_str(), GEOIP_MEMORY_CACHE);
+        gi_country = GeoIP_open(path_country.c_str(), GEOIP_MEMORY_CACHE);
         if (gi_country == nullptr) {
-            return InvalidGeoIPDatabase();
+            return CannotOpenGeoIpCountryDatabase();
         }
     }
     GeoIPLookup gl;
@@ -59,9 +59,9 @@ ErrorOr<std::string> IPLocation::resolve_country_code(std::string ip) {
 
 ErrorOr<std::string> IPLocation::resolve_country_name(std::string ip) {
     if (gi_country == nullptr) {
-        gi_country = GeoIP_open(_path_country.c_str(), GEOIP_MEMORY_CACHE);
+        gi_country = GeoIP_open(path_country.c_str(), GEOIP_MEMORY_CACHE);
         if (gi_country == nullptr) {
-            return InvalidGeoIPDatabase();
+            return CannotOpenGeoIpCountryDatabase();
         }
     }
     GeoIPLookup gl;
@@ -78,9 +78,9 @@ ErrorOr<std::string> IPLocation::resolve_country_name(std::string ip) {
 
 ErrorOr<std::string> IPLocation::resolve_asn(std::string ip) {
     if (gi_asn == nullptr) {
-        gi_asn = GeoIP_open(_path_asn.c_str(), GEOIP_MEMORY_CACHE);
+        gi_asn = GeoIP_open(path_asn.c_str(), GEOIP_MEMORY_CACHE);
         if (gi_asn == nullptr) {
-            return InvalidGeoIPDatabase();
+            return CannotOpenGeoIpAsnDatabase();
         }
     }
     GeoIPLookup gl;

--- a/src/ooni/utils.hpp
+++ b/src/ooni/utils.hpp
@@ -38,8 +38,8 @@ class IPLocation {
       ErrorOr<std::string> resolve_asn(std::string ip);
 
     private:
-      std::string _path_country = "";
-      std::string _path_asn = "";
+      std::string path_country = "";
+      std::string path_asn = "";
       GeoIP *gi_asn = nullptr;
       GeoIP *gi_country = nullptr;
       Var<Logger> logger = Logger::make();

--- a/src/ooni/utils.hpp
+++ b/src/ooni/utils.hpp
@@ -8,6 +8,7 @@
 #include <measurement_kit/common.hpp>
 #include <measurement_kit/ext.hpp>
 #include <measurement_kit/http.hpp>
+#include <measurement_kit/ooni/error.hpp>
 #include <regex>
 #include <string>
 
@@ -37,6 +38,8 @@ class IPLocation {
       ErrorOr<std::string> resolve_asn(std::string ip);
 
     private:
+      std::string _path_country = "";
+      std::string _path_asn = "";
       GeoIP *gi_asn = nullptr;
       GeoIP *gi_country = nullptr;
       Var<Logger> logger = Logger::make();

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -30,10 +30,16 @@ TEST_CASE("geoip works") {
     REQUIRE(((*json)["country_name"] == std::string{"United States"}));
 }
 
-TEST_CASE("geoip can handle an invalid database") {
+TEST_CASE("geoip returns an error if it can't open the country database") {
     mk::ErrorOr<json> json = mk::ooni::geoip(
         "8.8.8.8", "test/fixtures/GeoIPinvalid.dat", "invalid_path.dat");
-    REQUIRE(json.as_error() == mk::ooni::InvalidGeoIPDatabase());
+    REQUIRE(json.as_error() == mk::ooni::CannotOpenGeoIpCountryDatabase());
+}
+
+TEST_CASE("geoip returns an error if it can't open the asn database") {
+    mk::ErrorOr<json> json = mk::ooni::geoip(
+        "8.8.8.8", "test/fixtures/GeoIPinvalid.dat", "invalid_path.dat");
+    REQUIRE(json.as_error() == mk::ooni::CannotOpenGeoIpAsnDatabase());
 }
 
 TEST_CASE("is_ip_addr works on ipv4") {

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -30,6 +30,12 @@ TEST_CASE("geoip works") {
     REQUIRE(((*json)["country_name"] == std::string{"United States"}));
 }
 
+TEST_CASE("geoip can handle an invalid database") {
+    mk::ErrorOr<json> json = mk::ooni::geoip(
+        "8.8.8.8", "test/fixtures/GeoIPinvalid.dat", "invalid_path.dat");
+    REQUIRE(json.as_error() == mk::ooni::InvalidGeoIPDatabase());
+}
+
 TEST_CASE("is_ip_addr works on ipv4") {
     REQUIRE(mk::ooni::is_ip_addr("127.0.0.1") == true);
 }


### PR DESCRIPTION
This PR is related to #738 
I did the following changes:

1. Add a specific error to handle an invalid db. 
2. The constructor will just save the path and nothing more
3. Move the db opening phase to the functions that needs it and leave it open until the destructor is called.
This makes us able to do multiple query to the same db without having to reopen it.
4. Adapt the function `geoip` to return the correct error. I will remove it in future PR  according to #737

I think this will also complete #736 if I interpreted it right. 