### PR TITLE
test/net/connect.cpp: refactor to avoid global poller

### DIFF
--- a/build/valgrind/openssl.supp
+++ b/build/valgrind/openssl.supp
@@ -10,7 +10,7 @@
    fun:_ZN2mk8libevent11poller_loopIXadL_Z9event_newEEXadL_Z10event_freeEEXadL_Z9event_addEEXadL_Z19event_base_dispatchEEEEvNS_3VarI10event_baseEEPNS0_6PollerE
    fun:_ZN2mk8libevent6Poller4loopEv
    fun:_ZN2mk7Reactor23loop_with_initial_eventESt8functionIFvvEE
-   fun:_ZN2mk23loop_with_initial_eventESt8functionIFvvEENS_3VarINS_7ReactorEEE
-   fun:_ZL31____C_A_T_C_H____T_E_S_T____418v
+   fun:_ZL31____C_A_T_C_H____T_E_S_T____440v
    fun:_ZN5Catch8runTestsERKNS_3PtrINS_6ConfigEEE
+   fun:main
 }

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -29,14 +29,15 @@ struct bufferevent;
 static int fail(const char *, sockaddr *, int *) { return -1; }
 
 TEST_CASE("connect_base deals with evutil_parse_sockaddr_port error") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base<fail>("130.192.16.172", 80,
-                           [](Error e, bufferevent *b, double) {
+                           [=](Error e, bufferevent *b, double) {
                                REQUIRE(e);
                                REQUIRE(b == nullptr);
-                               break_loop();
+                               reactor->stop();
                            },
-                           3.14);
+                           3.14, reactor);
     });
 }
 
@@ -70,16 +71,17 @@ static int fail(bufferevent *, sockaddr *, int) { return -1; }
 
 TEST_CASE("connect_base deals with bufferevent_socket_connect error") {
     // Note: connectivity not required to run this test
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base<::evutil_parse_sockaddr_port, ::bufferevent_socket_new,
                      bufferevent_set_timeouts, fail>(
             "130.192.16.172", 80,
-            [](Error e, bufferevent *b, double) {
+            [=](Error e, bufferevent *b, double) {
                 REQUIRE(e);
                 REQUIRE(b == nullptr);
-                break_loop();
+                reactor->stop();
             },
-            3.14);
+            3.14, reactor);
     });
 }
 
@@ -89,13 +91,14 @@ static void success(std::string, int, Callback<Error, Var<Transport>> cb,
 }
 
 TEST_CASE("net::connect_many() correctly handles net::connect() success") {
+    Var<Reactor> reactor = Reactor::make();
     Var<ConnectManyCtx> ctx =
         connect_many_make("www.google.com", 80, 3,
                           [](Error err, std::vector<Var<Transport>> conns) {
                               REQUIRE(!err);
                               REQUIRE(conns.size() == 3);
                           },
-                          {}, Reactor::global(), Logger::global());
+                          {}, reactor, Logger::global());
     connect_many_impl<success>(ctx);
 }
 
@@ -105,13 +108,14 @@ static void fail(std::string, int, Callback<Error, Var<Transport>> cb, Settings,
 }
 
 TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
+    Var<Reactor> reactor = Reactor::make();
     Var<ConnectManyCtx> ctx =
         connect_many_make("www.google.com", 80, 3,
                           [](Error err, std::vector<Var<Transport>> conns) {
                               REQUIRE(err);
                               REQUIRE(conns.size() == 0);
                           },
-                          {}, Reactor::global(), Logger::global());
+                          {}, reactor, Logger::global());
     connect_many_impl<fail>(ctx);
 }
 
@@ -127,15 +131,16 @@ TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
 #ifdef ENABLE_INTEGRATION_TESTS
 
 TEST_CASE("connect_base works with ipv4") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base("130.192.16.172", 80,
-                     [](Error err, bufferevent *bev, double) {
+                     [=](Error err, bufferevent *bev, double) {
                          REQUIRE(!err);
                          REQUIRE(bev);
                          ::bufferevent_free(bev);
-                         break_loop();
+                         reactor->stop();
                      },
-                     3.14);
+                     3.14, reactor);
     });
 }
 
@@ -144,33 +149,36 @@ static bool check_error(Error err) {
 }
 
 TEST_CASE("connect_base works with ipv4 and closed port") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base("130.192.16.172", 81,
-                     [](Error err, bufferevent *bev, double) {
+                     [=](Error err, bufferevent *bev, double) {
                          REQUIRE(check_error(err));
                          REQUIRE(bev == nullptr);
-                         break_loop();
+                         reactor->stop();
                      },
-                     3.14);
+                     3.14, reactor);
     });
 }
 
 TEST_CASE("connect_base works with ipv4 and timeout") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base("130.192.16.172", 80,
-                     [](Error err, bufferevent *bev, double) {
+                     [=](Error err, bufferevent *bev, double) {
                          REQUIRE(err == TimeoutError());
                          REQUIRE(bev == nullptr);
-                         break_loop();
+                         reactor->stop();
                      },
-                     0.00001);
+                     0.00001, reactor);
     });
 }
 
 TEST_CASE("connect_base works with ipv6") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_base("2a00:1450:4001:801::1004", 80,
-                     [](Error err, bufferevent *bev, double) {
+                     [=](Error err, bufferevent *bev, double) {
                          if (err) {
                              REQUIRE(err);
                              REQUIRE(bev == nullptr);
@@ -179,187 +187,198 @@ TEST_CASE("connect_base works with ipv6") {
                              REQUIRE(bev);
                              ::bufferevent_free(bev);
                          }
-                         break_loop();
+                         reactor->stop();
                      },
-                     3.14);
+                     3.14, reactor);
     });
 }
 
 TEST_CASE("connect_first_of works with empty vector") {
+    Var<Reactor> reactor = Reactor::make();
     Var<ConnectResult> result(new ConnectResult);
-    loop_with_initial_event([=]() {
+    reactor->loop_with_initial_event([=]() {
         connect_first_of(result, 80,
-                         [](std::vector<Error> errors, bufferevent *bev) {
+                         [=](std::vector<Error> errors, bufferevent *bev) {
                              REQUIRE(errors.size() == 0);
                              REQUIRE(bev == nullptr);
-                             break_loop();
+                             reactor->stop();
                          },
-                         {{"net/timeout", 3.14}});
+                         {{"net/timeout", 3.14}}, reactor);
     });
 }
 
 TEST_CASE("connect_first_of works when all connect fail") {
+    Var<Reactor> reactor = Reactor::make();
     Var<ConnectResult> result(new ConnectResult);
     result->resolve_result.addresses = {
         "130.192.16.172", "130.192.16.172", "130.192.16.172",
     };
-    loop_with_initial_event([&]() {
+    reactor->loop_with_initial_event([&result, reactor]() {
         connect_first_of(
             result,
             80,
-            [](std::vector<Error> errors, bufferevent *bev) {
+            [=](std::vector<Error> errors, bufferevent *bev) {
                 REQUIRE(errors.size() == 3);
                 for (Error err : errors) {
                     REQUIRE(err == TimeoutError());
                 }
                 REQUIRE(bev == nullptr);
-                break_loop();
+                reactor->stop();
             },
-            {{"net/timeout", 0.00001}});
+            {{"net/timeout", 0.00001}}, reactor);
     });
 }
 
 TEST_CASE("connect_first_of works when a connect succeeds") {
+    Var<Reactor> reactor = Reactor::make();
     Var<ConnectResult> result(new ConnectResult);
     result->resolve_result.addresses = {
         "130.192.16.172", "130.192.16.172", "130.192.16.172",
     };
-    loop_with_initial_event([&]() {
+    reactor->loop_with_initial_event([&result, reactor]() {
         connect_first_of(
             result,
             80,
-            [](std::vector<Error> errors, bufferevent *bev) {
+            [=](std::vector<Error> errors, bufferevent *bev) {
                 REQUIRE(errors.size() == 1);
                 for (Error err : errors) {
                     REQUIRE(err == NoError());
                 }
                 REQUIRE(bev);
                 ::bufferevent_free(bev);
-                break_loop();
+                reactor->stop();
             },
-            {{"net/timeout", 3.14}});
+            {{"net/timeout", 3.14}}, reactor);
     });
 }
 
 TEST_CASE("resolve_hostname works with IPv4 address") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         std::string hostname = "130.192.16.172";
-        resolve_hostname(hostname, [hostname](ResolveHostnameResult r) {
+        resolve_hostname(hostname, [=](ResolveHostnameResult r) {
             REQUIRE(r.inet_pton_ipv4);
             REQUIRE(r.addresses.size() == 1);
             REQUIRE(r.addresses[0] == hostname);
-            break_loop();
-        });
+            reactor->stop();
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("resolve_hostname works with IPv6 address") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         std::string hostname = "2a00:1450:400d:807::200e";
-        resolve_hostname(hostname, [hostname](ResolveHostnameResult r) {
+        resolve_hostname(hostname, [=](ResolveHostnameResult r) {
             REQUIRE(r.inet_pton_ipv6);
             REQUIRE(r.addresses.size() == 1);
             REQUIRE(r.addresses[0] == hostname);
-            break_loop();
-        });
+            reactor->stop();
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("resolve_hostname works with domain") {
-    loop_with_initial_event([]() {
-        resolve_hostname("google.com", [](ResolveHostnameResult r) {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
+        resolve_hostname("google.com", [=](ResolveHostnameResult r) {
             REQUIRE(not r.inet_pton_ipv4);
             REQUIRE(not r.inet_pton_ipv6);
             REQUIRE(not r.ipv4_err);
             REQUIRE(not r.ipv6_err);
             // At least one IPv4 and one IPv6 addresses
             REQUIRE(r.addresses.size() > 1);
-            break_loop();
-        });
+            reactor->stop();
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("stress resolve_hostname with invalid address and domain") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         // Pass input that is neither invalid IPvX nor valid domain
-        resolve_hostname("192.1688.antani", [](ResolveHostnameResult r) {
+        resolve_hostname("192.1688.antani", [=](ResolveHostnameResult r) {
             REQUIRE(not r.inet_pton_ipv4);
             REQUIRE(not r.inet_pton_ipv6);
             REQUIRE(r.ipv4_err);
             REQUIRE(r.ipv6_err);
             REQUIRE(r.addresses.size() == 0);
-            break_loop();
-        });
+            reactor->stop();
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("connect() works with valid IPv4") {
-    loop_with_initial_event([]() {
-        connect_logic("www.google.com", 80, [](Error e, Var<ConnectResult> r) {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
+        connect_logic("www.google.com", 80, [=](Error e, Var<ConnectResult> r) {
             REQUIRE(!e);
             REQUIRE(r->connected_bev != nullptr);
             ::bufferevent_free(r->connected_bev);
-            break_loop();
-        });
+            reactor->stop();
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("connect() fails when port is closed or filtered") {
-    loop_with_initial_event([]() {
-        connect_logic("www.google.com", 81, [](Error e, Var<ConnectResult> r) {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
+        connect_logic("www.google.com", 81, [=](Error e, Var<ConnectResult> r) {
             REQUIRE(e);
             REQUIRE(r->connected_bev == nullptr);
-            break_loop();
-        });
+            reactor->stop();
+        }, {{"net/timeout", 1.0}}, reactor);
     });
 }
 
 TEST_CASE("connect() fails when setting an invalid dns") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_logic("www.google.com", 80,
-                      [](Error e, Var<ConnectResult> r) {
+                      [=](Error e, Var<ConnectResult> r) {
                           REQUIRE(e);
                           REQUIRE(r->connected_bev == nullptr);
-                          break_loop();
+                          reactor->stop();
                       },
                       {{"dns/nameserver", "8.8.8.1"},
                        {"dns/timeout", 0.001},
-                       {"dns/attempts", 1}});
+                       {"dns/attempts", 1}},
+                      reactor);
     });
 }
 
 TEST_CASE("net::connect_many() works as expected") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect_many("www.google.com", 80, 3,
-                     [](Error error, std::vector<Var<Transport>> conns) {
+                     [=](Error error, std::vector<Var<Transport>> conns) {
                          REQUIRE(!error);
                          REQUIRE(conns.size() == 3);
                          Var<int> n(new int(0));
                          for (auto conn : conns) {
                              REQUIRE(static_cast<bool>(conn));
-                             conn->close([n]() {
+                             conn->close([=]() {
                                  if (++(*n) >= 3) {
-                                     break_loop();
+                                     reactor->stop();
                                  }
                              });
                          }
-                     });
+                     }, {}, reactor);
     });
 }
 
 TEST_CASE("net::connect() works with a custom reactor") {
     // Note: this is how Portolan uses measurement-kit
-    set_verbosity(MK_LOG_DEBUG);
     Var<Reactor> reactor = Reactor::make();
     auto ok = false;
     reactor->loop_with_initial_event([&]() {
         connect("nexa.polito.it", 22,
                 [&](Error error, Var<Transport> txp) {
                     if (error) {
-                        reactor->break_loop();
+                        reactor->stop();
                         return;
                     }
-                    txp->close([&]() { reactor->break_loop(); });
+                    txp->close([&]() { reactor->stop(); });
                     ok = true;
                 },
                 {}, reactor, Logger::global());
@@ -368,8 +387,9 @@ TEST_CASE("net::connect() works with a custom reactor") {
 }
 
 TEST_CASE("net::connect() can connect to open port") {
-    loop_with_initial_event([]() {
-        connect("www.kernel.org", 80, [](Error error, Var<Transport> txp) {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
+        connect("www.kernel.org", 80, [=](Error error, Var<Transport> txp) {
             REQUIRE(!error);
             Var<ConnectResult> cr = error.context.as<ConnectResult>();
             REQUIRE(cr);
@@ -377,16 +397,16 @@ TEST_CASE("net::connect() can connect to open port") {
             REQUIRE(!cr->resolve_result.inet_pton_ipv6);
             REQUIRE(cr->resolve_result.addresses.size() > 0);
             REQUIRE(cr->connected_bev);
-            txp->close([]() { break_loop(); });
-        });
+            txp->close([=]() { reactor->stop(); });
+        }, {}, reactor);
     });
 }
 
 TEST_CASE("net::connect() can connect to ssl port") {
-    loop_with_initial_event([]() {
-        set_verbosity(MK_LOG_DEBUG);
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect("nexa.polito.it", 443,
-                [](Error error, Var<Transport> txp) {
+                [=](Error error, Var<Transport> txp) {
                     REQUIRE(!error);
                     Var<ConnectResult> cr = error.context.as<ConnectResult>();
                     REQUIRE(cr);
@@ -394,57 +414,62 @@ TEST_CASE("net::connect() can connect to ssl port") {
                     REQUIRE(!cr->resolve_result.inet_pton_ipv6);
                     REQUIRE(cr->resolve_result.addresses.size() > 0);
                     REQUIRE(cr->connected_bev);
-                    txp->close([]() { break_loop(); });
+                    txp->close([=]() { reactor->stop(); });
                 },
                 {{"net/ssl", true},
-                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}},
+                reactor);
     });
 }
 
 TEST_CASE("net::connect() ssl fails when presented an expired certificate") {
-    loop_with_initial_event([]() {
-        set_verbosity(MK_LOG_DEBUG);
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect("expired.badssl.com", 443,
-                [](Error error, Var<Transport> ) {
+                [=](Error error, Var<Transport> ) {
                     REQUIRE(error);
-                    break_loop();
+                    reactor->stop();
                 },
                 {{"net/ssl", true},
-                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}},
+                reactor);
     });
 }
 
 TEST_CASE("net::connect() ssl fails when presented a certificate with the "
           "wrong hostname") {
-    loop_with_initial_event([]() {
-        set_verbosity(MK_LOG_DEBUG);
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect("wrong.host.badssl.com", 443,
-                [](Error error, Var<Transport>) {
+                [=](Error error, Var<Transport>) {
                     REQUIRE(error);
-                    break_loop();
+                    reactor->stop();
                 },
                 {{"net/ssl", true},
-                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}},
+                reactor);
     });
 }
 
 TEST_CASE("net::connect() ssl works when using SNI") {
-    loop_with_initial_event([]() {
-        set_verbosity(MK_LOG_DEBUG);
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect("sha256.badssl.com", 443,
-                [](Error error, Var<Transport> txp) {
+                [=](Error error, Var<Transport> txp) {
                     REQUIRE(!error);
-                    txp->close([]() { break_loop(); });
+                    txp->close([=]() { reactor->stop(); });
                 },
                 {{"net/ssl", true},
-                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}});
+                 {"net/ca_bundle_path", "test/fixtures/certs.pem"}},
+                reactor);
     });
 }
 
 TEST_CASE("net::connect() works in case of error") {
-    loop_with_initial_event([]() {
+    Var<Reactor> reactor = Reactor::make();
+    reactor->loop_with_initial_event([=]() {
         connect("nexa.polito.it", 81,
-                [](Error error, Var<Transport>) {
+                [=](Error error, Var<Transport>) {
                     REQUIRE(error);
                     Var<ConnectResult> cr = error.context.as<ConnectResult>();
                     REQUIRE(cr);
@@ -452,9 +477,10 @@ TEST_CASE("net::connect() works in case of error") {
                     REQUIRE(!cr->resolve_result.inet_pton_ipv6);
                     REQUIRE(cr->resolve_result.addresses.size() > 0);
                     REQUIRE(!cr->connected_bev);
-                    break_loop();
+                    reactor->stop();
                 },
-                {{"net/timeout", 5.0}});
+                {{"net/timeout", 5.0}},
+                reactor);
     });
 }
 


### PR DESCRIPTION
This way, a test failing does not cause the failure of all the
following tests and we can see easily what has failed.

Related to #919