### PR TITLE
connect: start fixing IPv6 addresses

### DIFF
--- a/doc/api/net/connect.md
+++ b/doc/api/net/connect.md
@@ -114,6 +114,9 @@ were successful.
 Most MeasurementKit functions receive the `reactor` argument before the `logger`
 argument, but `connect()` uses the opposite convention.
 
+As of MeasurementKit v0.4, `connect()` does not correctly deal with scoped
+link-local IPv6 addresses (e.g. `fe80::1%lo0`).
+
 # HISTORY
 
 The `connect` submodule appeared in MeasurementKit 0.2.0.


### PR DESCRIPTION
* connect_impl: fix treatment of IPv6 addresses

I believe, this diff alone should be enough to fix the issue
reported in measurement-kit/ooniprobe-ios#61.

I have noticed that also from my home (where there is no IPv6
connectivity) the code fails because it cannot even parse such
addresses. With this diff applied, instead, it fails because
of a `host_unreachable` error, which makes more sense to me (of
course, to see the real error, all of #1098 is required).

* connect: document scoped link-local IPv6 addrs bug

I was temped to fix this as part of this pull request but then
noticed it would have taken a bit of refactoring that instead I
would like to perform separately.

* connect: add warnings for each error case

We can (and will) do better by mapping errors, but, for now, let's
start by adding basic warning messages that end up in logs.