### PR TITLE
reactor.hpp: add missing header

### DIFF
--- a/include/measurement_kit/common/reactor.hpp
+++ b/include/measurement_kit/common/reactor.hpp
@@ -5,6 +5,7 @@
 #define MEASUREMENT_KIT_COMMON_REACTOR_HPP
 
 #include <measurement_kit/common/callback.hpp>
+#include <measurement_kit/common/error.hpp>
 #include <measurement_kit/common/socket.hpp>
 #include <measurement_kit/common/var.hpp>
 


### PR DESCRIPTION
Spotted while doing random things for which I needed to include `reactor.hpp` directly.