### PR TITLE
Fix/case sensitive drive

### DIFF
--- a/build/ios/build-frameworks
+++ b/build/ios/build-frameworks
@@ -17,26 +17,26 @@ EXTLIBRARIES="libevent libevent_pthreads libevent_openssl libcrypto libssl libGe
 
     # Copying x86 headers. This has no implications because measurement-kit
     # uses no machine-dependent headers.
-    cp -Rp tmp/iPhoneSimulator/i386/include/measurement_kit \
+    cp -Rp tmp/iphonesimulator/i386/include/measurement_kit \
         Frameworks/measurement_kit.framework/Headers
 
     # Lipo external libraries
     for lib in $EXTLIBRARIES; do 
         lipo -create -output Frameworks/$lib.framework/$lib \
-          tmp/iPhoneOS/arm64/lib/$lib.a \
-          tmp/iPhoneOS/armv7s/lib/$lib.a \
-          tmp/iPhoneOS/armv7/lib/$lib.a \
-          tmp/iPhoneSimulator/i386/lib/$lib.a \
-          tmp/iPhoneSimulator/x86_64/lib/$lib.a
+          tmp/iphoneos/arm64/lib/$lib.a \
+          tmp/iphoneos/armv7s/lib/$lib.a \
+          tmp/iphoneos/armv7/lib/$lib.a \
+          tmp/iphonesimulator/i386/lib/$lib.a \
+          tmp/iphonesimulator/x86_64/lib/$lib.a
     done
     
     # Lipo measurement-kit library 
     lipo -create -output Frameworks/measurement_kit.framework/measurement_kit \
-      tmp/iPhoneOS/arm64/lib/libmeasurement_kit.a \
-      tmp/iPhoneOS/armv7s/lib/libmeasurement_kit.a \
-      tmp/iPhoneOS/armv7/lib/libmeasurement_kit.a \
-      tmp/iPhoneSimulator/i386/lib/libmeasurement_kit.a \
-      tmp/iPhoneSimulator/x86_64/lib/libmeasurement_kit.a
+      tmp/iphoneos/arm64/lib/libmeasurement_kit.a \
+      tmp/iphoneos/armv7s/lib/libmeasurement_kit.a \
+      tmp/iphoneos/armv7/lib/libmeasurement_kit.a \
+      tmp/iphonesimulator/i386/lib/libmeasurement_kit.a \
+      tmp/iphonesimulator/x86_64/lib/libmeasurement_kit.a
 
     # Create fake header to make CocoaPod happy
     for lib in $EXTLIBRARIES; do


### PR DESCRIPTION
While investigating an issue I had with building ooniprobe-ios, I seem to have uncovered a bug related to case (in)sensitive drives.

For the record when running `pod update` (or `pod install`) I was getting the following error:

```
configure: WARNING: using cross tools not prefixed with host triplet
configure: WARNING: skipped the ca-bundle detection when cross-compiling
configure: WARNING: using cross tools not prefixed with host triplet
configure: WARNING: skipped the ca-bundle detection when cross-compiling
configure: WARNING: using cross tools not prefixed with host triplet
configure: WARNING: skipped the ca-bundle detection when cross-compiling
configure: WARNING: using cross tools not prefixed with host triplet
configure: WARNING: skipped the ca-bundle detection when cross-compiling
configure: WARNING: using cross tools not prefixed with host triplet
configure: WARNING: skipped the ca-bundle detection when cross-compiling
cp: tmp/iPhoneSimulator/i386/include/measurement_kit: No such file or directory
```

However from looking at a measurement-kit build the true path is actually `tmp/iphonesimulator/i386/` (all lowercase). I didn't encounter this issue in the past because my main drive was case insensitive and I suspect so are the drives of @bassosimone and @lorenzoPrimi .

I pushed this branch in the hope that I can build a good ooniprobe-ios. If this actually fixes it I will update this PR.

(note: this branch is actually based against stable)