### PR TITLE
Add Apache Portable Runtime as dependency

### DIFF
--- a/build/android/make-toolchain
+++ b/build/android/make-toolchain
@@ -37,7 +37,8 @@ bash $MAKE_TOOLCHAIN \
   --toolchain=${ARCH}-4.9 \
   --install-dir=${INSTALL_DIR} \
   --use-llvm \
-  --stl=libc++
+  --stl=libc++ \
+  --force
 
 if [ $ARCH = x86 ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/

--- a/build/dependency
+++ b/build/dependency
@@ -24,6 +24,19 @@ Examples:
 EOF
 }
 
+pkg_autogen() {
+    if [ -x ./autogen.sh ]; then
+        echo "- ./autogen.sh"
+        ./autogen.sh
+    elif [ -x ./buildconf ]; then
+        echo "- ./buildconf"
+        ./buildconf
+    elif [ -f ./configure.ac ]; then
+        echo "- autoreconf -i"
+        autoreconf -i
+    fi
+}
+
 pkg_configure() {
     if [ -x ./configure ]; then
         echo "- ./configure --prefix=$pkg_prefix $pkg_configure_flags"
@@ -86,11 +99,7 @@ if [ ! -d third_party/cache/$pkg_name ]; then
             rm $diff
         done
     fi
-    if [ -x ./autogen.sh ]; then
-        ./autogen.sh
-    elif [ -f ./configure.ac ]; then
-        autoreconf -i
-    fi
+    pkg_autogen
     if [ -d ../../../build/patch/post-autogen/$pkg_name ]; then
         for diff in `ls ../../../build/patch/post-autogen/$pkg_name`; do
             cp ../../../build/patch/post-autogen/$pkg_name/$diff .

--- a/build/ios/cross
+++ b/build/ios/cross
@@ -41,7 +41,7 @@ export CFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --sh
 export CXXFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 export LDFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 
-export pkg_configure_flags="$EXTRA_CONFIG -q"
+export pkg_configure_flags="$EXTRA_CONFIG"
 export pkg_prefix="$DESTDIR"
 
 if [ $# -gt 0 ]; then

--- a/build/patch/pre-autogen/apr/0000.patch
+++ b/build/patch/pre-autogen/apr/0000.patch
@@ -1,0 +1,111 @@
+--- a/configure.in	2016-12-05 21:17:10.000000000 +0100
++++ b/configure.in	2016-12-05 21:17:34.000000000 +0100
+@@ -970,7 +970,7 @@
+ fi
+ 
+ dnl ----------------------------- Checking for fdatasync: OS X doesn't have it
+-AC_CHECK_FUNCS(fdatasync)
++dnl AC_CHECK_FUNCS(fdatasync)
+ 
+ dnl ----------------------------- Checking for extended file descriptor handling
+ # test for epoll_create1
+@@ -1136,7 +1136,9 @@
+                 create_area])
+ 
+ APR_CHECK_DEFINE(MAP_ANON, sys/mman.h)
+-AC_CHECK_FILE(/dev/zero)
++if test "$cross_compiling" = "no"; then
++  AC_CHECK_FILE(/dev/zero)
++fi
+ 
+ # Not all systems can mmap /dev/zero (such as HP-UX).  Check for that.
+ if test "$ac_cv_func_mmap" = "yes" &&
+@@ -1591,7 +1591,11 @@
+ AC_CHECK_TYPE(ssize_t, int)
+ AC_C_INLINE
+ AC_C_CONST
+-AC_FUNC_SETPGRP
++if test "$cross_compiling" = "no"; then
++    AC_FUNC_SETPGRP
++else
++    ac_cv_func_setpgrp_void=yes
++fi
+ 
+ APR_CHECK_SOCKLEN_T
+ 
+@@ -1937,6 +1937,9 @@
+ else
+     have_iovec=1
+ fi
++if test "$cross_compiling" = "yes"; then
++    have_iovec=1  # override
++fi
+ 
+ AC_SUBST(voidp_size)
+ AC_SUBST(short_value)
+@@ -2202,6 +2202,7 @@
+     # really support PROCESS_SHARED locks.  So, we must validate that we 
+     # can go through the steps without receiving some sort of system error.
+     # Linux and older versions of AIX have this problem.
++    if test "$cross_compiling" = "no"; then
+     APR_IFALLYES(header:pthread.h define:PTHREAD_PROCESS_SHARED func:pthread_mutexattr_setpshared, [
+       AC_CACHE_CHECK([for working PROCESS_SHARED locks], apr_cv_process_shared_works, [
+       AC_TRY_RUN([
+@@ -2225,6 +2226,10 @@
+         }], [apr_cv_process_shared_works=yes], [apr_cv_process_shared_works=no])])
+       # Override detection of pthread_mutexattr_setpshared
+       ac_cv_func_pthread_mutexattr_setpshared=$apr_cv_process_shared_works])
++    else
++      apr_cv_process_shared_works=no
++      ac_cv_func_pthread_mutexattr_setpshared=$apr_cv_process_shared_works
++    fi
+ 
+     if test "$ac_cv_func_pthread_mutexattr_setpshared" = "yes"; then
+         APR_CHECK_PTHREAD_ROBUST_SHARED_MUTEX
+--- a/build/apr_network.m4	2016-12-06 00:40:06.000000000 +0100
++++ b/build/apr_network.m4	2016-12-06 00:41:20.000000000 +0100
+@@ -500,6 +500,7 @@
+ dnl on a TCP socket.
+ dnl
+ AC_DEFUN([APR_CHECK_TCP_NODELAY_WITH_CORK], [
++if test "$cross_compiling" != "yes"; then
+ AC_CACHE_CHECK([whether TCP_NODELAY and TCP_CORK can both be enabled],
+ [apr_cv_tcp_nodelay_with_cork],
+ [AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+@@ -541,6 +542,7 @@
+ 
+     exit(0);
+ ]])], [apr_cv_tcp_nodelay_with_cork=yes], [apr_cv_tcp_nodelay_with_cork=no])])
++fi
+ 
+ if test "$apr_cv_tcp_nodelay_with_cork" = "yes"; then
+   AC_DEFINE([HAVE_TCP_NODELAY_WITH_CORK], 1,
+--- a/include/apr_general.h	2016-12-06 01:31:24.000000000 +0100
++++ b/include/apr_general.h	2016-12-06 01:32:43.000000000 +0100
+@@ -33,6 +33,8 @@
+ #include <signal.h>
+ #endif
+ 
++#include <stddef.h>
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif /* __cplusplus */
+@@ -76,6 +76,9 @@
+  * @return offset
+  */
+ 
++#ifdef offsetof
++#define APR_OFFSETOF(s_type,field) offsetof(s_type,field)
++#else
+ #if defined(CRAY) || (defined(__arm) && !(defined(LINUX) || defined(__FreeBSD__)))
+ #ifdef __STDC__
+ #define APR_OFFSET(p_type,field) _Offsetof(p_type,field)
+@@ -108,6 +111,7 @@
+ #else
+ #define APR_OFFSETOF(s_type,field) APR_OFFSET(s_type*,field)
+ #endif
++#endif
+ 
+ #ifndef DOXYGEN
+ 

--- a/build/spec/apr
+++ b/build/spec/apr
@@ -1,3 +1,9 @@
 pkg_name=apr
 pkg_repository=https://github.com/apache/apr.git
 pkg_tag=1.5.2
+pkg_configure_flags="--disable-posix-shm $pkg_configure_flags"
+
+pkg_make() {
+    make tools/gen_test_char CC="cc" CFLAGS="-Wall" CPPFLAGS="" LDFLAGS=""
+    make $pkg_make_flags
+}

--- a/build/spec/apr
+++ b/build/spec/apr
@@ -4,6 +4,27 @@ pkg_tag=1.5.2
 pkg_configure_flags="--disable-posix-shm $pkg_configure_flags"
 
 pkg_make() {
-    make tools/gen_test_char CC="cc" CFLAGS="-Wall" CPPFLAGS="" LDFLAGS=""
+    #
+    # XXX Your attention, please:
+    #
+    # The build process of APR builds and uses this executable to create
+    # a table telling APR itself how apr_escape_string() should escape
+    # the strings passed to it. The problem is that, if we compile using
+    # Android cross compiler, the result executable can't be executed
+    # given that it's for another architecture.
+    #
+    # To workaround this issue, I decided to compile using the system's
+    # compiler; given that the generator should generate the same output
+    # for all Unix systems we are safe until we include Windows.
+    #
+    echo "- ./libtool --mode=compile cc -c -Wall -o tools/gen_test_char.lo tools/gen_test_char.c"
+    ./libtool --mode=compile cc -c -Wall -o tools/gen_test_char.lo tools/gen_test_char.c
+    echo "- ./libtool --mode=link cc -o tools/gen_test_char tools/gen_test_char.lo"
+    ./libtool --mode=link cc -o tools/gen_test_char tools/gen_test_char.lo
+    echo "- install -d include/private"
+    install -d include/private
+    echo "- ./tools/gen_test_char > include/private/apr_escape_test_char.h"
+    ./tools/gen_test_char > include/private/apr_escape_test_char.h
+    echo "- make $pkg_make_flags"
     make $pkg_make_flags
 }

--- a/build/spec/apr
+++ b/build/spec/apr
@@ -1,0 +1,3 @@
+pkg_name=apr
+pkg_repository=https://github.com/apache/apr.git
+pkg_tag=1.5.2


### PR DESCRIPTION
I did some *yolo* choices when developing this pull request to have APR compiling as quick as possible, but I feel like the following actions need to be done before being ready for review:

- [ ] evaluate the impact of the `./configure` tests that were disabled
- [ ] evaluate the impact of generating the characters table using the host's compiler
- [ ] make sure we pass `-Wall` and other warnings to compiler