### PR TITLE
Refactoring of runner

### DIFF
--- a/include/measurement_kit/common/runner.hpp
+++ b/include/measurement_kit/common/runner.hpp
@@ -17,10 +17,10 @@ class NetTest;
 class Runner {
   public:
     Runner();
-    void run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> func);
-    void break_loop();
+    void run_test(Var<NetTest> test, Callback<Var<NetTest>> func);
+    void break_loop_();
     bool empty();
-    void join();
+    void join_();
     ~Runner();
     static Var<Runner> global();
 

--- a/src/libmeasurement_kit/common/runner.cpp
+++ b/src/libmeasurement_kit/common/runner.cpp
@@ -4,14 +4,16 @@
 
 #include <measurement_kit/common.hpp>
 
+#include <cassert>
 #include <future>
 
 namespace mk {
 
 Runner::Runner() {}
 
-void Runner::run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> fn) {
-    if (!running) {
+void Runner::run_test(Var<NetTest> test, Callback<Var<NetTest>> fn) {
+    assert(active >= 0);
+    if (not running) {
         std::promise<bool> promise;
         std::future<bool> future = promise.get_future();
         // WARNING: below we're passing `this` to the thread, which means that
@@ -56,11 +58,11 @@ void Runner::run_test(Var<NetTest> test, std::function<void(Var<NetTest>)> fn) {
     });
 }
 
-void Runner::break_loop() { reactor->break_loop(); }
+void Runner::break_loop_() { reactor->break_loop(); }
 
 bool Runner::empty() { return active == 0; }
 
-void Runner::join() {
+void Runner::join_() {
     if (running) {
         thread.join();
         running = false;
@@ -70,8 +72,8 @@ void Runner::join() {
 Runner::~Runner() {
     // WARNING: This MUST be here to make sure we break the loop before we
     // stop the thread. Not doing that leads to undefined behavior.
-    break_loop();
-    join();
+    break_loop_();
+    join_();
 }
 
 /*static*/ Var<Runner> Runner::global() {

--- a/test/common/runner.cpp
+++ b/test/common/runner.cpp
@@ -86,8 +86,8 @@ TEST_CASE("The destructor work as expected if the thread was already joined") {
     while (!runner.empty()) {
         sleep(1);
     }
-    runner.break_loop();
-    runner.join();
+    runner.break_loop_();
+    runner.join_();
 }
 
 TEST_CASE("Nothing strange happens if no thread is bound to Runner") {


### PR DESCRIPTION
1) make certain possibly ambiguous functions less ambiguous
   by adding an underscore to their name.

2) make sure we use Callback rather than std::function.

3) add one more assert.