### PR TITLE
Finish cleaning up docker build system

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,11 @@ valgrind-gcc:
   script: ./build/docker/script/run valgrind-gcc
   only:
     - master
+    - stable
 
 valgrind-clang:
   image: ubuntu:xenial
   script: ./build/docker/script/run valgrind-clang
   only:
     - master
+    - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
 
     - sudo: required
-      env: DOCKER_SPEC=coveralls make_flags="-j3"
+      env: DOCKER_SPEC=coveralls pkg_make_flags="V=0 -j3"
       services:
         - docker
 

--- a/build/dependency
+++ b/build/dependency
@@ -82,6 +82,8 @@ pkg_make_check() {
             fi
             exit 1
         fi
+    else
+        echo 'not running checks because $pkg_make_check_rule is not set'
     fi
 }
 
@@ -129,9 +131,8 @@ if [ -z "$pkg_steps" ]; then
     pkg_steps="patch_pre_autogen autogen patch_post_autogen configure make make_check make_install"
 fi
 for step in $pkg_steps; do
-    echo "- - -"
     echo ""
-    echo "# $step"
+    echo "./build/dependency: $step"
     echo ""
     pkg_$step
 done

--- a/build/dependency
+++ b/build/dependency
@@ -11,10 +11,11 @@ Override default behavior by setting these environment variables:
   - pkg_clone_flags: extra flags for 'git clone' (e.g. '--recursive')
   - pkg_configure_flags: extra flags for './configure' (if any)
   - pkg_cmake_flags: extra flags for 'cmake .' (if CMakeLists.txt exists)
+  - pkg_make_check_rule: rule to run tests (default: not set, no tests are run)
   - pkg_make_flags: extra flags for 'make' (e.g. 'V=0')
   - pkg_make_install_flags: extra flags for 'make install' (e.g. DESTDIR=/opt)
   - pkg_prefix: prefix where to install (e.g. '/usr/local')
-  - pkg_steps: steps to execute (default is: 'configure make make_install')
+  - pkg_steps: steps to execute (default is: 'patch_pre_autogen autogen patch_post_autogen configure make make_check make_install')
   - pkg_sudo: optional comand to execute 'make install' with (e.g. sudo)
 
 Examples:
@@ -72,6 +73,18 @@ pkg_make() {
     make $pkg_make_flags
 }
 
+pkg_make_check() {
+    if [ "$pkg_make_check_rule" != "" ]; then
+        echo "- make $pkg_make_flags $pkg_make_check_rule"
+        if ! make $pkg_make_flags $pkg_make_check_rule; then
+            if [ -f ./test-suite.log ]; then
+                cat ./test-suite.log
+            fi
+            exit 1
+        fi
+    fi
+}
+
 pkg_make_install() {
     echo "- $pkg_sudo make $pkg_make_install_flags install"
     $pkg_sudo make $pkg_make_install_flags install
@@ -113,7 +126,7 @@ if [ "$pkg_repository" != "" ]; then
 fi
 
 if [ -z "$pkg_steps" ]; then
-    pkg_steps="patch_pre_autogen autogen patch_post_autogen configure make make_install"
+    pkg_steps="patch_pre_autogen autogen patch_post_autogen configure make make_check make_install"
 fi
 for step in $pkg_steps; do
     echo "- - -"

--- a/build/docker/script/run
+++ b/build/docker/script/run
@@ -8,42 +8,29 @@ fi
 spec_name=$1
 shift
 
+subr_depend() {
+    echo "- install debian deps: $debian_deps"
+    apt-get update
+    apt-get upgrade -y
+    apt-get install -y $debian_deps
+    if [ "$pip_deps" != "" ]; then
+        echo "- install pip deps: $pip_deps"
+        pip install --user $pip_deps
+    fi
+}
+
 subr_start_over() {
     if [ -f Makefile ]; then
         make distclean
     fi
 }
 
-subr_autogen() {
-    echo "- ./autogen.sh"
-    ./autogen.sh
-}
-
-subr_configure() {
-    echo "- ./configure $configure_flags"
-    ./configure $configure_flags
-}
-
-subr_make() {
-    echo "- make $make_flags V=0"
-    make $make_flags V=0
-}
-
-subr_make_check() {
-    if [ -z "$make_check_name" ]; then
-        make_check_name=check
-    fi
-    echo "- make $make_flags $make_check_name V=0"
-    if ! make $make_flags $make_check_name V=0; then
-        if [ -f ./test-suite.log ]; then
-            cat ./test-suite.log
-        fi
-        exit 1
-    fi
+subr_build() {
+    ./build/dependency mk
 }
 
 subr_finalize() {
-    exit 0
+    echo "- finalize"
 }
 
 . build/docker/spec/$spec_name
@@ -51,7 +38,7 @@ env | sed 's/^COVERALLS_REPO_TOKEN=.*$/COVERALLS_REPO_TOKEN=[secure]/g'
 sleep 5
 
 if [ $# -eq 0 ]; then
-    set -- depend start_over autogen configure make make_check finalize
+    set -- depend start_over build finalize
 fi
 
 while [ $# -gt 0 ]; do

--- a/build/docker/script/run
+++ b/build/docker/script/run
@@ -43,9 +43,7 @@ fi
 
 while [ $# -gt 0 ]; do
     echo ""
-    echo "- - -"
-    echo ""
-    echo "# $1"
+    echo "docker/script/run: $1"
     echo ""
     subr_$1
     shift

--- a/build/docker/script/setup
+++ b/build/docker/script/setup
@@ -10,8 +10,8 @@ fi
 shift
 
 docker run                                                                 \
-    -e "configure_flags=$configure_flags"                                  \
-    -e "make_flags=$make_flags"                                            \
+    -e "pkg_configure_flags=$pkg_configure_flags"                          \
+    -e "pkg_make_flags=$pkg_make_flags"                                    \
     -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN"                        \
     -e "TRAVIS_BRANCH=$TRAVIS_BRANCH"                                      \
     -v $REPOROOT:/mk                                                       \

--- a/build/docker/spec/coveralls
+++ b/build/docker/spec/coveralls
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-configure_flags="--enable-coverage"
+export pkg_configure_flags="$pkg_configure_flags --enable-coverage"
+export pkg_make_check_rule="check"
 
 export CFLAGS="$CFLAGS -g -O0"
 export CXXFLAGS="$CXXFLAGS -g -O0"
@@ -18,13 +19,7 @@ debian_deps="$debian_deps make"
 debian_deps="$debian_deps python"
 debian_deps="$debian_deps python-pip"
 debian_deps="$debian_deps wget"
-
-subr_depend() {
-    apt-get update
-    apt-get upgrade -y
-    apt-get install -y $debian_deps
-    pip install --user cpp-coveralls
-}
+pip_deps="$pip_deps cpp-coveralls"
 
 subr_finalize() {
     $HOME/.local/bin/coveralls                                             \

--- a/build/docker/spec/valgrind-clang
+++ b/build/docker/spec/valgrind-clang
@@ -4,8 +4,7 @@ set -e
 export CPP="clang -E"
 export CC="clang"
 export CXX="clang++"
-
-export configure_flags="$configure_flags --disable-shared"
+export pkg_make_check_rule="run-valgrind"
 
 debian_deps="$debian_deps autoconf"
 debian_deps="$debian_deps automake"
@@ -18,13 +17,3 @@ debian_deps="$debian_deps libtool"
 debian_deps="$debian_deps make"
 debian_deps="$debian_deps valgrind"
 debian_deps="$debian_deps wget"
-
-subr_depend() {
-    apt-get update
-    apt-get upgrade -y
-    apt-get install -y $debian_deps
-}
-
-subr_make_check() {
-    make $make_flags run-valgrind V=0
-}

--- a/build/docker/spec/valgrind-gcc
+++ b/build/docker/spec/valgrind-gcc
@@ -4,8 +4,7 @@ set -e
 export CPP="gcc -E"
 export CC="gcc"
 export CXX="g++"
-
-export configure_flags="$configure_flags --disable-shared"
+export pkg_make_check_rule="run-valgrind"
 
 debian_deps="$debian_deps autoconf"
 debian_deps="$debian_deps automake"
@@ -18,13 +17,3 @@ debian_deps="$debian_deps libtool"
 debian_deps="$debian_deps make"
 debian_deps="$debian_deps valgrind"
 debian_deps="$debian_deps wget"
-
-subr_depend() {
-    apt-get update
-    apt-get upgrade -y
-    apt-get install -y $debian_deps
-}
-
-subr_make_check() {
-    make $make_flags run-valgrind V=0
-}

--- a/build/spec/embedded-mk
+++ b/build/spec/embedded-mk
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+# TODO: see if we can merge this and ./build/spec/mk
+
 ROOTDIR=$(cd $(dirname $(dirname $(dirname $0))) && pwd -P)
 if [ $? -ne 0 ]; then
     echo "$0: cannot determine root directory" 1>&2

--- a/build/spec/mk
+++ b/build/spec/mk
@@ -1,0 +1,1 @@
+pkg_name=measurement-kit

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,11 @@ machine:
   services:
     - docker
 
-#general:
-#  branches:
-#    ignore:
-#      - /^doc\/.*$/
+general:
+  branches:
+    only:
+      - master
+      - stable
 
 test:
   override:


### PR DESCRIPTION
Rather than duplicating code to build a package, tap into the
`./build/dependency` script.

Move code to install required dependencies in the `run` script
of `./build/docker/script`, to reduce specs complexity.