### PR TITLE
ndt: exchange reactor and logger arguments

### DIFF
--- a/include/measurement_kit/ndt/run.hpp
+++ b/include/measurement_kit/ndt/run.hpp
@@ -13,21 +13,23 @@ using namespace mk::report;
 
 // By default we pass MK_NDT_UPLOAD|MK_NDT_DOWNLOAD as settings["test_suite"]
 // but you can tweak that by only requesting a single phase.
-// XXX These should kept in sync with src/ndt/internal.hpp; perhaps we can
-// define all defines here and there just redefine?
+#define MK_NDT_MIDDLEBOX 1
 #define MK_NDT_UPLOAD 2
 #define MK_NDT_DOWNLOAD 4
-//#define MK_NDT_UPLOAD_EXT 64 // not implemented
+#define MK_NDT_SIMPLE_FIREWALL 8
+#define MK_NDT_STATUS 16
+#define MK_NDT_META 32
+#define MK_NDT_UPLOAD_EXT 64 // not implemented
 #define MK_NDT_DOWNLOAD_EXT 128
 
 void run_with_specific_server(Var<Entry> entry, std::string address, int port,
                               Callback<Error> callback, Settings settings = {},
-                              Var<Logger> logger = Logger::global(),
-                              Var<Reactor> reactor = Reactor::global());
+                              Var<Reactor> reactor = Reactor::global(),
+                              Var<Logger> logger = Logger::global());
 
 void run(Var<Entry> entry, Callback<Error> callback, Settings settings = {},
-         Var<Logger> logger = Logger::global(),
-         Var<Reactor> reactor = Reactor::global());
+         Var<Reactor> reactor = Reactor::global(),
+         Var<Logger> logger = Logger::global());
 
 } // namespace ndt
 } // namespace mk

--- a/src/libmeasurement_kit/ndt/internal.hpp
+++ b/src/libmeasurement_kit/ndt/internal.hpp
@@ -37,14 +37,16 @@
 #define MSG_WAITING 10
 #define MSG_EXTENDED_LOGIN 11
 
-#define TEST_MID 1
+// Those are the original defines of NDT. I'd rather use them in the
+// implementation rather than using our define names.
+#define TEST_MID MK_NDT_MIDDLEBOX
 #define TEST_C2S MK_NDT_UPLOAD
 #define TEST_S2C MK_NDT_DOWNLOAD
-#define TEST_SFW 8
-#define TEST_STATUS 16
-#define TEST_META 32
-//#define TEST_C2S_EXT 64
-#define TEST_S2C_EXT 128
+#define TEST_SFW MK_NDT_SIMPLE_FIREWALL
+#define TEST_STATUS MK_NDT_STATUS
+#define TEST_META MK_NDT_META
+#define TEST_C2S_EXT MK_NDT_UPLOAD_EXT
+#define TEST_S2C_EXT MK_NDT_DOWNLOAD_EXT
 
 #define KICKOFF_MESSAGE "123456 654321"
 #define KICKOFF_MESSAGE_SIZE (sizeof(KICKOFF_MESSAGE) - 1)

--- a/src/libmeasurement_kit/ndt/ndt_test.cpp
+++ b/src/libmeasurement_kit/ndt/ndt_test.cpp
@@ -28,7 +28,7 @@ void NdtTest::main(std::string, Settings settings, Callback<Entry> cb) {
         }
         // XXX The callback should probably take a Var<Entry>
         cb(*entry);
-    }, settings, logger, reactor);
+    }, settings, reactor, logger);
 }
 
 Var<NetTest> NdtTest::create_test_() {

--- a/src/libmeasurement_kit/ndt/run.cpp
+++ b/src/libmeasurement_kit/ndt/run.cpp
@@ -9,19 +9,19 @@ namespace ndt {
 
 void run_with_specific_server(Var<Entry> entry, std::string address, int port,
                               Callback<Error> callback, Settings settings,
-                              Var<Logger> logger, Var<Reactor> reactor) {
+                              Var<Reactor> reactor, Var<Logger> logger) {
     run_with_specific_server_impl<
         protocol::connect, protocol::send_extended_login,
         protocol::recv_and_ignore_kickoff, protocol::wait_in_queue,
         protocol::recv_version, protocol::recv_tests_id, protocol::run_tests,
         protocol::recv_results_and_logout, protocol::wait_close,
         protocol::disconnect_and_callback>(entry, address, port, callback, settings,
-                                           logger, reactor);
+                                           reactor, logger);
 }
 
-void run(Var<Entry> entry, Callback<Error> callback, Settings settings, Var<Logger> logger,
-         Var<Reactor> reactor) {
-    run_impl(entry, callback, settings, logger, reactor);
+void run(Var<Entry> entry, Callback<Error> callback, Settings settings,
+         Var<Reactor> reactor, Var<Logger> logger) {
+    run_impl(entry, callback, settings, reactor, logger);
 }
 
 } // namespace mk

--- a/src/libmeasurement_kit/ndt/run_impl.hpp
+++ b/src/libmeasurement_kit/ndt/run_impl.hpp
@@ -19,7 +19,7 @@ template <Phase connect, Phase send_login, Phase recv_and_ignore_kickoff,
           Cleanup disconnect_and_callback>
 void run_with_specific_server_impl(Var<Entry> entry, std::string address, int port,
                                    Callback<Error> callback, Settings settings,
-                                   Var<Logger> logger, Var<Reactor> reactor) {
+                                   Var<Reactor> reactor, Var<Logger> logger) {
 
     // Note: this implementation is a template because that allows us to
     // easily change the functions implementing each phase of the protocol
@@ -95,8 +95,8 @@ void run_with_specific_server_impl(Var<Entry> entry, std::string address, int po
 }
 
 template <MK_MOCK(run_with_specific_server), MK_MOCK_NAMESPACE(mlabns, query)>
-void run_impl(Var<Entry> entry, Callback<Error> callback, Settings settings, Var<Logger> logger,
-              Var<Reactor> reactor) {
+void run_impl(Var<Entry> entry, Callback<Error> callback, Settings settings,
+              Var<Reactor> reactor, Var<Logger> logger) {
     ErrorOr<int> port = settings.get_noexcept<int>("port", NDT_PORT);
     if (!port) {
         callback(InvalidPortError(port.as_error()));
@@ -104,8 +104,8 @@ void run_impl(Var<Entry> entry, Callback<Error> callback, Settings settings, Var
     }
     std::string address = settings.get<std::string>("address", "");
     if (address != "") {
-        run_with_specific_server(entry, address, *port, callback, settings, logger,
-                                 reactor);
+        run_with_specific_server(entry, address, *port, callback, settings,
+                                 reactor, logger);
         return;
     }
     mlabns_query("ndt",
@@ -115,7 +115,7 @@ void run_impl(Var<Entry> entry, Callback<Error> callback, Settings settings, Var
                          return;
                      }
                      run_with_specific_server(entry, reply.fqdn, *port, callback,
-                                              settings, logger, reactor);
+                                              settings, reactor, logger);
                  },
                  settings, reactor, logger);
 }

--- a/test/ndt/run.cpp
+++ b/test/ndt/run.cpp
@@ -28,7 +28,7 @@ TEST_CASE("We deal with connect error") {
     run_with_specific_server_impl<failure, die, die, die, die, die, die, die,
                                   die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with send-login error") {
@@ -36,7 +36,7 @@ TEST_CASE("We deal with send-login error") {
     run_with_specific_server_impl<success, failure, die, die, die, die, die,
                                   die, die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with recv-and-ignore-kickoff error") {
@@ -44,7 +44,7 @@ TEST_CASE("We deal with recv-and-ignore-kickoff error") {
     run_with_specific_server_impl<success, success, failure, die, die, die, die,
                                   die, die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with wait-in-queue error") {
@@ -53,7 +53,7 @@ TEST_CASE("We deal with wait-in-queue error") {
                                   die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with recv-version error") {
@@ -62,7 +62,7 @@ TEST_CASE("We deal with recv-version error") {
                                   die, die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with recv-tests-id error") {
@@ -71,7 +71,7 @@ TEST_CASE("We deal with recv-tests-id error") {
                                   failure, die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with run-tests error") {
@@ -80,7 +80,7 @@ TEST_CASE("We deal with run-tests error") {
                                   success, failure, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("We deal with recv-results-and-logout error") {
@@ -89,7 +89,7 @@ TEST_CASE("We deal with recv-results-and-logout error") {
                                   success, success, failure, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 TEST_CASE("run() deals with invalid port error") {
@@ -109,7 +109,7 @@ TEST_CASE("run() deals with mlab-ns query error") {
     Var<Entry> entry{new Entry};
     run_impl<run_with_specific_server, fail>(
         entry, [](Error err) { REQUIRE(err == MlabnsQueryError()); }, {},
-        Logger::global(), Reactor::global());
+        Reactor::global(), Logger::global());
 }
 
 /*


### PR DESCRIPTION
While there, remove one XXX by moving defines in the public header
and using the real-ndt-names only inside of private sources.

Closes #844 