### PR TITLE
Release: v0.4.0-beta

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# MeasurementKit 0.4.0-beta [2017-01-13]
+
+- Feature: recognize utf8 (#1062)
+- Support for country-specific test lists (#1030)
+
 # MeasurementKit 0.4.0-alpha.3 [2017-01-06]
 
 - nettests: randomize input (#1029)

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # information on the copying conditions.
 
 # Autoconf requirements
-AC_INIT(measurement_kit, 0.4.0-alpha.3, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.4.0-beta, bassosimone@gmail.com)
 
 # information on the package
 AC_CONFIG_SRCDIR([Makefile.am])

--- a/doc/api/common/version.md
+++ b/doc/api/common/version.md
@@ -8,7 +8,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/common/version.h>
 
-#define MEASUREMENT_KIT_VERSION "0.4.0-alpha.3"
+#define MEASUREMENT_KIT_VERSION "0.4.0-beta"
 
 const char *mk_version(void);
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-Welcome to Measurement Kit **v0.4.0-alpha.3** documentation!
+Welcome to Measurement Kit **v0.4.0-beta** documentation!
 
 # How to generate documentation
 

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -5,7 +5,7 @@
 #define MEASUREMENT_KIT_COMMON_VERSION_HPP
 
 // Note: we use semantic versioning (see: http://semver.org/)
-#define MEASUREMENT_KIT_VERSION "0.4.0-alpha.3"
+#define MEASUREMENT_KIT_VERSION "0.4.0-beta"
 
 #ifdef __cplusplus
 extern "C" {

--- a/measurement_kit.podspec
+++ b/measurement_kit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "measurement_kit"
-  s.version = "0.4.0-alpha.3"
+  s.version = "0.4.0-beta"
   s.summary = "Portable network measurement library"
   s.author = "Simone Basso",
              "Arturo Filastò",


### PR DESCRIPTION
Integration branch for release v0.4.0-beta. It will be merge-squashed into `stable` once all the following pull requests have been tested and merged into `stable`.

- [x] runnable: add support for country specific test list (#1030)
- [x] runnable: randomize list in memory (#1029)
- [x] web-connectivity: fix encoding (#1031)
- [x] fix API and ABI compatibility for old Androids (#1047)