### PR TITLE
system_resolver.hpp: do not warn on getaddrinfo failure

### DIFF
--- a/src/libmeasurement_kit/dns/system_resolver.hpp
+++ b/src/libmeasurement_kit/dns/system_resolver.hpp
@@ -58,7 +58,6 @@ void resolve_async(ResolverContext *context) {
     int error = getaddrinfo(ctx->name.c_str(), nullptr, &ctx->hints, &sip);
     ctx->logger->log(MK_LOG_DEBUG2, "getaddrinfo result: %d", error);
     if (error) {
-        ctx->logger->warn("getaddrinfo failed: %s", gai_strerror(error));
         Error resolver_error;
         switch (error) {
         case EAI_AGAIN:


### PR DESCRIPTION
This is too low level. For example, we can get an error here
because we're resolving AAAA and there is no associated record
but in fact there is a record for A and we can connect.

Issue noticed on measurement-kit/ios-example where this is the
last log message printed during each working test.

The general principle is that low level code should not warn or
emit log messages for failure unless it's unrecoverable.