### PR TITLE
bufferevent: use BEV_OPT_DEFER_CALLBACKS

### DIFF
--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -156,9 +156,13 @@ void connect_ssl(bufferevent *orig_bev, ssl_st *ssl, std::string hostname,
                  Var<Logger> logger) {
     logger->debug("connect ssl...");
 
+    // Perhaps DEFER not needed on SSL but setting it won't hurt. See
+    // the similar comment in connect_impl.hpp for rationale.
+    static const int flags = BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS;
+
     auto bev = bufferevent_openssl_filter_new(
         reactor->get_event_base(), orig_bev, ssl, BUFFEREVENT_SSL_CONNECTING,
-        BEV_OPT_CLOSE_ON_FREE);
+        flags);
     if (bev == nullptr) {
         bufferevent_free(orig_bev);
         cb(GenericError(), nullptr);

--- a/src/libmeasurement_kit/net/listen.hpp
+++ b/src/libmeasurement_kit/net/listen.hpp
@@ -31,8 +31,10 @@ inline void listen4(std::string address, int port, ListenCb cb) {
     }
 
     auto cbp = new ListenInternalCb([cb](evutil_socket_t so) {
+        // See similar comment in connect_impl.hpp for DEFER rationale
+        static const int flgs = BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS;
         bufferevent *bev = bufferevent_socket_new(
-                Reactor::global()->get_event_base(), so, BEV_OPT_CLOSE_ON_FREE);
+                Reactor::global()->get_event_base(), so, flgs);
         if (bev == nullptr) {
             (void)evutil_closesocket(so);
             return;


### PR DESCRIPTION
Quoting from the diff itself:

```diff
+    /*
+     *  Rationale for deferring callbacks:
+     *
+     *  When using IOCP on Windows, the kernel calls callbacks when selected
+     *  events occur (i.e., there is no loop that guarantees callbacks run in
+     *  the same thread); set DEFER_CALLBACKS to tell libevent to serialize
+     *  bufferevent's callbacks into the event loop to avoid creating MT issues
+     *  in code that otherwise (on Unices) is single threaded.
+     *
+     *  Yes, the current implementation forces serializing the callbacks also
+     *  on Unix where this wouldn't be needed thus adding some overhead. For
+     *  uniformity, I am for serializing for all platforms and then, if we see
+     *  that there's too much overhead, to only enable that on Windows.
+     */
```

Close #901 