### PR TITLE
Do not use `using namespace` in public headers

### DIFF
--- a/include/measurement_kit/ndt/ndt_test.hpp
+++ b/include/measurement_kit/ndt/ndt_test.hpp
@@ -9,15 +9,12 @@
 namespace mk {
 namespace ndt {
 
-using namespace mk::ooni;
-using namespace mk::report;
-
-class NdtTest : public OoniTest {
+class NdtTest : public ooni::OoniTest {
   public:
     NdtTest() : NdtTest(Settings()) {}
     NdtTest(Settings s);
   protected:
-    void main(std::string, Settings, Callback<Entry>) override;
+    void main(std::string, Settings, Callback<report::Entry>) override;
     Var<NetTest> create_test_() override;
 };
 

--- a/include/measurement_kit/ndt/run.hpp
+++ b/include/measurement_kit/ndt/run.hpp
@@ -9,8 +9,6 @@
 namespace mk {
 namespace ndt {
 
-using namespace mk::report;
-
 // By default we pass MK_NDT_UPLOAD|MK_NDT_DOWNLOAD as settings["test_suite"]
 // but you can tweak that by only requesting a single phase.
 #define MK_NDT_MIDDLEBOX 1
@@ -22,12 +20,12 @@ using namespace mk::report;
 #define MK_NDT_UPLOAD_EXT 64 // not implemented
 #define MK_NDT_DOWNLOAD_EXT 128
 
-void run_with_specific_server(Var<Entry> entry, std::string address, int port,
+void run_with_specific_server(Var<report::Entry> entry, std::string address, int port,
                               Callback<Error> callback, Settings settings = {},
                               Var<Reactor> reactor = Reactor::global(),
                               Var<Logger> logger = Logger::global());
 
-void run(Var<Entry> entry, Callback<Error> callback, Settings settings = {},
+void run(Var<report::Entry> entry, Callback<Error> callback, Settings settings = {},
          Var<Reactor> reactor = Reactor::global(),
          Var<Logger> logger = Logger::global());
 

--- a/include/measurement_kit/ooni/collector_client.hpp
+++ b/include/measurement_kit/ooni/collector_client.hpp
@@ -11,8 +11,6 @@ namespace mk {
 namespace ooni {
 namespace collector {
 
-using namespace mk::report;
-
 /*
     To submit a file report, use one of the following collectors. By default
     the library uses the `testing` collector which is a HTTPS service running
@@ -45,21 +43,21 @@ void submit_report(std::string filepath, std::string collector_base_url,
 void connect(Settings, Callback<Error, Var<net::Transport>>,
              Var<Reactor> = Reactor::global(), Var<Logger> = Logger::global());
 
-void create_report(Var<net::Transport>, Entry,
+void create_report(Var<net::Transport>, report::Entry,
                    Callback<Error, std::string>, Settings = {},
                    Var<Reactor> = Reactor::global(),
                    Var<Logger> = Logger::global());
 
-void connect_and_create_report(Entry, Callback<Error, std::string>,
+void connect_and_create_report(report::Entry, Callback<Error, std::string>,
                                Settings = {}, Var<Reactor> = Reactor::global(),
                                Var<Logger> = Logger::global());
 
-void update_report(Var<net::Transport>, std::string report_id, Entry,
+void update_report(Var<net::Transport>, std::string report_id, report::Entry,
                    Callback<Error>, Settings = {},
                    Var<Reactor> = Reactor::global(),
                    Var<Logger> = Logger::global());
 
-void connect_and_update_report(std::string report_id, Entry,
+void connect_and_update_report(std::string report_id, report::Entry,
                                Callback<Error>, Settings = {},
                                Var<Reactor> = Reactor::global(),
                                Var<Logger> = Logger::global());

--- a/include/measurement_kit/ooni/dns_injection.hpp
+++ b/include/measurement_kit/ooni/dns_injection.hpp
@@ -10,9 +10,7 @@
 namespace mk {
 namespace ooni {
 
-using namespace mk::report;
-
-void dns_injection(std::string, Settings, Callback<Var<Entry>>,
+void dns_injection(std::string, Settings, Callback<Var<report::Entry>>,
                    Var<Reactor> = Reactor::global(),
                    Var<Logger> = Logger::global());
 
@@ -26,8 +24,8 @@ class DnsInjection : public OoniTest {
     }
 
     void main(std::string input, Settings options,
-              Callback<Entry> cb) override {
-        dns_injection(input, options, [=](Var<Entry> entry) {
+              Callback<report::Entry> cb) override {
+        dns_injection(input, options, [=](Var<report::Entry> entry) {
             cb(*entry);
         }, reactor, logger);
     }

--- a/include/measurement_kit/ooni/http_invalid_request_line.hpp
+++ b/include/measurement_kit/ooni/http_invalid_request_line.hpp
@@ -10,9 +10,7 @@
 namespace mk {
 namespace ooni {
 
-using namespace mk::report;
-
-void http_invalid_request_line(Settings, Callback<Var<Entry>>,
+void http_invalid_request_line(Settings, Callback<Var<report::Entry>>,
                                Var<Reactor> = Reactor::global(),
                                Var<Logger> = Logger::global());
 
@@ -24,8 +22,8 @@ class HttpInvalidRequestLine : public OoniTest {
         test_version = "0.0.1";
     }
 
-    void main(std::string, Settings options, Callback<Entry> cb) override {
-        http_invalid_request_line(options, [=](Var<Entry> e) {
+    void main(std::string, Settings options, Callback<report::Entry> cb) override {
+        http_invalid_request_line(options, [=](Var<report::Entry> e) {
              cb(*e);
         }, reactor, logger);
     }

--- a/include/measurement_kit/ooni/ooni_reporter.hpp
+++ b/include/measurement_kit/ooni/ooni_reporter.hpp
@@ -9,12 +9,12 @@
 namespace mk {
 namespace ooni {
 
-class OoniReporter : public BaseReporter {
+class OoniReporter : public report::BaseReporter {
   public:
     static Var<BaseReporter> make(const OoniTest &ooni_test);
 
-    Continuation<Error> open(Report report) override;
-    Continuation<Error> write_entry(Entry entry) override;
+    Continuation<Error> open(report::Report report) override;
+    Continuation<Error> write_entry(report::Entry entry) override;
     Continuation<Error> close() override;
 
     ~OoniReporter() override {}

--- a/include/measurement_kit/ooni/ooni_test.hpp
+++ b/include/measurement_kit/ooni/ooni_test.hpp
@@ -12,8 +12,6 @@
 namespace mk {
 namespace ooni {
 
-using namespace mk::report;
-
 class OoniTest : public NetTest, public NonCopyable, public NonMovable {
     // Note: here we make the reasonable assumption that the owner of this
     // instance would keep it safe until the final callback is fired
@@ -43,12 +41,12 @@ class OoniTest : public NetTest, public NonCopyable, public NonMovable {
     // Functions that derived classes SHOULD override
     virtual void setup(std::string) {}
     virtual void teardown(std::string) {}
-    virtual void main(std::string, Settings, Callback<Entry> cb) {
-        reactor->call_soon([=]() { cb(Entry{}); });
+    virtual void main(std::string, Settings, Callback<report::Entry> cb) {
+        reactor->call_soon([=]() { cb(report::Entry{}); });
     }
 
   private:
-    Report report;
+    report::Report report;
     tm test_start_time;
     Var<std::istream> input_generator;
 

--- a/include/measurement_kit/ooni/tcp_connect.hpp
+++ b/include/measurement_kit/ooni/tcp_connect.hpp
@@ -10,9 +10,7 @@
 namespace mk {
 namespace ooni {
 
-using namespace mk::report;
-
-void tcp_connect(std::string, Settings, Callback<Var<Entry>>,
+void tcp_connect(std::string, Settings, Callback<Var<report::Entry>>,
                  Var<Reactor> = Reactor::global(),
                  Var<Logger> = Logger::global());
 
@@ -26,8 +24,8 @@ class TcpConnect : public OoniTest {
     }
 
     void main(std::string input, Settings options,
-              Callback<Entry> cb) override {
-        tcp_connect(input, options, [=](Var<Entry> entry) {
+              Callback<report::Entry> cb) override {
+        tcp_connect(input, options, [=](Var<report::Entry> entry) {
             cb(*entry);
         }, reactor, logger);
     }

--- a/include/measurement_kit/ooni/templates.hpp
+++ b/include/measurement_kit/ooni/templates.hpp
@@ -11,13 +11,13 @@ namespace mk {
 namespace ooni {
 namespace templates {
 
-void dns_query(Var<Entry> entry, dns::QueryType, dns::QueryClass,
+void dns_query(Var<report::Entry> entry, dns::QueryType, dns::QueryClass,
                std::string query_name, std::string nameserver,
                Callback<Error, Var<dns::Message>>, Settings = {},
                Var<Reactor> = Reactor::global(),
                Var<Logger> = Logger::global());
 
-void http_request(Var<Entry> entry, Settings settings, http::Headers headers,
+void http_request(Var<report::Entry> entry, Settings settings, http::Headers headers,
                   std::string body, Callback<Error, Var<http::Response>> cb,
                   Var<Reactor> reactor = Reactor::global(),
                   Var<Logger> logger = Logger::global());

--- a/include/measurement_kit/ooni/web_connectivity.hpp
+++ b/include/measurement_kit/ooni/web_connectivity.hpp
@@ -10,10 +10,8 @@
 namespace mk {
 namespace ooni {
 
-using namespace mk::report;
-
 void web_connectivity(std::string input, Settings,
-                      Callback<Var<Entry>>,
+                      Callback<Var<report::Entry>>,
                       Var<Reactor> = Reactor::global(),
                       Var<Logger> = Logger::global());
 
@@ -28,8 +26,8 @@ class WebConnectivity : public OoniTest {
     }
 
     void main(std::string input, Settings options,
-              Callback<Entry> cb) override {
-        web_connectivity(input, options, [=](Var<Entry> e) {
+              Callback<report::Entry> cb) override {
+        web_connectivity(input, options, [=](Var<report::Entry> e) {
              cb(*e);
         }, reactor, logger);
     }

--- a/src/libmeasurement_kit/ooni/ooni_reporter.cpp
+++ b/src/libmeasurement_kit/ooni/ooni_reporter.cpp
@@ -7,6 +7,8 @@
 namespace mk {
 namespace ooni {
 
+using namespace mk::report;
+
 OoniReporter::OoniReporter(const OoniTest &parent) {
     settings = parent.options; // Copy the parent's settings
     logger = parent.logger;

--- a/src/libmeasurement_kit/ooni/ooni_test.cpp
+++ b/src/libmeasurement_kit/ooni/ooni_test.cpp
@@ -8,6 +8,8 @@
 namespace mk {
 namespace ooni {
 
+using namespace mk::report;
+
 void OoniTest::run_next_measurement(size_t thread_id, Callback<Error> cb,
                                     size_t num_entries,
                                     Var<size_t> current_entry) {


### PR DESCRIPTION
Ideally, I'd like to always use namespaces rather than taking
shortcuts using `using namespace`. One step at a time.