### PR TITLE
net: start exposing network errors

### DIFF
--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -34,11 +34,55 @@ MK_DEFINE_ERR(MK_ERR_NET(20), SslInvalidHostnameError, "ssl_invalid_hostname")
 MK_DEFINE_ERR(MK_ERR_NET(21), SslError, "ssl_error")
 MK_DEFINE_ERR(MK_ERR_NET(22), NotEnoughDataError, "")
 MK_DEFINE_ERR(MK_ERR_NET(23), MissingCaBundlePathError, "")
-MK_DEFINE_ERR(MK_ERR_NET(24), BrokenPipeError, "")
+/* Error code not used; was the old BrokenPipeError */
 MK_DEFINE_ERR(MK_ERR_NET(25), SslNewError, "")
 MK_DEFINE_ERR(MK_ERR_NET(26), SslCtxNewError, "")
 MK_DEFINE_ERR(MK_ERR_NET(27), SslCtxLoadVerifyLocationsError, "")
 MK_DEFINE_ERR(MK_ERR_NET(28), SslCtxLoadVerifyMemError, "")
+
+/*
+ * Maps std::errc from <system_error>
+ *
+ * Note that EAGAIN is not handled here but in the .cpp file
+ * and gets mapped to EWOULDBLOCK unconditionally like most modern
+ * Unix systems already do in their <errno.h> or <sys/errno.h>.
+ */
+#define MK_NET_ERRORS_XX                                                   \
+    XX(29, AddressFamilyNotSupportedError, address_family_not_supported)   \
+    XX(30, AddressInUseError, address_in_use)                              \
+    XX(31, AddressNotAvailableError, address_not_available)                \
+    XX(32, AlreadyConnectedError, already_connected)                       \
+    XX(33, BadAddressError, bad_address)                                   \
+    XX(34, BadFileDescriptorError, bad_file_descriptor)                    \
+    XX(35, BrokenPipeError, broken_pipe)                                   \
+    XX(36, ConnectionAbortedError, connection_aborted)                     \
+    XX(37, ConnectionAlreadyInProgressError,                               \
+       connection_already_in_progress)                                     \
+    XX(38, ConnectionRefusedError, connection_refused)                     \
+    XX(39, ConnectionResetError, connection_reset)                         \
+    XX(40, DestinationAddressRequiredError, destination_address_required)  \
+    XX(41, HostUnreachableError, host_unreachable)                         \
+    XX(42, InterruptedError, interrupted)                                  \
+    XX(43, InvalidArgumentError, invalid_argument)                         \
+    XX(44, MessageSizeError, message_size)                                 \
+    XX(45, NetworkDownError, network_down)                                 \
+    XX(46, NetworkResetError, network_reset)                               \
+    XX(47, NetworkUnreachableError, network_unreachable)                   \
+    XX(48, NoBufferSpaceError, no_buffer_space)                            \
+    XX(49, NoProtocolOptionError, no_protocol_option)                      \
+    XX(50, NotASocketError, not_a_socket)                                  \
+    XX(51, NotConnectedError, not_connected)                               \
+    XX(52, OperationWouldBlockError, operation_would_block)                \
+    XX(53, PermissionDeniedError, permission_denied)                       \
+    XX(54, ProtocolErrorError, protocol_error)                             \
+    XX(55, ProtocolNotSupportedError, protocol_not_supported)              \
+    XX(56, TimedOutError, timed_out)                                       \
+    XX(57, WrongProtocolTypeError, wrong_protocol_type)
+
+#define XX(_code_, _name_, _descr_)                                        \
+    MK_DEFINE_ERR(MK_ERR_NET(_code_), _name_, #_descr_)
+MK_NET_ERRORS_XX
+#undef XX
 
 } // namespace net
 } // namespace mk

--- a/src/libmeasurement_kit/libevent/connection.cpp
+++ b/src/libmeasurement_kit/libevent/connection.cpp
@@ -3,13 +3,14 @@
 // information on the copying conditions.
 
 #include "../libevent/connection.hpp"
+#include "../net/utils.hpp"
 
 #include <measurement_kit/net.hpp>
 
 #include <event2/buffer.h>
 #include <event2/dns.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <new>
 
 extern "C" {
@@ -75,12 +76,14 @@ void Connection::handle_event_(short what) {
         return;
     }
 
+    Error sys_error = net::map_errno(errno);
+    logger->warn("Got error: %s", sys_error.as_ooni_error().c_str());
+    // TODO: we should propagate this error updating code below:
+
     if (errno == EPIPE) {
         emit_error(BrokenPipeError());
         return;
     }
-
-    // TODO: Here we need to map more network errors
 
     emit_error(SocketError());
 }

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -30,7 +30,7 @@ void mk_bufferevent_on_event(bufferevent *bev, short what, void *ptr) {
     } else if ((what & BEV_EVENT_TIMEOUT) != 0) {
         (*cb)(mk::net::TimeoutError(), bev);
     } else {
-        // TODO: here we should map to the actual error that occurred
+        // Note: the actual error is mapped in the callback
         (*cb)(mk::net::NetworkError(), bev);
     }
     delete cb;

--- a/src/libmeasurement_kit/net/utils.cpp
+++ b/src/libmeasurement_kit/net/utils.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <deque>
 #include <sstream>
+#include <system_error>
 
 #include <event2/util.h>
 
@@ -238,6 +239,30 @@ Error disable_nagle(socket_t sockfd) {
         return SocketError();
     }
     return NoError();
+}
+
+Error map_errno(int error_code) {
+    if (error_code == 0) {
+        return ValueError(); /* We don't expect this to happen */
+    }
+    /*
+     * In most Unix systems they are the same error. For the few systems in
+     * which they are not (and note I don't even know whether measurement-kit
+     * does compile on these systems), force EAGAIN to be EWOULDBLOCK.
+     *
+     * (Yes, EWOULDBLOCK is a BSD-ism, but I like it more.)
+     */
+    if (error_code == EAGAIN) {
+        error_code = EWOULDBLOCK;
+        // FALLTHROUGH
+    }
+#define XX(_code_, _name_, _descr_)                                            \
+    if (std::make_error_condition(std::errc::_descr_).value() == error_code) { \
+        return _name_();                                                       \
+    }
+    MK_NET_ERRORS_XX
+#undef XX
+    return GenericError();
 }
 
 } // namespace net

--- a/src/libmeasurement_kit/net/utils.hpp
+++ b/src/libmeasurement_kit/net/utils.hpp
@@ -51,6 +51,8 @@ std::string unreverse_ipv4(std::string s);
 
 Error disable_nagle(socket_t);
 
+Error map_errno(int);
+
 } // namespace net
 } // namespace mk
 #endif

--- a/test/net/utils.cpp
+++ b/test/net/utils.cpp
@@ -2,6 +2,8 @@
 // Measurement-kit is free software. See AUTHORS and LICENSE for more
 // information on the copying conditions.
 
+#include <cerrno>
+
 #define CATCH_CONFIG_MAIN
 #include "../src/libmeasurement_kit/ext/catch.hpp"
 
@@ -225,5 +227,39 @@ TEST_CASE("Verify that invalid input is rejected") {
             mk::net::unreverse_ipv6(
                 "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0."
                 "2.") == "");
+    }
+}
+
+TEST_CASE("map_errno() works as expected") {
+    SECTION("Make sure that 0 maps on mk::ValueError") {
+        REQUIRE(mk::net::map_errno(0) == mk::ValueError());
+    }
+
+    SECTION("Make sure that EAGAIN is correctly handled") {
+        REQUIRE(mk::net::map_errno(EAGAIN) ==
+                mk::net::OperationWouldBlockError());
+    }
+
+    SECTION("Make sure that mapped errors map to correct classes") {
+#define XX(_code_, _name_, _descr_)                                            \
+    {                                                                          \
+        auto err_cond = std::make_error_condition(std::errc::_descr_);         \
+        int code = err_cond.value();                                           \
+        REQUIRE(mk::net::map_errno(code) == mk::net::_name_());                \
+    }
+        MK_NET_ERRORS_XX
+#undef XX
+    }
+
+    SECTION("Make sure some errors maps by passing the definition directly") {
+        REQUIRE(mk::net::map_errno(EWOULDBLOCK) ==
+                mk::net::OperationWouldBlockError());
+        REQUIRE(mk::net::map_errno(EINTR) == mk::net::InterruptedError());
+        REQUIRE(mk::net::map_errno(ENOBUFS)
+                == mk::net::NoBufferSpaceError());
+    }
+
+    SECTION("Make sure that unmapped errors map to mk::GenericError") {
+        REQUIRE(mk::net::map_errno(ENOENT) == mk::GenericError());
     }
 }


### PR DESCRIPTION
Extracted from #1098. Adds enough verbosity to understand from the logs what is going on, but avoids changing the behaviour or changing (or refactoring) the code.