### PR TITLE
Bug in ndt JSON

### DIFF
--- a/src/libmeasurement_kit/ooni/ooni_test.cpp
+++ b/src/libmeasurement_kit/ooni/ooni_test.cpp
@@ -31,7 +31,8 @@ void OoniTest::run_next_measurement(size_t thread_id, Callback<Error> cb,
         prog = *current_entry / (double)num_entries;
     }
     *current_entry += 1;
-    logger->log(MK_LOG_INFO|MK_LOG_JSON, "{\"progress\": %f}", prog);
+    logger->log(MK_LOG_INFO|MK_LOG_JSON,
+        "{\"progress\": %f, \"type\": \"progress\"}", prog);
 
     logger->debug("net_test: creating entry");
     struct tm measurement_start_time;


### PR DESCRIPTION
While checking the output of NDT with @bassosimone we discovered this bug, where the JSON doesn't have a valid type entry.
