### PR TITLE
http: fix EOF-implies-end-of-body logic

### DIFF
--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -9,7 +9,7 @@
 namespace mk {
 namespace net {
 
-MK_DEFINE_ERR(MK_ERR_NET(0), EofError, "")
+MK_DEFINE_ERR(MK_ERR_NET(0), EofError, "eof_error")
 MK_DEFINE_ERR(MK_ERR_NET(1), TimeoutError, "generic_timeout_error")
 /* Unused: MK_ERR_NET(2) */
 MK_DEFINE_ERR(MK_ERR_NET(3), ConnectFailedError, "connect_error")

--- a/src/libmeasurement_kit/http/request.cpp
+++ b/src/libmeasurement_kit/http/request.cpp
@@ -151,6 +151,9 @@ void request_recv_response(Var<Transport> txp,
             // Calling parser->on_eof() could trigger parser->on_end() and
             // we don't want this function to call ->emit_error()
             *prevent_emit = true;
+            // Assume there was no error. The parser will tell us if that
+            // is true (it was in final state) or false.
+            err = NoError();
             try {
                 logger->debug("Now passing EOF to parser");
                 parser->eof();

--- a/src/measurement_kit/cmdline/http_request.cpp
+++ b/src/measurement_kit/cmdline/http_request.cpp
@@ -76,7 +76,7 @@ int main(const char *, int argc, char **argv) {
             body,
             [](Error error, Var<http::Response> response) {
                 if (error) {
-                    std::cout << "Error: " << error.code << "\n";
+                    std::cout << "Error: " << error.explain() << "\n";
                     break_loop();
                     return;
                 }


### PR DESCRIPTION
We had logic to specially deal with EOF to signal end-of-body, however
the code was not resetting error after EOF resulting in inability to
process redirects where bodies were terminated by EOF.

This causes measurement-kit/ooniprobe-ios#79 reported by @willscott.

For the records, I also saw a failure for `hushmail.com` but I flagged
it as a transient network error. However, when also @willscott reported
the same error, it was clear this was something more than I thought.

While there, give a meaningful name to error 1000.

Also, since there is an open pull request refactoring HTTP, and
specifically I refer to measurement-kit/measurement-kit#1041, it
is wise to make sure this error is not re-introduced there.