### PR TITLE
Fix gitlab on stable by using yakkety

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,11 @@
 valgrind-gcc:
-  image: ubuntu:xenial
+  image: ubuntu:yakkety
   script: ./build/docker/script/run valgrind-gcc
   only:
     - master
     - stable
 valgrind-clang:
-  image: ubuntu:xenial
+  image: ubuntu:yakkety
   script: ./build/docker/script/run valgrind-clang
   only:
     - master


### PR DESCRIPTION
We have seen that the Valgrind that ships with xenial produces too
many errors with measurement_kit, so use yakkety instead.