### PR TITLE
runnable: add on_destroy() callback

### DIFF
--- a/doc/api/nettests/base_test.md
+++ b/doc/api/nettests/base_test.md
@@ -27,6 +27,7 @@ class BaseTest {
     BaseTest &on_entry(Delegate<std::string>);
     BaseTest &on_begin(Delegate<>);
     BaseTest &on_end(Delegate<> cb);
+    BaseTest &on_destroy(Delegate<> cb);
 
     void run();
     void start(Callback<>);
@@ -104,6 +105,12 @@ respectively when the test is about to begin and when the test is about
 to end. They may be useful to start and stop filtering for tests
 related events, for example. You MAY specify multiple `on_end` callbacks
 if you wish; they will be executed sequentially at end of test.
+
+The `on_destroy` method allows to register delegates called when the
+test object is about to be destroyed. These delegates will be invoked
+sequentially by `~BaseTest`. This is the correct place to free the
+resources allocated for the purpose of allowing other test callbacks
+to run in other languages (e.g. Java and Python).
 
 The `run` method runs the test synchronously. It will not return until
 the test has terminated. Note that measurement-kit MAY run the test

--- a/include/measurement_kit/nettests/base_test.hpp
+++ b/include/measurement_kit/nettests/base_test.hpp
@@ -34,6 +34,7 @@ class BaseTest {
     BaseTest &on_entry(Delegate<std::string>);
     BaseTest &on_begin(Delegate<>);
     BaseTest &on_end(Delegate<> cb);
+    BaseTest &on_destroy(Delegate<> cb);
 
     void run();
     void start(Callback<> func);

--- a/include/measurement_kit/nettests/runnable.hpp
+++ b/include/measurement_kit/nettests/runnable.hpp
@@ -28,6 +28,7 @@ class Runnable : public NonCopyable, public NonMovable {
     Delegate<std::string> entry_cb;
     Delegate<> begin_cb;
     std::list<Delegate<>> end_cbs;
+    std::list<Delegate<>> destroy_cbs;
 
     std::string test_name = "ooni_test";
     std::string test_version = "0.0.1";

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -72,6 +72,11 @@ BaseTest &BaseTest::on_end(Delegate<> cb) {
     return *this;
 }
 
+BaseTest &BaseTest::on_destroy(Delegate<> cb) {
+    runnable->destroy_cbs.push_back(cb);
+    return *this;
+}
+
 void BaseTest::run() {
     // Note: here we MUST point to a fresh reactor which we know for sure is
     // not already being used otherwise we cannot run the test

--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -13,7 +13,15 @@ namespace nettests {
 using namespace mk::report;
 using namespace mk::ooni;
 
-Runnable::~Runnable() {}
+Runnable::~Runnable() {
+    for (auto fn : destroy_cbs) {
+        try {
+            fn();
+        } catch (const std::exception &) {
+            /* Suppress */ ;
+        }
+    }
+}
 
 void Runnable::setup(std::string) {}
 void Runnable::teardown(std::string) {}

--- a/test/nettests/runnable.cpp
+++ b/test/nettests/runnable.cpp
@@ -75,6 +75,29 @@ TEST_CASE("Make sure that on_end() works") {
     REQUIRE(ok == 3);
 }
 
+TEST_CASE("Make sure that on_destroy() works") {
+    int ok = 0;
+    {
+        nettests::Runnable test;
+        test.reactor = Reactor::global();
+        loop_with_initial_event([&]() {
+            test.destroy_cbs.push_back([&]() {
+                ok += 1;
+            });
+            test.destroy_cbs.push_back([&]() {
+                ok += 2;
+            });
+            test.begin([&](Error) {
+                test.end([&](Error) {
+                    break_loop();
+                });
+            });
+        });
+        REQUIRE(ok == 0);
+    }
+    REQUIRE(ok == 3);
+}
+
 TEST_CASE("Ensure we do not save too much information by default") {
     nettests::Runnable test;
     test.reactor = Reactor::global();


### PR DESCRIPTION
Useful to free resources allocated in the Java code. As some other
callbacks, this one can be set multiple times. We should probably
find another convention, rather than on_foo(), for callbacks settable
more than once, to make it more intuitive.