### PR TITLE
connect.cpp: increase default net/timeout

### DIFF
--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -236,7 +236,7 @@ void connect(std::string address, int port,
         return;
     }
     if (settings.find("net/timeout") == settings.end()) {
-        settings["net/timeout"] = 5.0;
+        settings["net/timeout"] = 30.0;
     }
     double timeout = settings["net/timeout"].as<double>();
     connect_logic(

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -339,8 +339,10 @@ static void compare_control_experiment(
       std::string blocking = (*entry)["blocking"];
       logger->info("web_connectivity: BLOCKING detected due to: %s on %s",
                    blocking.c_str(), input.c_str());
+      (*entry)["accessible"] = false;
     } else {
       logger->info("web_connectivity: no blocking detected");
+      (*entry)["accessible"] = true;
     }
 }
 


### PR DESCRIPTION
A timeout of at least 30 seconds for connect() should be a reasonable
timeout and it should in particular be more reasonable than five seconds
given that we have seen that inactive heroku machines, for example,
take more than five seconds to respond.

This should fix the immediate bug reported in #864. I've yet to decide
whether this would also mean we can close the bug or not.