### PR TITLE
http/request: don't redirect if *max_request <= 0

### DIFF
--- a/src/libmeasurement_kit/http/request.cpp
+++ b/src/libmeasurement_kit/http/request.cpp
@@ -223,7 +223,8 @@ void request(Settings settings, Headers headers, std::string body,
                             return;
                         }
                         response->previous = previous;
-                        if (response->status_code / 100 == 3) {
+                        if (response->status_code / 100 == 3 and
+                            *max_redirects > 0) {
                             logger->debug("following redirect...");
                             std::string loc = response->headers["Location"];
                             if (loc == "") {


### PR DESCRIPTION
If the user has not asked to follow redirect (i.e. the max number of
redirects is zero or less than that), do not enter into the branch
where we follow the redirect even if there is a `location` header in
the received headers set.

Fix originally implemented to #811 and backported as hotfix.

(This is same as #908 but for master.)