### PR TITLE
Use default backends when it makes sense

### DIFF
--- a/doc/api/ooni/collector_client.md
+++ b/doc/api/ooni/collector_client.md
@@ -8,7 +8,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/ooni.hpp>
 
-std::string default_collector_url();
+std::string testing_collector_url();
+std::string production_collector_url();
 
 void mk::ooni::submit_report(std::string filepath, std::string collector_base_url,
         Callback<Error> callback, Settings settings = {},
@@ -48,7 +49,8 @@ void mk::ooni::close_report(Var<net::Transport> txp, std::string report_id,
 
 This header contains routines to interact with OONI's collector.
 
-The `default_collector_url()` function returns the default collector URL.
+The `testing_collector_url()` function returns the testing collector URL,
+and the `production_collector_url()` returns the production one.
 
 The `submit_report()` function submits the report at `filepath` using the collector
 identifier by `collector_base_url` and calls `callback` when done. You can also

--- a/include/measurement_kit/ooni/collector_client.hpp
+++ b/include/measurement_kit/ooni/collector_client.hpp
@@ -13,11 +13,10 @@ namespace collector {
 
 /*
     To submit a file report, use one of the following collectors. By default
-    the library uses the `testing` collector which is a HTTPS service running
-    on Heroku that discards all the input it receives.
+    the library uses the `production` collector.
 */
 
-#define MK_OONI_PRODUCTION_COLLECTOR_URL "https://a.collector.ooni.io:4441"
+#define MK_OONI_PRODUCTION_COLLECTOR_URL "https://b.collector.ooni.io"
 #define MK_OONI_TESTING_COLLECTOR_URL "https://b.collector.test.ooni.io:4441"
 
 std::string production_collector_url();

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -364,8 +364,7 @@ static void control_request(Var<Entry> entry, SocketList socket_list,
         // TODO set the appropriate headers to support cloud-fronting.
     }
 
-    logger->debug("web_connectivity: performing control request to %s",
-                  settings["backend"].c_str());
+    logger->info("Using backend %s", settings["backend"].c_str());
 
     mk::dump_settings(settings, "web_connectivity", logger);
 

--- a/src/libmeasurement_kit/report/ooni_reporter.cpp
+++ b/src/libmeasurement_kit/report/ooni_reporter.cpp
@@ -13,10 +13,10 @@ OoniReporter::OoniReporter(Settings s, Var<Reactor> r, Var<Logger> l) {
     reactor = r;
     logger = l;
     if (settings.find("collector_base_url") == settings.end()) {
-        // Note: by default we use the testing collector URL because otherwise
-        // testing runs would be collected creating noise and using resources
+        // Note: by default we use the production collector URL and we need
+        // to remember to switch to the testing one in tests.
         settings["collector_base_url"] =
-            ooni::collector::testing_collector_url();
+            ooni::collector::production_collector_url();
     }
     logger->info("Results collector: %s",
         settings["collector_base_url"].c_str());

--- a/src/measurement_kit/cmdline/web_connectivity.cpp
+++ b/src/measurement_kit/cmdline/web_connectivity.cpp
@@ -15,7 +15,7 @@ namespace web_connectivity {
 "usage: %s [-nv] [-b backend] [-N nameserver] [-t runtime] [file_name...]\n"
 
 int main(const char *, int argc, char **argv) {
-    std::string backend = "https://a.web-connectivity.th.ooni.io:4442";
+    std::string backend = "https://b.web-connectivity.th.ooni.io";
     std::string nameserver = "8.8.8.8";
     std::string name = argv[0];
     uint32_t verbosity = 0;

--- a/test/nettests/dns_injection.cpp
+++ b/test/nettests/dns_injection.cpp
@@ -5,38 +5,25 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 #ifdef ENABLE_INTEGRATION_TESTS
 
 TEST_CASE("Synchronous dns-injection test") {
-    nettests::DnsInjectionTest{}
+    test::nettests::make_test<DnsInjectionTest>("hosts.txt")
         .set_options("backend", "8.8.8.1:53")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
         .set_options("dns/timeout", "0.1")
-        .set_input_filepath("test/fixtures/hosts.txt")
         .run();
 }
 
 TEST_CASE("Asynchronous dns-injection test") {
-    bool done = false;
-    nettests::DnsInjectionTest{}
-        .set_options("backend", "8.8.8.1:53")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
-        .set_options("dns/timeout", "0.1")
-        .set_input_filepath("test/fixtures/hosts.txt")
-        .start([&]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<DnsInjectionTest>("hosts.txt")
+            .set_options("backend", "8.8.8.1:53")
+            .set_options("dns/timeout", "0.1")
+    );
 }
 
 #endif
@@ -47,7 +34,7 @@ TEST_CASE("Make sure that set_output_filepath() works") {
        Note: must also set valid input file path otherwise the constructor
        called inside create_test_() throws an exception
     */
-    auto runnable = nettests::DnsInjectionTest{}
+    auto runnable = DnsInjectionTest{}
                         .set_input_filepath("test/fixtures/hosts.txt")
                         .set_output_filepath("foo.txt")
                         .runnable;

--- a/test/nettests/http_invalid_request_line.cpp
+++ b/test/nettests/http_invalid_request_line.cpp
@@ -7,40 +7,27 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 TEST_CASE("Synchronous http-invalid-request-line test") {
-    nettests::HttpInvalidRequestLineTest{}
+    test::nettests::make_test<HttpInvalidRequestLineTest>()
         .set_options("backend", "http://213.138.109.232/")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
         .run();
 }
 
 TEST_CASE("Synchronous http-invalid-request-line test with HTTP backend") {
-    nettests::HttpInvalidRequestLineTest()
+    test::nettests::make_test<HttpInvalidRequestLineTest>()
         .set_options("backend", "http://data.neubot.org/")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
         .run();
 }
 
 TEST_CASE("Asynchronous http-invalid-request-line test") {
-    bool done = false;
-    nettests::HttpInvalidRequestLineTest{}
-        .set_options("backend", "http://213.138.109.232/")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
-        .start([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<HttpInvalidRequestLineTest>()
+            .set_options("backend", "http://213.138.109.232/")
+    );
 }
 
 #else

--- a/test/nettests/multi_ndt.cpp
+++ b/test/nettests/multi_ndt.cpp
@@ -7,28 +7,19 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 TEST_CASE("Synchronous NDT test") {
-    nettests::MultiNdtTest{}
-        .set_verbosity(MK_LOG_INFO)
+    test::nettests::make_test<MultiNdtTest>()
         .run();
 }
 
 TEST_CASE("Asynchronous NDT test") {
-    bool done = false;
-    nettests::MultiNdtTest{}
-        .set_verbosity(MK_LOG_INFO)
-        .start([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<MultiNdtTest>()
+    );
 }
 
 #else

--- a/test/nettests/ndt.cpp
+++ b/test/nettests/ndt.cpp
@@ -7,28 +7,19 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 TEST_CASE("Synchronous NDT test") {
-    nettests::NdtTest{}
-        .set_verbosity(MK_LOG_INFO)
+    test::nettests::make_test<NdtTest>()
         .run();
 }
 
 TEST_CASE("Asynchronous NDT test") {
-    bool done = false;
-    nettests::NdtTest{}
-        .set_verbosity(MK_LOG_INFO)
-        .start([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<NdtTest>()
+    );
 }
 
 #else

--- a/test/nettests/runnable.cpp
+++ b/test/nettests/runnable.cpp
@@ -6,12 +6,13 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
+using namespace mk::nettests;
 using namespace mk;
 
 TEST_CASE("Make sure that on_entry() works") {
-    nettests::Runnable test;
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     test.reactor = Reactor::global();
     loop_with_initial_event([&]() {
         test.entry_cb = [](std::string s) {
@@ -36,11 +37,12 @@ TEST_CASE("Make sure that on_entry() works") {
             });
         });
     });
+    });
 }
 
 TEST_CASE("Make sure that on_begin() works") {
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     bool ok = false;
-    nettests::Runnable test;
     test.reactor = Reactor::global();
     loop_with_initial_event([&]() {
         test.begin_cb = [&]() {
@@ -53,11 +55,12 @@ TEST_CASE("Make sure that on_begin() works") {
         });
     });
     REQUIRE(ok);
+    });
 }
 
 TEST_CASE("Make sure that on_end() works") {
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     int ok = 0;
-    nettests::Runnable test;
     test.reactor = Reactor::global();
     loop_with_initial_event([&]() {
         test.end_cbs.push_back([&]() {
@@ -73,12 +76,13 @@ TEST_CASE("Make sure that on_end() works") {
         });
     });
     REQUIRE(ok == 3);
+    });
 }
 
 TEST_CASE("Make sure that on_destroy() works") {
     int ok = 0;
     {
-        nettests::Runnable test;
+        test::nettests::with_runnable([&](nettests::Runnable &test) {
         test.reactor = Reactor::global();
         loop_with_initial_event([&]() {
             test.destroy_cbs.push_back([&]() {
@@ -94,12 +98,13 @@ TEST_CASE("Make sure that on_destroy() works") {
             });
         });
         REQUIRE(ok == 0);
+        });
     }
     REQUIRE(ok == 3);
 }
 
 TEST_CASE("Ensure we do not save too much information by default") {
-    nettests::Runnable test;
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     test.reactor = Reactor::global();
     test.options["geoip_country_path"] = "GeoIP.dat";
     test.options["geoip_asn_path"] = "GeoIPASNum.dat";
@@ -117,10 +122,11 @@ TEST_CASE("Ensure we do not save too much information by default") {
             });
         });
     });
+    });
 }
 
 TEST_CASE("Ensure we can save IP address if we want") {
-    nettests::Runnable test;
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     test.reactor = Reactor::global();
     test.options["geoip_country_path"] = "GeoIP.dat";
     test.options["geoip_asn_path"] = "GeoIPASNum.dat";
@@ -139,10 +145,11 @@ TEST_CASE("Ensure we can save IP address if we want") {
             });
         });
     });
+    });
 }
 
 TEST_CASE("Ensure we can avoid saving CC and ASN if we want") {
-    nettests::Runnable test;
+    test::nettests::with_runnable([](nettests::Runnable &test) {
     test.reactor = Reactor::global();
     test.options["geoip_country_path"] = "GeoIP.dat";
     test.options["geoip_asn_path"] = "GeoIPASNum.dat";
@@ -162,6 +169,7 @@ TEST_CASE("Ensure we can avoid saving CC and ASN if we want") {
             });
         });
     });
+    });
 }
 
 TEST_CASE("Make sure that 'randomize_input' works") {
@@ -179,12 +187,12 @@ TEST_CASE("Make sure that 'randomize_input' works") {
 
     auto run = [&](bool shuffle) -> std::vector<std::string> {
 
-        nettests::Runnable test;
+        std::vector<std::string> result;
+        test::nettests::with_runnable([&](nettests::Runnable &test) {
         test.reactor = Reactor::make();
         test.input_filepaths.push_back("./test/fixtures/hosts.txt");
         test.options["randomize_input"] = shuffle;
         test.needs_input = true;
-        std::vector<std::string> result;
 
         test.reactor->loop_with_initial_event([&]() {
             test.entry_cb = [&](std::string s) {
@@ -194,6 +202,7 @@ TEST_CASE("Make sure that 'randomize_input' works") {
             test.begin([&](Error) {
                 test.end([&](Error) { test.reactor->break_loop(); });
             });
+        });
         });
         return result;
     };

--- a/test/nettests/runner.cpp
+++ b/test/nettests/runner.cpp
@@ -7,61 +7,50 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
+using namespace mk::nettests;
 using namespace mk;
 
-static void run_http_invalid_request_line(nettests::Runner &runner) {
-    runner.start_test(nettests::HttpInvalidRequestLineTest{}
+static void run_http_invalid_request_line(Runner &runner) {
+    runner.start_test(test::nettests::make_test<HttpInvalidRequestLineTest>()
                        .set_options("backend", "http://nexa.polito.it/")
-                       .set_options("geoip_country_path", "GeoIP.dat")
-                       .set_options("geoip_asn_path", "GeoIPASNum.dat")
                        .on_log([](uint32_t, const char *s) {
                            (void)fprintf(stderr, "test #1: %s\n", s);
                        })
                        .runnable,
-                   [](Var<nettests::Runnable> test) {
+                   [](Var<Runnable> test) {
                        mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 
-static void run_dns_injection(nettests::Runner &runner) {
-    runner.start_test(nettests::DnsInjectionTest{}
+static void run_dns_injection(Runner &runner) {
+    runner.start_test(test::nettests::make_test<DnsInjectionTest>("hosts.txt")
                        .set_options("backend", "8.8.8.8:53")
-                       .set_options("geoip_country_path", "GeoIP.dat")
-                       .set_options("geoip_asn_path", "GeoIPASNum.dat")
-                       .set_input_filepath("test/fixtures/hosts.txt")
                        .on_log([](uint32_t, const char *s) {
                            (void)fprintf(stderr, "test #3: %s\n", s);
                        })
                        .runnable,
-                   [](Var<nettests::Runnable> test) {
+                   [](Var<Runnable> test) {
                        mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 
-static void run_tcp_connect(nettests::Runner &runner) {
-    runner.start_test(nettests::TcpConnectTest{}
+static void run_tcp_connect(Runner &runner) {
+    runner.start_test(test::nettests::make_test<TcpConnectTest>("hosts.txt")
                        .set_options("port", "80")
-                       .set_options("geoip_country_path", "GeoIP.dat")
-                       .set_options("geoip_asn_path", "GeoIPASNum.dat")
-                       .set_input_filepath("test/fixtures/hosts.txt")
                        .on_log([](uint32_t, const char *s) {
                            (void)fprintf(stderr, "test #4: %s\n", s);
                        })
                        .runnable,
-                   [](Var<nettests::Runnable> test) {
+                   [](Var<Runnable> test) {
                        mk::debug("test complete: %p", (void *)test.get());
                    });
 }
 
 TEST_CASE("The runner engine works as expected") {
 
-    nettests::Runner runner;
+    Runner runner;
 
     for (int i = 0; i < 4; ++i) {
         mk::debug("do another iteration of tests");
@@ -81,7 +70,7 @@ TEST_CASE("The runner engine works as expected") {
 }
 
 TEST_CASE("The destructor work as expected if the thread was already joined") {
-    nettests::Runner runner;
+    Runner runner;
     run_dns_injection(runner);
     run_dns_injection(runner);
     while (!runner.empty()) {
@@ -92,7 +81,7 @@ TEST_CASE("The destructor work as expected if the thread was already joined") {
 }
 
 TEST_CASE("Nothing strange happens if no thread is bound to Runner") {
-    nettests::Runner runner;
+    Runner runner;
     REQUIRE(runner.empty()); // Mainly to avoid unused variable warning
 }
 

--- a/test/nettests/tcp_connect.cpp
+++ b/test/nettests/tcp_connect.cpp
@@ -6,34 +6,21 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 TEST_CASE("Synchronous tcp-connect test") {
-    nettests::TcpConnectTest{}
+    test::nettests::make_test<TcpConnectTest>("hosts.txt")
         .set_options("port", "80")
-        .set_input_filepath("test/fixtures/hosts.txt")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
         .run();
 }
 
 TEST_CASE("Asynchronous tcp-connect test") {
-    bool done = false;
-    nettests::TcpConnectTest{}
-        .set_options("port", "80")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
-        .set_input_filepath("test/fixtures/hosts.txt")
-        .start([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<TcpConnectTest>("hosts.txt")
+            .set_options("port", "80")
+    );
 }
 
 #else

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -39,6 +39,7 @@ with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
     test.options["collector_base_url"] =
         mk::ooni::collector::testing_collector_url();
+    test.logger->set_verbosity(MK_LOG_INFO);
     lambda(test);
 }
 

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -1,0 +1,47 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifndef TEST_NETTESTS_UTILS_HPP
+#define TEST_NETTESTS_UTILS_HPP
+
+#include <measurement_kit/nettests.hpp>
+#include <measurement_kit/ooni.hpp>
+
+#include <chrono>
+#include <thread>
+
+namespace test {
+namespace nettests {
+
+template <typename T> mk::nettests::BaseTest make_test() {
+    return T{}
+        .set_options("geoip_country_path", "GeoIP.dat")
+        .set_options("geoip_asn_path", "GeoIPASNum.dat")
+        .set_verbosity(MK_LOG_INFO)
+        .set_options("collector_base_url",
+                      mk::ooni::collector::testing_collector_url());
+}
+
+template <typename T> mk::nettests::BaseTest make_test(std::string s) {
+    return make_test<T>().set_input_filepath("./test/fixtures/" + s);
+}
+
+static inline void run_async(mk::nettests::BaseTest test) {
+    volatile bool done = false;
+    test.start([&]() { done = true; });
+    do {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    } while (!done);
+}
+
+static inline void
+with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
+    mk::nettests::Runnable test;
+    test.options["collector_base_url"] =
+        mk::ooni::collector::testing_collector_url();
+    lambda(test);
+}
+
+} // namespace nettests
+} // namespace test
+#endif

--- a/test/nettests/web_connectivity.cpp
+++ b/test/nettests/web_connectivity.cpp
@@ -6,36 +6,24 @@
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
-#include <measurement_kit/nettests.hpp>
+#include "../nettests/utils.hpp"
 
-#include <chrono>
-#include <iostream>
-#include <thread>
-
-using namespace mk;
+using namespace mk::nettests;
 
 TEST_CASE("Synchronous web connectivity test") {
-    nettests::WebConnectivityTest{}
-        .set_options("backend", "https://a.collector.test.ooni.io:4444")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
+    test::nettests::make_test<WebConnectivityTest>("urls.txt")
+        .set_options("backend", "https://a.web-connectivity.th.ooni.io:4442")
         .set_options("nameserver", "8.8.8.8")
-        .set_input_filepath("test/fixtures/urls.txt")
         .run();
 }
 
 TEST_CASE("Asynchronous web-connectivity test") {
-    bool done = false;
-    nettests::WebConnectivityTest{}
-        .set_options("backend", "https://a.collector.test.ooni.io:4444")
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
-        .set_options("nameserver", "8.8.8.8")
-        .set_input_filepath("test/fixtures/urls.txt")
-        .start([&done]() { done = true; });
-    do {
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    } while (!done);
+    test::nettests::run_async(
+        test::nettests::make_test<WebConnectivityTest>("urls.txt")
+            .set_options("backend",
+                         "https://a.web-connectivity.th.ooni.io:4442")
+            .set_options("nameserver", "8.8.8.8")
+    );
 }
 
 #else


### PR DESCRIPTION
Basically always except in the regress tests. Refactor regress tests
a bit to make sure it is not an hell to keep them up to date.