### PR TITLE
web_connectivity: set the accessible key

### DIFF
--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -339,8 +339,10 @@ static void compare_control_experiment(
       std::string blocking = (*entry)["blocking"];
       logger->info("web_connectivity: BLOCKING detected due to: %s on %s",
                    blocking.c_str(), input.c_str());
+      (*entry)["accessible"] = false;
     } else {
       logger->info("web_connectivity: no blocking detected");
+      (*entry)["accessible"] = true;
     }
 }
 


### PR DESCRIPTION
As reported by @lorenzoPrimi in #867, the accessible key was not
correctly set in the output JSON.

This simple diff should fix the issue by setting the accessible
key depending on whether there was blocking.

Closes #867.