### PR TITLE
travis: fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,7 @@
 language: cpp
 
-install:
-    - if [ "$COVERAGE" = "--enable-coverage" ]; then
-        pip install --user cpp-coveralls;
-      fi
-    - ./autogen.sh
-
 script:
-    - export CXX="$CXX_NAME" CC="$CC_NAME";
-    - export pkg_make_flags="V=0 -j3"
-    - export pkg_configure_flags="--quiet --disable-static"
-    # On 12.04 the linker needs LD_RUN_PATH otherwise the linking fails
-    - export LD_RUN_PATH=$TRAVIS_BUILD_DIR/builtin
-    # So, here we build our dependencies because it doesn't take too much time,
-    # because travis uses 12.04 with very old libs which cause many warnings
-    # with the also very old valgrind available:
-    - ./build/dependency geoip
-    - ./build/dependency libressl
-    - ./build/dependency libevent
-    # Note: --with-ca-bundle="" is to force using libressl's builtin CA
-    # rather than the system one (the former is the configuration we use
-    # on mobile thus we are interested to test that here on travis)
-    - ./configure $pkg_configure_flags --with-geoip=builtin --with-ca-bundle=""
-        --with-openssl=builtin --with-libevent=builtin $COVERAGE
-    - make $pkg_make_flags
-    - make $pkg_make_flags check-am$VALGRIND
-    - if [ -f test-suite.log ]; then cat test-suite.log; fi
-
-# Silence gcov standard output since it produces way too much output
-after_success:
-    - if [ "$COVERAGE" = "--enable-coverage" ]; then
-        coveralls --gcov /usr/bin/gcov-6 --exclude src/libmeasurement_kit/ext
-                  -b .  --exclude example --exclude third_party
-                  --exclude include/measurement_kit/ext
-                  --exclude src/libmeasurement_kit/cmdline > /dev/null;
-      fi
+    - ./build/travis
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,11 @@ script:
 matrix:
   include:
 
-    - sudo: false
-      compiler: gcc-6
-      env: COVERAGE=--enable-coverage CXX_NAME=g++-6 CC_NAME=gcc-6
-      addons:
-        apt:
-          packages:
-            - g++-6
-            - gcc-6
-          sources:
-            - ubuntu-toolchain-r-test
+    - sudo: required
+      env: DOCKER_IMAGE=ubuntu:yakkety DOCKER_SPEC=coveralls
+           make_flags="-j3"
+      services:
+        - docker
 
     - sudo: false
       compiler: gcc-6

--- a/build/docker/script/run
+++ b/build/docker/script/run
@@ -15,35 +15,39 @@ subr_start_over() {
 }
 
 subr_autogen() {
+    echo "- ./autogen.sh"
     ./autogen.sh
 }
 
 subr_configure() {
+    echo "- ./configure $configure_flags"
     ./configure $configure_flags
 }
 
 subr_make() {
+    echo "- make $make_flags V=0"
     make $make_flags V=0
 }
 
 subr_make_check() {
-    make $make_flags check V=0
+    if [ -z "$make_check_name" ]; then
+        make_check_name=check
+    fi
+    echo "- make $make_flags $make_check_name V=0"
+    if ! make $make_flags $make_check_name V=0; then
+        if [ -f ./test-suite.log ]; then
+            cat ./test-suite.log
+        fi
+        exit 1
+    fi
 }
 
 subr_finalize() {
     exit 0
 }
 
-if [ -z "$make_flags" ]; then
-    NPROC=$(nproc)
-    if [ $NPROC -gt 4 ]; then
-        NPROC=4
-    fi
-    make_flags="-j$NPROC"
-fi
-
 . build/docker/spec/$spec_name
-env
+env | sed 's/^COVERALLS_REPO_TOKEN=.*$/COVERALLS_REPO_TOKEN=[secure]/g'
 sleep 5
 
 if [ $# -eq 0 ]; then
@@ -51,6 +55,11 @@ if [ $# -eq 0 ]; then
 fi
 
 while [ $# -gt 0 ]; do
+    echo ""
+    echo "- - -"
+    echo ""
+    echo "# $1"
+    echo ""
     subr_$1
     shift
 done

--- a/build/docker/script/setup
+++ b/build/docker/script/setup
@@ -11,6 +11,9 @@ fi
 if [ "$COVERALLS_REPO_TOKEN" != "" ]; then
     args="$args -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN"
 fi
+if [ "$TRAVIS_BRANCH" != "" ]; then
+    args="$args -e TRAVIS_BRANCH=$TRAVIS_BRANCH"
+fi
 
 docker_image=$1
 if [ "$docker_image" = "" ]; then

--- a/build/docker/spec/coveralls
+++ b/build/docker/spec/coveralls
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -e
 
-export CC="gcc"
-export CFLAGS="$CFLAGS --coverage -g -O0"
-export CPP="gcc -E"
-export CXXFLAGS="$CXXFLAGS --coverage -g -O0"
-export CXX="g++"
-export LDFLAGS="$LDFLAGS --coverage"
+configure_flags="--enable-coverage"
+
+export CFLAGS="$CFLAGS -g -O0"
+export CXXFLAGS="$CXXFLAGS -g -O0"
 
 debian_deps="$debian_deps autoconf"
 debian_deps="$debian_deps automake"
@@ -29,11 +27,12 @@ subr_depend() {
 }
 
 subr_finalize() {
-    /root/.local/bin/coveralls                                             \
+    $HOME/.local/bin/coveralls                                             \
                                --gcov-options '\-lp'                       \
                                --build-root .                              \
                                --exclude include/measurement_kit/ext       \
-                               --exclude src/ext                           \
+                               --exclude src/libmeasurement_kit/ext        \
+                               --exclude src/measurement_kit               \
                                --exclude example                           \
                                --exclude third_party                       \
       > /dev/null;

--- a/build/travis
+++ b/build/travis
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
-if [ "$COVERAGE" = "--enable-coverage" ]; then
-    pip install --user cpp-coveralls;
+if [ "$DOCKER_IMAGE" != "" -a "$DOCKER_SPEC" != "" ]; then
+    ./build/docker/script/setup $DOCKER_IMAGE $DOCKER_SPEC
+    exit 0
 fi
+
 ./autogen.sh
 
 export CXX="$CXX_NAME" CC="$CC_NAME";
@@ -33,12 +35,4 @@ if ! make $pkg_make_flags check-am$VALGRIND; then
         cat test-suite.log;
     fi
     exit 1
-fi
-
-# Silence gcov standard output since it produces way too much output
-if [ "$COVERAGE" = "--enable-coverage" ]; then
-    coveralls --gcov /usr/bin/gcov-6 --exclude src/libmeasurement_kit/ext      \
-        -b .  --exclude example --exclude third_party                          \
-        --exclude include/measurement_kit/ext                                  \
-        --exclude src/libmeasurement_kit/cmdline > /dev/null;
 fi

--- a/build/travis
+++ b/build/travis
@@ -23,7 +23,7 @@ export LD_RUN_PATH=$TRAVIS_BUILD_DIR/builtin
 # Note: --with-ca-bundle="" is to force using libressl's builtin CA
 # rather than the system one (the former is the configuration we use
 # on mobile thus we are interested to test that here on travis)
-./configure $pkg_configure_flags --with-geoip=builtin --with-ca-bundle=""         \
+./configure $pkg_configure_flags --with-geoip=builtin --with-ca-bundle=""      \
     --with-openssl=builtin --with-libevent=builtin $COVERAGE
 
 make $pkg_make_flags
@@ -37,8 +37,8 @@ fi
 
 # Silence gcov standard output since it produces way too much output
 if [ "$COVERAGE" = "--enable-coverage" ]; then
-    coveralls --gcov /usr/bin/gcov-6 --exclude src/libmeasurement_kit/ext
-        -b .  --exclude example --exclude third_party
-        --exclude include/measurement_kit/ext
+    coveralls --gcov /usr/bin/gcov-6 --exclude src/libmeasurement_kit/ext      \
+        -b .  --exclude example --exclude third_party                          \
+        --exclude include/measurement_kit/ext                                  \
         --exclude src/libmeasurement_kit/cmdline > /dev/null;
 fi

--- a/build/travis
+++ b/build/travis
@@ -28,8 +28,12 @@ export LD_RUN_PATH=$TRAVIS_BUILD_DIR/builtin
 
 make $pkg_make_flags
 
-make $pkg_make_flags check-am$VALGRIND
-if [ -f test-suite.log ]; then cat test-suite.log; fi
+if ! make $pkg_make_flags check-am$VALGRIND; then
+    if [ -f test-suite.log ]; then
+        cat test-suite.log;
+    fi
+    exit 1
+fi
 
 # Silence gcov standard output since it produces way too much output
 if [ "$COVERAGE" = "--enable-coverage" ]; then

--- a/build/travis
+++ b/build/travis
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+if [ "$COVERAGE" = "--enable-coverage" ]; then
+    pip install --user cpp-coveralls;
+fi
+./autogen.sh
+
+export CXX="$CXX_NAME" CC="$CC_NAME";
+export pkg_make_flags="V=0 -j3"
+export pkg_configure_flags="--quiet --disable-static"
+
+# On 12.04 the linker needs LD_RUN_PATH otherwise the linking fails
+export LD_RUN_PATH=$TRAVIS_BUILD_DIR/builtin
+
+# So, here we build our dependencies because it doesn't take too much time,
+# because travis uses 12.04 with very old libs which cause many warnings
+# with the also very old valgrind available:
+./build/dependency geoip
+./build/dependency libressl
+./build/dependency libevent
+
+# Note: --with-ca-bundle="" is to force using libressl's builtin CA
+# rather than the system one (the former is the configuration we use
+# on mobile thus we are interested to test that here on travis)
+./configure $pkg_configure_flags --with-geoip=builtin --with-ca-bundle=""         \
+    --with-openssl=builtin --with-libevent=builtin $COVERAGE
+
+make $pkg_make_flags
+
+make $pkg_make_flags check-am$VALGRIND
+if [ -f test-suite.log ]; then cat test-suite.log; fi
+
+# Silence gcov standard output since it produces way too much output
+if [ "$COVERAGE" = "--enable-coverage" ]; then
+    coveralls --gcov /usr/bin/gcov-6 --exclude src/libmeasurement_kit/ext
+        -b .  --exclude example --exclude third_party
+        --exclude include/measurement_kit/ext
+        --exclude src/libmeasurement_kit/cmdline > /dev/null;
+fi

--- a/test/net/ssl_context.cpp
+++ b/test/net/ssl_context.cpp
@@ -22,7 +22,7 @@ TEST_CASE("make_ssl() works") {
             net::make_ssl<ssl_new_fail>(ctx, "www.google.com");
         REQUIRE(!maybe_ssl);
         REQUIRE(maybe_ssl.as_error().code == net::SslNewError().code);
-        //SSL_CTX_free(ctx); /* Test valgrind */
+        SSL_CTX_free(ctx);
     }
 }
 

--- a/test/net/ssl_context.cpp
+++ b/test/net/ssl_context.cpp
@@ -22,7 +22,7 @@ TEST_CASE("make_ssl() works") {
             net::make_ssl<ssl_new_fail>(ctx, "www.google.com");
         REQUIRE(!maybe_ssl);
         REQUIRE(maybe_ssl.as_error().code == net::SslNewError().code);
-        SSL_CTX_free(ctx);
+        //SSL_CTX_free(ctx); /* Test valgrind */
     }
 }
 


### PR DESCRIPTION
This pull request firstly exposes that coveralls was not working (see [travis job #4426.1](https://travis-ci.org/measurement-kit/measurement-kit/jobs/191907943)) and that `.travis.yml` was not serving us well because it would have been much better for the build to fail if coverage could not be submitted.

Hence:

1. move verbatim the script part of `.travis.yml` to `./build/travis` and make sure the script fails when it needs to fail (as evidenced by the afore-mentioned build that now fails as it ough to be)

2. solve the issue that coveralls is not working by admitting that I am now pissed off of using ubuntu 12.04 and that I would be much better off using ubuntu 16.10 through docker

Changes in here mostly backported from #1035. It is safe to move forward and merge this pull request as an hotfix for the following reasons:

- [x] the overall build time has increased a bit but it is still acceptable
- [x] coveralls [is now clearly working](https://coveralls.io/builds/9671517) and we have verified that [if it does not work the build fails](https://travis-ci.org/measurement-kit/measurement-kit/jobs/191907943)
- [x] [valgrind is invoked](https://travis-ci.org/measurement-kit/measurement-kit/jobs/191921416#L2021) and we have verified that [if it does not work the build fails](https://travis-ci.org/measurement-kit/measurement-kit/jobs/191921396#L2218)

When these checks above have been performed, I am going to merge the pull request.

Closes #1060.