### PR TITLE
dns: take 4 resolvers

### DIFF
--- a/src/libmeasurement_kit/libevent/dns_impl.hpp
+++ b/src/libmeasurement_kit/libevent/dns_impl.hpp
@@ -14,6 +14,8 @@
 #include <limits.h>
 #include <type_traits>
 
+#define MAX_DNS_NAMESERVER 4
+
 extern "C" {
 void handle_resolve(
         int code, char type, int count, int ttl, void *addresses, void *opaque);
@@ -64,7 +66,16 @@ static inline evdns_base *create_evdns_base(
         if (evdns_base_nameserver_ip_add(
                     base, settings["dns/nameserver"].c_str()) != 0) {
             evdns_base_free(base, 1);
-            throw std::runtime_error("Cannot set server address");
+            throw std::runtime_error("Cannot set dns nameserver address");
+        }
+        for (int i=1; i<MAX_DNS_NAMESERVER; i++) {
+            if (settings.find("dns/nameserver"+i) != settings.end()) {
+                if (evdns_base_nameserver_ip_add(
+                            base, settings["dns/nameserver"+i].c_str()) != 0) {
+                    evdns_base_free(base, 1);
+                    throw std::runtime_error("Cannot set dns nameserver address");
+                }
+            }
         }
     } else if ((base = evdns_base_new(evb, 1)) == nullptr) {
         throw std::bad_alloc();

--- a/src/libmeasurement_kit/libevent/dns_impl.hpp
+++ b/src/libmeasurement_kit/libevent/dns_impl.hpp
@@ -68,10 +68,10 @@ static inline evdns_base *create_evdns_base(
             evdns_base_free(base, 1);
             throw std::runtime_error("Cannot set dns nameserver address");
         }
-        for (int i=1; i<MAX_DNS_NAMESERVER; i++) {
-            if (settings.find("dns/nameserver"+i) != settings.end()) {
+        for (int i=1; i<MAX_DNS_NAMESERVER; i++) {
+            if (settings.find("dns/nameserver" + std::to_string(i)) != settings.end()) {
                 if (evdns_base_nameserver_ip_add(
-                            base, settings["dns/nameserver"+i].c_str()) != 0) {
+                            base, settings["dns/nameserver" + std::to_string(i)].c_str()) != 0) {
                     evdns_base_free(base, 1);
                     throw std::runtime_error("Cannot set dns nameserver address");
                 }

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -296,4 +296,23 @@ TEST_CASE("The system resolver works as expected") {
     });
 }
 
+TEST_CASE("The system resolver works as expected setting 2 invalid dns and 1 valid") {
+
+    loop_with_initial_event([]() {
+        query("IN", "A", "www.neubot.org", [](Error e, Var<Message> message) {
+            REQUIRE(!e);
+            REQUIRE(message->error_code == DNS_ERR_NONE);
+            REQUIRE(message->answers.size() == 1);
+            REQUIRE(message->answers[0].ipv4 == "130.192.16.172");
+            REQUIRE(message->rtt > 0.0);
+            REQUIRE(message->answers[0].ttl > 0);
+            break_loop();
+        }, {
+            {"dns/nameserver", "6.6.6.6"},
+            {"dns/nameserver1", "7.7.7.7"},
+            {"dns/nameserver2", "8.8.8.8"}
+           }
+        );
+    });
+}
 #endif


### PR DESCRIPTION
This fast fix help us using the library in mobile applications where we need to set more than one dns resolver.

This is an hotfix to solve #904 until we refactor the settings class to support string vectors.