### PR TITLE
getaddrinfo: android dislikes AI_V4MAPPED | AI_ALL

### DIFF
--- a/src/libmeasurement_kit/dns/system_resolver.hpp
+++ b/src/libmeasurement_kit/dns/system_resolver.hpp
@@ -151,7 +151,14 @@ void system_resolver(QueryClass dns_class, QueryType dns_type, std::string name,
     std::unique_ptr<ResolverContext> ctx(new ResolverContext(
         dns_class, dns_type, name, cb, settings, reactor, logger));
     Query query;
-    ctx->hints.ai_flags = AI_ALL | AI_V4MAPPED;
+    /*
+     * Note: here we pass empty flags. It used to be AI_ALL | AI_V4MAPPED but
+     * Android did not like it and, honestly, I do not think having back v4
+     * mapped addresses would be super useful to us (or in general) given that
+     * when we want to connect we usually connect trying to resolve AAAA and
+     * A at the same time. Keeping the feature conditionally may lead to
+     * odd behaviors in corner cases and I'd like to avoid future headaches.
+     */
     ctx->hints.ai_socktype = SOCK_STREAM;
 
     if (dns_class != MK_DNS_CLASS_IN) {


### PR DESCRIPTION
Honestly, those are not super important flags anyway, because they
instruct getaddrinfo to return ipv4-mapped addresses only when there
are no IPv6 addresses and one requests for AAAA.

We always request for both A and AAAA when we resolve for connecting (and
for more precise results one should probably use c-ares in future).

Sure, I could keep the feature, but then I wonder whether this would lead
to the library behavior being inconsistent across different platforms in
a not-super-simple-to-debug way.

For this reason, I'm removing the feature entirely rather than just
making it conditional on !__ANDROID__.