### PR TITLE
logger: add callback for JSON encoded events

### DIFF
--- a/doc/api/common/logger.md
+++ b/doc/api/common/logger.md
@@ -17,7 +17,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 #define MK_LOG_DEBUG2 3
 #define MK_LOG_VERBOSITY_MASK 31
 
-#define MK_LOG_JSON 32 ///< log message is a valid JSON document
+#define MK_LOG_EVENT 32          // Event occurred (encoded as JSON)
+#define MK_LOG_JSON MK_LOG_EVENT // Backward compat for v0.3.x
 
 namespace mk {
 
@@ -36,6 +37,7 @@ class Logger : public NonCopyable, public NonMovable {
     uint32_t get_verbosity();
 
     void on_log(Delegate<uint32_t, const char *> fn);
+    void on_event(Delegate<const char *> fn);
 
     void set_logfile(std::string path);
 
@@ -105,6 +107,14 @@ debug: A debug2 message
 ```
 
 To disable the log callback, pass `nullptr` to it.
+
+By default `MK_LOG_EVENT` messages are passed to the log callback. But you
+can route them to the event callback by specifying it using `on_event()`. In
+such case, those messages will be passed to the event callback only,
+meaning that the log callback will not be called for them and they will
+not be written on the logfile. This behavior is meant to transition between
+when events where passed to the log callback and a future where they will
+be either ignored or passed to the event callback.
 
 The `set_logfile` method instructs the logger to write a copy of each log
 message into the specified log file. Setting the logfile has no impact on

--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -23,12 +23,17 @@
 #define MK_LOG_DEBUG2 3
 #define MK_LOG_VERBOSITY_MASK 31
 
-#define MK_LOG_JSON 32 // Information encoded as JSON
+#define MK_LOG_EVENT 32 // Information encoded as JSON
+
+// Backwards compatibility until v0.5.0
+#define MK_LOG_JSON MK_LOG_EVENT
 
 namespace mk {
 
 class Logger : public NonCopyable, public NonMovable {
   public:
+    // TODO: refactor class to move all implementation in .cpp files
+
     static Var<Logger> make();
 
     void logv(uint32_t, const char *, va_list)
@@ -47,6 +52,8 @@ class Logger : public NonCopyable, public NonMovable {
     void on_log(Delegate<uint32_t, const char *> fn) { consumer_ = fn; }
 
     void on_eof(Delegate<> fn) { eof_handler_ = fn; }
+
+    void on_event(Delegate<const char *> fn);
 
     void set_logfile(std::string fpath);
 
@@ -68,6 +75,7 @@ class Logger : public NonCopyable, public NonMovable {
     std::mutex mutex_;
     Var<std::ofstream> ofile_;
     Delegate<> eof_handler_;
+    Delegate<const char *> event_handler_;
 
     Logger();
 };

--- a/include/measurement_kit/nettests/base_test.hpp
+++ b/include/measurement_kit/nettests/base_test.hpp
@@ -13,6 +13,7 @@ class Runnable;
 class BaseTest {
   public:
     BaseTest &on_log(Delegate<uint32_t, const char *>);
+    BaseTest &on_event(Delegate<const char *>);
     BaseTest &set_verbosity(uint32_t);
     BaseTest &increase_verbosity();
 

--- a/src/libmeasurement_kit/common/logger.cpp
+++ b/src/libmeasurement_kit/common/logger.cpp
@@ -47,6 +47,12 @@ void Logger::logv(uint32_t level, const char *fmt, va_list ap) {
     if (res < 0 || (unsigned int)res >= sizeof(buffer_)) {
         return;
     }
+    // Since v0.4 we dispatch the MK_LOG_EVENT event to the proper handler
+    // if set, otherwise we fallthrough passing it to consumer_.
+    if (event_handler_ and (level & MK_LOG_EVENT) != 0) {
+        event_handler_(buffer_);
+        return;
+    }
     if (consumer_) {
         consumer_(level, buffer_);
     }
@@ -71,6 +77,8 @@ void Logger::log(uint32_t level, const char *fmt, ...) { XX(this, level); }
 void Logger::warn(const char *fmt, ...) { XX(this, MK_LOG_WARNING); }
 void Logger::info(const char *fmt, ...) { XX(this, MK_LOG_INFO); }
 void Logger::debug(const char *fmt, ...) { XX(this, MK_LOG_DEBUG); }
+
+void Logger::on_event(Delegate<const char *> f) { event_handler_ = f; }
 
 void log(uint32_t level, const char *fmt, ...) { XX(Logger::global(), level); }
 void warn(const char *fmt, ...) { XX(Logger::global(), MK_LOG_WARNING); }

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -14,6 +14,11 @@ BaseTest &BaseTest::on_log(Delegate<uint32_t, const char *> func) {
     return *this;
 }
 
+BaseTest &BaseTest::on_event(Delegate<const char *> func) {
+    runnable->logger->on_event(func);
+    return *this;
+}
+
 BaseTest &BaseTest::set_verbosity(uint32_t level) {
     runnable->logger->set_verbosity(level);
     return *this;

--- a/test/common/logger.cpp
+++ b/test/common/logger.cpp
@@ -93,3 +93,31 @@ TEST_CASE("The logger's EOF handler works") {
     }
     REQUIRE(called);
 }
+
+TEST_CASE("We pass MK_LOG_EVENT to logger if event-handler not set") {
+    Var<Logger> logger = Logger::make();
+    auto called = false;
+    logger->on_log([&](uint32_t v, const char *s) {
+        REQUIRE(v == (MK_LOG_WARNING|MK_LOG_EVENT));
+        REQUIRE(s == std::string{"{}"});
+        called = true;
+    });
+    logger->log(MK_LOG_WARNING|MK_LOG_EVENT, "{}");
+    REQUIRE(called);
+}
+
+TEST_CASE("We pass MK_LOG_EVENT only to event-handler if it is set") {
+    Var<Logger> logger = Logger::make();
+    auto log_called = false;
+    auto eh_called = false;
+    logger->on_log([&](uint32_t, const char *) {
+        log_called = true;
+    });
+    logger->on_event([&](const char *s) {
+        REQUIRE(s == std::string{"{}"});
+        eh_called = true;
+    });
+    logger->log(MK_LOG_WARNING|MK_LOG_EVENT, "{}");
+    REQUIRE(!log_called);
+    REQUIRE(eh_called);
+}


### PR DESCRIPTION
For now, if such callback is not set, pass through events to the log
callback for backward compatibility with MK v0.3.x.

Closes #923.