### PR TITLE
settings_entry.md: expand on bug documentation

### DIFF
--- a/doc/api/common/settings_entry.md
+++ b/doc/api/common/settings_entry.md
@@ -45,6 +45,10 @@ rather than throwing exception on error.
 Since `std::stringstream` represents `true` using `1` and `false` using `0`, the
 commonly established semantic that any nonzero value is `true` does not hold.
 
+Additionally, this means that the string `"true"` is not going to be parsed
+as a true value and likewise `"false"` is not going to be parsed as a false
+value. This behavior is not what one whould expect.
+
 # HISTORY
 
 The `SettingsEntry` class appeared in MeasurementKit 0.2.0.


### PR DESCRIPTION
As experienced by @lorenzoPrimi, this behavior of the Settings
class with respect to booleans is super annoying.