### PR TITLE
connect: support also ipv6 link local with scope

### DIFF
--- a/build/valgrind/openssl.supp
+++ b/build/valgrind/openssl.supp
@@ -10,7 +10,7 @@
    fun:_ZN2mk8libevent11poller_loopIXadL_Z9event_newEEXadL_Z10event_freeEEXadL_Z9event_addEEXadL_Z19event_base_dispatchEEEEvNS_3VarI10event_baseEEPNS0_6PollerE
    fun:_ZN2mk8libevent6Poller4loopEv
    fun:_ZN2mk7Reactor23loop_with_initial_eventESt8functionIFvvEE
-   fun:_ZL31____C_A_T_C_H____T_E_S_T____440v
+   fun:_ZL31____C_A_T_C_H____T_E_S_T____*
    fun:_ZN5Catch8runTestsERKNS_3PtrINS_6ConfigEEE
    fun:main
 }

--- a/doc/api/net/utils.md
+++ b/doc/api/net/utils.md
@@ -11,9 +11,10 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 namespace mk {
 namespace net {
 
-struct Endpoint {
+class Endpoint {
+  public:
     std::string hostname;
-    uint16_t port;
+    uint16_t port = 0;
 };
 
 bool is_ipv4_addr(std::string s);
@@ -22,6 +23,20 @@ bool is_ip_addr(std::string s);
 
 ErrorOr<Endpoint> parse_endpoint(std::string s, uint16_t default_port);
 std::string serialize_endpoint(Endpoint e);
+
+Error make_sockaddr(
+        std::string address,
+        std::string port,
+        sockaddr_storage *ss,
+        socklen_t *len
+) noexcept;
+
+Error make_sockaddr(
+        std::string address,
+        uint16_t port,
+        sockaddr_storage *ss,
+        socklen_t *len
+) noexcept;
 
 }}
 ```
@@ -51,6 +66,11 @@ address, then the square brackets MAY be omitted.
 
 The `serialize_endpoint` function transforms the endpoint `e` into
 a string. As such, it is the dual operation of `parse_endpoint`.
+
+The `make_sockaddr` functions fills a `sockaddr_storage` structure and its
+length from a string possibly containing an IPv4 or IPv6 address and a
+port (either as a string or as an integer). The return value is `NoError`
+on success and an error on failure.
 
 # BUGS
 

--- a/include/measurement_kit/net/utils.hpp
+++ b/include/measurement_kit/net/utils.hpp
@@ -9,9 +9,10 @@
 namespace mk {
 namespace net {
 
-struct Endpoint {
+class Endpoint {
+  public:
     std::string hostname;
-    uint16_t port;
+    uint16_t port = 0;
 };
 
 bool is_ipv4_addr(std::string s);
@@ -20,6 +21,20 @@ bool is_ip_addr(std::string s);
 
 ErrorOr<Endpoint> parse_endpoint(std::string s, uint16_t def_port);
 std::string serialize_endpoint(Endpoint);
+
+Error make_sockaddr(
+        std::string address,
+        std::string port,
+        sockaddr_storage *storage,
+        socklen_t *len
+) noexcept;
+
+Error make_sockaddr(
+        std::string address,
+        uint16_t port,
+        sockaddr_storage *storage,
+        socklen_t *len
+) noexcept;
 
 } // namespace net
 } // namespace mk

--- a/src/libmeasurement_kit/net/connect_impl.hpp
+++ b/src/libmeasurement_kit/net/connect_impl.hpp
@@ -24,7 +24,13 @@ void mk_bufferevent_on_event(bufferevent *, short, void *);
 namespace mk {
 namespace net {
 
-template <MK_MOCK(evutil_parse_sockaddr_port), MK_MOCK(bufferevent_socket_new),
+// Proxy required because `make_sockaddr` is overloaded
+static Error make_sockaddr_proxy(std::string s, std::string p,
+                                 sockaddr_storage *ss, socklen_t *len) {
+    return make_sockaddr(s, p, ss, len);
+}
+
+template <MK_MOCK(make_sockaddr_proxy), MK_MOCK(bufferevent_socket_new),
           MK_MOCK(bufferevent_set_timeouts),
           MK_MOCK(bufferevent_socket_connect)>
 void connect_base(std::string address, int port,
@@ -32,27 +38,25 @@ void connect_base(std::string address, int port,
                   double timeout = 10.0,
                   Var<Reactor> reactor = Reactor::global(),
                   Var<Logger> logger = Logger::global()) {
-    logger->debug("connect_base %s:%d", address.c_str(), port);
 
     std::string endpoint = [&]() {
         Endpoint endpoint;
         endpoint.hostname = address;
-        endpoint.port = port;
+        endpoint.port = (uint16_t)port; /* XXX We should change the prototype */
         return serialize_endpoint(endpoint);
     }();
+    logger->debug("connect_base %s", endpoint.c_str());
 
-    sockaddr_storage storage;
-    sockaddr *saddr = (sockaddr *)&storage;
-    int salen = sizeof storage;
-
-    // XXX: as we have seen in #915, the following function does not deal with
-    // IPv6 scoped link local addresses. We can fix this by copying from the
-    // way in which such problem is solved in libevent/dns_utils.hpp.
-    if (evutil_parse_sockaddr_port(endpoint.c_str(), saddr, &salen) != 0) {
+    std::string port_string = std::to_string(port);
+    sockaddr_storage storage = {};
+    socklen_t salen = 0;
+    Error err = make_sockaddr_proxy(address, port_string, &storage, &salen);
+    if (err != NoError()) {
         logger->warn("cannot parse endpoint: '%s'", endpoint.c_str());
-        cb(GenericError(), nullptr, 0.0);
+        cb(err, nullptr, 0.0);
         return;
     }
+    sockaddr *saddr = (sockaddr *)&storage;
 
     /*
      *  Rationale for deferring callbacks:

--- a/src/libmeasurement_kit/net/utils.cpp
+++ b/src/libmeasurement_kit/net/utils.cpp
@@ -18,14 +18,48 @@
 namespace mk {
 namespace net {
 
+static Error make_sockaddr_ipv4(std::string s, uint16_t p, sockaddr_storage *ss,
+                                socklen_t *solen) noexcept {
+    sockaddr_storage ss4 = {};
+    sockaddr_in *sin4 = (sockaddr_in *)&ss4;
+    if (inet_pton(AF_INET, s.c_str(), &sin4->sin_addr) != 1) {
+        return ValueError();
+    }
+    sin4->sin_family = AF_INET;
+    sin4->sin_port = htons(p);
+    if (ss != nullptr) {
+        *ss = ss4;
+    }
+    if (solen != nullptr) {
+        *solen = sizeof(*sin4);
+    }
+    return NoError();
+}
+
+static Error make_sockaddr_ipv6(std::string s, uint16_t p, sockaddr_storage *ss,
+                                socklen_t *solen) noexcept {
+    sockaddr_storage ss6 = {};
+    sockaddr_in6 *sin6 = (sockaddr_in6 *)&ss6;
+    if (inet_pton(AF_INET6, s.c_str(), &sin6->sin6_addr) != 1) {
+        return ValueError();
+    }
+    sin6->sin6_family = AF_INET6;
+    sin6->sin6_port = htons(p);
+    if (ss != nullptr) {
+        *ss = ss6;
+    }
+    if (solen != nullptr) {
+        *solen = sizeof(*sin6);
+    }
+    return NoError();
+}
+
 bool is_ipv4_addr(std::string s) {
-    sockaddr_in sin;
-    return inet_pton(AF_INET, s.c_str(), &sin.sin_addr) == 1;
+    return make_sockaddr_ipv4(s, 80, nullptr, nullptr) == NoError();
 }
 
 bool is_ipv6_addr(std::string s) {
-    sockaddr_in6 sin6;
-    return inet_pton(AF_INET6, s.c_str(), &sin6.sin6_addr) == 1;
+    return make_sockaddr_ipv6(s, 80, nullptr, nullptr) == NoError();
 }
 
 bool is_ip_addr(std::string s) {
@@ -113,6 +147,10 @@ int storage_init(sockaddr_storage *storage, socklen_t *salen, int _family,
         logger->warn("utils:storage_init: invalid port");
         return -1;
     }
+
+    /*
+     * TODO: merge this code with the above helpers.
+     */
 
     memset(storage, 0, sizeof(*storage));
     switch (_family) {
@@ -263,6 +301,36 @@ Error map_errno(int error_code) {
     MK_NET_ERRORS_XX
 #undef XX
     return GenericError();
+}
+
+Error make_sockaddr(std::string s, std::string p, sockaddr_storage *ss,
+                    socklen_t *solen) noexcept {
+    auto maybe_pn = lexical_cast_noexcept<long long>(p);
+    if (!maybe_pn) {
+        return maybe_pn.as_error();
+    }
+    /*
+     * I initially thought that lexical_cast would have been able to detect
+     * overflow caused by negative numbers being feed to it when requested to
+     * parse a positive only integer. It seems it's not always like to.
+     *
+     * See <https://travis-ci.org/measurement-kit/measurement-kit/jobs/194992117#L2007>
+     */
+    if (*maybe_pn < 0 || *maybe_pn > 65535) {
+        return ValueError();
+    }
+    // Static cast good because above we make sure it is feasible
+    return make_sockaddr(s, static_cast<uint16_t>(*maybe_pn), ss, solen);
+}
+
+Error make_sockaddr(std::string s, uint16_t p, sockaddr_storage *ss,
+                    socklen_t *solen) noexcept {
+
+    Error err = make_sockaddr_ipv4(s, p, ss, solen);
+    if (err != NoError()) {
+        err = make_sockaddr_ipv6(s, p, ss, solen);
+    }
+    return err;
 }
 
 } // namespace net

--- a/src/libmeasurement_kit/net/utils.cpp
+++ b/src/libmeasurement_kit/net/utils.cpp
@@ -312,7 +312,7 @@ Error make_sockaddr(std::string s, std::string p, sockaddr_storage *ss,
     /*
      * I initially thought that lexical_cast would have been able to detect
      * overflow caused by negative numbers being feed to it when requested to
-     * parse a positive only integer. It seems it's not always like to.
+     * parse a positive only integer. It seems it's not always like this.
      *
      * See <https://travis-ci.org/measurement-kit/measurement-kit/jobs/194992117#L2007>
      */
@@ -325,7 +325,6 @@ Error make_sockaddr(std::string s, std::string p, sockaddr_storage *ss,
 
 Error make_sockaddr(std::string s, uint16_t p, sockaddr_storage *ss,
                     socklen_t *solen) noexcept {
-
     Error err = make_sockaddr_ipv4(s, p, ss, solen);
     if (err != NoError()) {
         err = make_sockaddr_ipv6(s, p, ss, solen);

--- a/test/net/utils.cpp
+++ b/test/net/utils.cpp
@@ -297,7 +297,8 @@ TEST_CASE("make_sockaddr() works as expected") {
     }
 
     SECTION("With numeric port: it deals with invalid address") {
-        check_for_error("antani", "22");
+        auto err = mk::net::make_sockaddr("antani", 22, nullptr, nullptr);
+        REQUIRE(err == mk::ValueError());
     }
 
     SECTION("With numeric port: it works with valid IPv4") {

--- a/test/net/utils.cpp
+++ b/test/net/utils.cpp
@@ -263,3 +263,68 @@ TEST_CASE("map_errno() works as expected") {
         REQUIRE(mk::net::map_errno(ENOENT) == mk::GenericError());
     }
 }
+
+TEST_CASE("make_sockaddr() works as expected") {
+    auto check_for_error = [](std::string address, std::string port) {
+        auto err = mk::net::make_sockaddr(address, port, nullptr, nullptr);
+        REQUIRE(err == mk::ValueError());
+    };
+
+    SECTION("With string port: we deal with invalid port") {
+        check_for_error("8.8.8.8", "antani");
+    }
+
+    SECTION("With string port: we deal with negative port") {
+        check_for_error("8.8.8.8", "-1");
+    }
+
+    SECTION("With string port: we deal with overflow") {
+        check_for_error("8.8.8.8", "65536");
+    }
+
+    SECTION("With string port: it works with a valid port") {
+        sockaddr_storage ss = {};
+        socklen_t sslen = 0;
+        auto err = mk::net::make_sockaddr("8.8.8.8", "22", &ss, &sslen);
+        REQUIRE(err == mk::NoError());
+        REQUIRE(sslen == sizeof(sockaddr_in));
+        sockaddr_in *sin4 = (sockaddr_in *)&ss;
+        REQUIRE(sin4->sin_family == AF_INET);
+        REQUIRE(sin4->sin_port == htons(22));
+        char x[INET_ADDRSTRLEN];
+        REQUIRE(inet_ntop(AF_INET, &sin4->sin_addr, x, sizeof(x)) != nullptr);
+        REQUIRE(std::string{"8.8.8.8"} == x);
+    }
+
+    SECTION("With numeric port: it deals with invalid address") {
+        check_for_error("antani", "22");
+    }
+
+    SECTION("With numeric port: it works with valid IPv4") {
+        sockaddr_storage ss = {};
+        socklen_t sslen = 0;
+        auto err = mk::net::make_sockaddr("8.8.8.8", 22, &ss, &sslen);
+        REQUIRE(err == mk::NoError());
+        REQUIRE(sslen == sizeof(sockaddr_in));
+        sockaddr_in *sin4 = (sockaddr_in *)&ss;
+        REQUIRE(sin4->sin_family == AF_INET);
+        REQUIRE(sin4->sin_port == htons(22));
+        char x[INET_ADDRSTRLEN];
+        REQUIRE(inet_ntop(AF_INET, &sin4->sin_addr, x, sizeof(x)) != nullptr);
+        REQUIRE(std::string{"8.8.8.8"} == x);
+    }
+
+    SECTION("With numeric port: it works with valid IPv6") {
+        sockaddr_storage ss = {};
+        socklen_t sslen = 0;
+        auto err = mk::net::make_sockaddr("fe80::1", 22, &ss, &sslen);
+        REQUIRE(err == mk::NoError());
+        REQUIRE(sslen == sizeof(sockaddr_in6));
+        sockaddr_in6 *sin6 = (sockaddr_in6 *)&ss;
+        REQUIRE(sin6->sin6_family == AF_INET6);
+        REQUIRE(sin6->sin6_port == htons(22));
+        char x[INET6_ADDRSTRLEN];
+        REQUIRE(inet_ntop(AF_INET6, &sin6->sin6_addr, x, sizeof(x)) != nullptr);
+        REQUIRE(std::string{"fe80::1"} == x);
+    }
+}


### PR DESCRIPTION
Run log on a box where `nc -vl fe80::1%lo0 8080`:

```
$ ./measurement_kit net_connect -vvp 8080 fe80::1%lo0
[D] resolve_hostname: fe80::1%lo0
[D] resolve_hostname: is valid ipv6
[D] connect_first_of begin
[D] connect_base [fe80::1%lo0]:8080
[D] connect() in progress...
[D] connect time: 0.000344
[D] connect_first_of success
```