### PR TITLE
var.hpp: fix as() to use dynamic cast

### DIFF
--- a/doc/api/common/var.md
+++ b/doc/api/common/var.md
@@ -55,6 +55,12 @@ The `as()` method casts the pointee to type `R` if possible. If conversion
 is not possible, the returned `Var<>` would point to a null pointer and hence
 attempting to dereference it would result in `std::runtime_error`.
 
+# CAVEAT
+
+The `as()` method does not seem to preserve any custom deleter that may
+have been passed to the original `Var<>`; this seems reasonable since the
+new `Var<>` will delete another type of object (if the cast worked).
+
 # HISTORY
 
 The `Var` template class appeared in MeasurementKit 0.1.0.

--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -11,7 +11,10 @@
 
 namespace mk {
 
-class ErrorContext {};
+class ErrorContext {
+  public:
+    virtual ~ErrorContext();
+};
 
 class Error : public std::exception {
   public:

--- a/include/measurement_kit/common/var.hpp
+++ b/include/measurement_kit/common/var.hpp
@@ -30,7 +30,7 @@ template <typename T> class Var : public std::shared_ptr<T> {
     }
 
     template <typename R> Var<R> as() {
-        return std::static_pointer_cast<R>(*this);
+        return std::dynamic_pointer_cast<R>(*this);
     }
 
   protected:

--- a/include/measurement_kit/net/connect.hpp
+++ b/include/measurement_kit/net/connect.hpp
@@ -24,11 +24,13 @@ struct ResolveHostnameResult {
     std::vector<std::string> addresses;
 };
 
-struct ConnectResult : public ErrorContext {
+class ConnectResult : public ErrorContext {
+  public:
     ResolveHostnameResult resolve_result;
     std::vector<Error> connect_result;
     double connect_time = 0.0;
     bufferevent *connected_bev = nullptr;
+    ~ConnectResult() override;
 };
 
 // Convert error returned by connect() in connect_time
@@ -40,8 +42,10 @@ void connect(std::string address, int port,
              Var<Reactor> reactor = Reactor::global(),
              Var<Logger> logger = Logger::global());
 
-struct ConnectManyResult : public ErrorContext {
+class ConnectManyResult : public ErrorContext {
+  public:
     std::vector<Var<ConnectResult>> results;
+    ~ConnectManyResult() override;
 };
 
 // Convert error returned by connect_many() into connect_times vector

--- a/src/libmeasurement_kit/common/error.cpp
+++ b/src/libmeasurement_kit/common/error.cpp
@@ -1,0 +1,11 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include <measurement_kit/common.hpp>
+
+namespace mk {
+
+ErrorContext::~ErrorContext() {}
+
+} // namespace mk

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -340,5 +340,8 @@ ErrorOr<std::vector<double>> get_connect_times(Error err) {
     return connect_times;
 }
 
+ConnectResult::~ConnectResult() {}
+ConnectManyResult::~ConnectManyResult() {}
+
 } // namespace net
 } // namespace mk

--- a/test/common/var.cpp
+++ b/test/common/var.cpp
@@ -15,13 +15,29 @@ class Foo {
     Foo() {}
     Foo(double x) : elem(x) {}
     void mascetti() {}
+    virtual ~Foo() noexcept;
 };
 
-class FooChild : public Foo {
- public:
-     double elemChild = 6.28;
-     FooChild(double y) : elemChild(y) {}
+Foo::~Foo() noexcept {}
+
+class FooBar : public Foo {
+  public:
+    double elem_child = 6.28;
+    FooBar(double y) : elem_child(y) {}
+    FooBar() {}
+    ~FooBar() noexcept override;
 };
+
+FooBar::~FooBar() noexcept {}
+
+// Enters the most glorious of the Sith lords...
+class JarJar {
+  public:
+    double binks = 0.91;
+    virtual ~JarJar() noexcept;
+};
+
+JarJar::~JarJar() noexcept {}
 
 TEST_CASE("Var raises an exception when the pointee is nullptr") {
     Var<Foo> foo;
@@ -69,8 +85,73 @@ TEST_CASE("Get() throws when nullptr") {
     REQUIRE_THROWS(il_melandri.get());
 }
 
-TEST_CASE("as() can downcast an object") {
-    Var<Foo> foo(new FooChild(7.0));
-    Var<FooChild> fooChild = foo.as<FooChild>();
-    REQUIRE(fooChild->elemChild == 7.0);
+TEST_CASE("as() works as expected") {
+    SECTION("When upcast is possible and target pointer is null") {
+        Var<FooBar> bar;
+        REQUIRE(!bar);
+        Var<Foo> foo = bar.as<Foo>();
+        REQUIRE(!foo);
+    }
+
+    SECTION("When upcast is possible and target pointer is not null") {
+        Var<FooBar> bar{new FooBar};
+        REQUIRE(!!bar);
+        Var<Foo> foo = bar.as<Foo>();
+        REQUIRE(!!foo);
+    }
+
+    SECTION("When downcast is possible and target pointer is null") {
+        Var<Foo> foo;
+        REQUIRE(!foo);
+        Var<FooBar> bar = foo.as<FooBar>();
+        REQUIRE(!bar);
+    }
+
+    SECTION("When downcast is possible and target pointer is not null") {
+        Var<Foo> foo{new FooBar};
+        REQUIRE(!!foo);
+        Var<FooBar> bar = foo.as<FooBar>();
+        REQUIRE(!!bar);
+    }
+
+    SECTION("When cast is not possible and target pointer is null") {
+        Var<Foo> foo;
+        REQUIRE(!foo);
+        Var<JarJar> jar = foo.as<JarJar>();
+        REQUIRE(!jar);
+    }
+
+    SECTION("When cast is not possible and target pointer is not null") {
+        Var<Foo> foo{new FooBar};
+        REQUIRE(!!foo);
+        Var<JarJar> jar = foo.as<JarJar>();
+        REQUIRE(!jar);
+    }
+
+    SECTION("The deleter cannot be preserved") {
+        auto count = 0;
+        {
+            Var<Foo> foo{new FooBar, [&](Foo *p) {
+                count += 1;
+                delete p;
+            }};
+            REQUIRE(!!foo);
+            Var<FooBar> bar = foo.as<FooBar>();
+            REQUIRE(!!bar);
+        }
+        REQUIRE(count == 1);
+    }
+
+    SECTION("The usage count is consistent") {
+        Var<FooBar> bar;
+        {
+            Var<Foo> foo{new FooBar};
+            REQUIRE(!!foo);
+            bar = foo.as<FooBar>();
+            REQUIRE(!!bar);
+            REQUIRE(foo.use_count() == 2);
+            REQUIRE(bar.use_count() == 2);
+        }
+        REQUIRE(bar.use_count() == 1);
+    }
 }


### PR DESCRIPTION
When developing a diff to improve NDT, I mistakenly wrote:

```C++
ErrorOr<std::vector<double>> ctimes = net::get_connect_times(err);
```

instead of:

```C++
ErrorOr<double> ctime = net::get_connect_time(err);
```

after `connect()`. Now, both functions internally use Var<T>::as()
to cast from a generic `ErrorContext` to a specific context.

The net effect of calling `get_connect_times` rather than the more
humble `get_connect_time` is that `ErrorContext` is downcasted to
`ConnectManyResult` rather than to `ConnectResult`. Since the cast
is not possible, one would have expected the cast to fail and the
resulting Var<T> to hold a nullptr. Hence the `ErrorOr` should not
be a value but rather an error. Right?

Wrong! What I obtained instead was a segfault.

It turns out that using a static-pointer cast in `as()` was a bad
idea, and that what I really would have wanted to have is a dynamic
cast instead. The dynamic cast, in fact, fails (as I expected) if
it is not possible to perform the cast.