### PR TITLE
Make sure http template produces good json

### DIFF
--- a/doc/api/ooni/utils.md
+++ b/doc/api/ooni/utils.md
@@ -25,7 +25,7 @@ void resolver_lookup(
         Var<Logger> logger = Logger::global()
 );
 
-report::Entry represent_http_body(const std::string &body);
+report::Entry represent_string(const std::string &s);
 
 } // namespace ooni
 } // namespace mk
@@ -63,11 +63,11 @@ especially for large ISPs. For example, if you use `8.8.8.8` as your DNS
 name server, this function will return an IP address owened by Google
 but different from `8.8.8.8`.
 
-The `represent_http_body` function represent the `body` passed as argument
-such that it can be serialized as JSON. Is the body is ASCII or UTF-8, it
+The `represent_string` function represent the `s` passed as argument
+such that it can be serialized as JSON. Is the string is ASCII or UTF-8, it
 is not changed. Otherwise, this function returns a JSON object where the
 `format` key maps to the `base64` string and the `data` key maps to the base64
-representation of the original body.
+representation of the original string.
 
 # HISTORY
 

--- a/include/measurement_kit/ooni/utils.hpp
+++ b/include/measurement_kit/ooni/utils.hpp
@@ -17,7 +17,7 @@ void resolver_lookup(Callback<Error, std::string> callback, Settings = {},
                      Var<Reactor> reactor = Reactor::global(),
                      Var<Logger> logger = Logger::global());
 
-report::Entry represent_http_body(const std::string &body);
+report::Entry represent_string(const std::string &s);
 
 } // namespace ooni
 } // namespace mk

--- a/src/libmeasurement_kit/ooni/templates.cpp
+++ b/src/libmeasurement_kit/ooni/templates.cpp
@@ -81,7 +81,7 @@ void http_request(Var<Entry> entry, Settings settings, http::Headers headers,
         [=](Error error, Var<http::Response> response) {
             Entry rr;
             rr["request"]["headers"] = headers;
-            rr["request"]["body"] = represent_http_body(body);
+            rr["request"]["body"] = represent_string(body);
             rr["request"]["url"] = settings.at("http/url").c_str();
             rr["request"]["method"] = settings.at("http/method").c_str();
 
@@ -89,9 +89,13 @@ void http_request(Var<Entry> entry, Settings settings, http::Headers headers,
             rr["method"] = settings.at("http/method").c_str();
 
             if (!error) {
-                rr["response"]["headers"] = response->headers;
-                rr["response"]["body"] = represent_http_body(response->body);
-                rr["response"]["response_line"] = response->response_line;
+                for (auto pair: response->headers) {
+                    rr["response"]["headers"][pair.first]
+                        = represent_string(pair.second);
+                }
+                rr["response"]["body"] = represent_string(response->body);
+                rr["response"]["response_line"] =
+                    represent_string(response->response_line);
                 rr["response"]["code"] = response->status_code;
                 rr["failure"] = nullptr;
             } else {

--- a/src/libmeasurement_kit/ooni/utils.cpp
+++ b/src/libmeasurement_kit/ooni/utils.cpp
@@ -145,13 +145,13 @@ bool is_private_ipv4_addr(const std::string &ipv4_addr) {
   return false;
 }
 
-report::Entry represent_http_body(const std::string &body) {
-    Error error = is_valid_utf8_string(body);
+report::Entry represent_string(const std::string &s) {
+    Error error = is_valid_utf8_string(s);
     if (error != NoError()) {
         return report::Entry{{"format", "base64"},
-                              {"data", base64_encode(body)}};
+                              {"data", base64_encode(s)}};
     }
-    return body;
+    return s;
 }
 
 } // namespace ooni

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -123,11 +123,11 @@ TEST_CASE("extract_html_title works") {
     REQUIRE(mk::ooni::extract_html_title(body) == "TITLE");
 }
 
-TEST_CASE("represent_http_body works") {
+TEST_CASE("represent_string works") {
     SECTION("For an ASCII body") {
         std::string s = "an ASCII body";
         mk::report::Entry e = s;
-        REQUIRE(mk::ooni::represent_http_body(s).dump() == e.dump());
+        REQUIRE(mk::ooni::represent_string(s).dump() == e.dump());
     }
 
     SECTION("For a UTF-8 body") {
@@ -135,14 +135,14 @@ TEST_CASE("represent_http_body works") {
                                0xc3, 0xa8, 'i', 'o', 'u'};
         std::string s{v.begin(), v.end()};
         mk::report::Entry e = s;
-        REQUIRE(mk::ooni::represent_http_body(s).dump() == e.dump());
+        REQUIRE(mk::ooni::represent_string(s).dump() == e.dump());
     }
 
     SECTION("For a binary body") {
         std::vector<uint8_t> v{0x04, 0x03, 0x02, 0x01, 0x00, 0x01, 0x02, 0x03};
         std::string s{v.begin(), v.end()};
         REQUIRE(
-            mk::ooni::represent_http_body(s).dump() ==
+            mk::ooni::represent_string(s).dump() ==
             (mk::report::Entry{{"format", "base64"}, {"data", "BAMCAQABAgM="}}
                  .dump()));
     }


### PR DESCRIPTION
Closes #1065. Specifically:

1) change name from represent_http_body to represent_string since
   the function is now used more generally than for the body

2) use represent_string to also represent the response line and the
   value of headers that both could be non UTF-8

There is no need to represent the name of the headers because
the standard says that it's

>
>    header-field   = field-name ":" OWS field-value OWS
>    field-name     = token
>
>    token = 1*tchar
>
>    tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
>                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
>                / DIGIT / ALPHA
>                ; any VCHAR, except delimiters
>
>    ALPHA =  %x41-5A / %x61-7A   ; A-Z / a-z
>    DIGIT =  "0" / "1" / "2" / "3" / "4" / "5" / "6" /
>                   "7" / "8" / "9"
>

So, we really don't have UTF-8 / non UTF-8 issues for names.

See:

- https://tools.ietf.org/html/rfc7230#section-3.2
- https://tools.ietf.org/html/rfc5234#appendix-B.1