### PR TITLE
ndt: print progress of the test

### DIFF
--- a/doc/api/common/logger.md
+++ b/doc/api/common/logger.md
@@ -38,6 +38,9 @@ class Logger : public NonCopyable, public NonMovable {
 
     void on_log(Delegate<uint32_t, const char *> fn);
     void on_event(Delegate<const char *> fn);
+    void on_progress(Delegate<double> fn);
+
+    void progress(double);
 
     void set_logfile(std::string path);
 
@@ -115,6 +118,11 @@ meaning that the log callback will not be called for them and they will
 not be written on the logfile. This behavior is meant to transition between
 when events where passed to the log callback and a future where they will
 be either ignored or passed to the event callback.
+
+The `set_progress` and `progress` methods allow respectively to register
+a callback called when the test makes some progress towards its end and to
+emit the test progress percentage. The test progress is an integer that
+varies between 0.0 (beginning) and end (1.0) of the test.
 
 The `set_logfile` method instructs the logger to write a copy of each log
 message into the specified log file. Setting the logfile has no impact on

--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -55,7 +55,11 @@ class Logger : public NonCopyable, public NonMovable {
 
     void on_event(Delegate<const char *> fn);
 
+    void on_progress(Delegate<double> fn);
+
     void set_logfile(std::string fpath);
+
+    void progress(double);
 
     static Var<Logger> global() {
         static Var<Logger> singleton(new Logger);
@@ -76,6 +80,7 @@ class Logger : public NonCopyable, public NonMovable {
     Var<std::ofstream> ofile_;
     Delegate<> eof_handler_;
     Delegate<const char *> event_handler_;
+    Delegate<double> progress_handler_;
 
     Logger();
 };

--- a/include/measurement_kit/nettests/base_test.hpp
+++ b/include/measurement_kit/nettests/base_test.hpp
@@ -14,6 +14,7 @@ class BaseTest {
   public:
     BaseTest &on_log(Delegate<uint32_t, const char *>);
     BaseTest &on_event(Delegate<const char *>);
+    BaseTest &on_progress(Delegate<double>);
     BaseTest &set_verbosity(uint32_t);
     BaseTest &increase_verbosity();
 

--- a/src/libmeasurement_kit/common/logger.cpp
+++ b/src/libmeasurement_kit/common/logger.cpp
@@ -93,9 +93,19 @@ void Logger::increase_verbosity() {
     }
 }
 
+void Logger::on_progress(Delegate<double> fn) {
+    progress_handler_ = fn;
+}
+
 void Logger::set_logfile(std::string path) {
     ofile_.reset(new std::ofstream(path));
     // TODO: what to do if we cannot open the logfile? return error?
+}
+
+void Logger::progress(double prog) {
+    if (progress_handler_) {
+        progress_handler_(prog);
+    }
 }
 
 } // namespace mk

--- a/src/libmeasurement_kit/ndt/internal.hpp
+++ b/src/libmeasurement_kit/ndt/internal.hpp
@@ -88,6 +88,8 @@ struct Context {
     Callback<Error> callback;
     Var<Entry> entry;
     std::list<std::string> granted_suite;
+    size_t granted_suite_count = 0;
+    size_t current_test_count = 0;
     Var<Logger> logger = Logger::global();
     int port = NDT_PORT;
     Var<Reactor> reactor = Reactor::global();

--- a/src/libmeasurement_kit/ndt/protocol_impl.hpp
+++ b/src/libmeasurement_kit/ndt/protocol_impl.hpp
@@ -164,6 +164,7 @@ void recv_tests_id_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->info("Authorized tests: %s", s.c_str());
         ctx->granted_suite = split(s);
+        ctx->granted_suite_count = ctx->granted_suite.size();
         callback(NoError());
     }, ctx->reactor);
 }
@@ -175,6 +176,11 @@ void run_tests_impl(Var<Context> ctx, Callback<Error> callback) {
     if (ctx->granted_suite.size() <= 0) {
         callback(NoError());
         return;
+    }
+
+    if (ctx->granted_suite_count > 0) {  // Defensive check
+        ctx->logger->progress(0.6 + (double)++ctx->current_test_count
+            / (double)ctx->granted_suite_count / 10.0);
     }
 
     std::string s = ctx->granted_suite.front();

--- a/src/libmeasurement_kit/ndt/run_impl.hpp
+++ b/src/libmeasurement_kit/ndt/run_impl.hpp
@@ -57,29 +57,38 @@ void run_with_specific_server_impl(Var<Entry> entry, std::string address, int po
 
     connect(ctx, [ctx](Error err) {
         TRAP_ERRORS(err);
+        ctx->logger->progress(0.1);
 
         send_login(ctx, [ctx](Error err) {
             TRAP_ERRORS(err);
+            ctx->logger->progress(0.2);
 
             recv_and_ignore_kickoff(ctx, [ctx](Error err) {
                 TRAP_ERRORS(err);
+                ctx->logger->progress(0.3);
 
                 wait_in_queue(ctx, [ctx](Error err) {
                     TRAP_ERRORS(err);
+                    ctx->logger->progress(0.4);
 
                     recv_version(ctx, [ctx](Error err) {
                         TRAP_ERRORS(err);
+                        ctx->logger->progress(0.5);
 
                         recv_tests_id(ctx, [ctx](Error err) {
                             TRAP_ERRORS(err);
+                            ctx->logger->progress(0.6);
 
                             run_tests(ctx, [ctx](Error err) {
                                 TRAP_ERRORS(err);
+                                // Progress printed by run_tests()
 
                                 recv_results_and_logout(ctx, [ctx](Error err) {
                                     TRAP_ERRORS(err);
+                                    ctx->logger->progress(0.8);
 
                                     wait_close(ctx, [ctx](Error err) {
+                                        ctx->logger->progress(0.9);
                                         disconnect_and_callback(ctx, err);
                                     });
                                 });

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -19,6 +19,11 @@ BaseTest &BaseTest::on_event(Delegate<const char *> func) {
     return *this;
 }
 
+BaseTest &BaseTest::on_progress(Delegate<double> func) {
+    runnable->logger->on_progress(func);
+    return *this;
+}
+
 BaseTest &BaseTest::set_verbosity(uint32_t level) {
     runnable->logger->set_verbosity(level);
     return *this;

--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -44,8 +44,7 @@ void Runnable::run_next_measurement(size_t thread_id, Callback<Error> cb,
         prog = *current_entry / (double)num_entries;
     }
     *current_entry += 1;
-    logger->log(MK_LOG_INFO|MK_LOG_JSON,
-        "{\"progress\": %f, \"type\": \"progress\"}", prog);
+    logger->progress(prog);
 
     logger->debug("net_test: creating entry");
     struct tm measurement_start_time;

--- a/src/measurement_kit/cmdline/ndt.cpp
+++ b/src/measurement_kit/cmdline/ndt.cpp
@@ -3,10 +3,12 @@
 // information on the copying conditions.
 
 #include "../cmdline/cmdline.hpp"
+#include <measurement_kit/ext/json.hpp>
 #include <measurement_kit/nettests.hpp>
 #include <measurement_kit/ndt.hpp>
 
 #include <string.h>
+#include <stdio.h>
 
 #include <iostream>
 
@@ -77,6 +79,9 @@ int main(const char *, int argc, char **argv) {
     }
 
     test
+        .on_progress([](double prog) {
+            printf("Progress: %.2f%%\n", prog * 100.0);
+        })
         .set_options("geoip_country_path", "GeoIP.dat")
         .set_options("geoip_asn_path", "GeoIPASNum.dat")
         .run();


### PR DESCRIPTION
I implemented this adding to `Logger` and `BaseTest` convenience
features allowing to easily pass around test progress.

Closes #922 