### PR TITLE
Switch travis builds to VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ after_success:
 
 matrix:
   include:
-
+    # We need to use VM based builds to have ipv6 enabled
     - sudo: true
       compiler: gcc-6
       env: COVERAGE=--enable-coverage CXX_NAME=g++-6 CC_NAME=gcc-6
@@ -46,7 +46,7 @@ matrix:
             - gcc-6
           sources:
             - ubuntu-toolchain-r-test
-
+    # We need to use VM based builds to have ipv6 enabled
     - sudo: true
       compiler: gcc-6
       env: CXX_NAME=g++-6 CC_NAME=gcc-6 VALGRIND=-valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ after_success:
 matrix:
   include:
 
-    - sudo: false
+    - sudo: true
       compiler: gcc-6
       env: COVERAGE=--enable-coverage CXX_NAME=g++-6 CC_NAME=gcc-6
       addons:
@@ -47,7 +47,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - sudo: false
+    - sudo: true
       compiler: gcc-6
       env: CXX_NAME=g++-6 CC_NAME=gcc-6 VALGRIND=-valgrind
       addons:


### PR DESCRIPTION
We were using the container based build system that doesn't support ipv6. 
To be able to test ipv6 we need to switch to the VM based build system.