### PR TITLE
ooni/templates http: include all request/responses

### DIFF
--- a/test/ooni/templates.cpp
+++ b/test/ooni/templates.cpp
@@ -107,16 +107,15 @@ TEST_CASE("http requests template works as expected") {
                         REQUIRE(root.is_object());
                         requests = root["requests"];
                         REQUIRE(requests.is_array());
-                        REQUIRE((requests.size() == 2));
+                        REQUIRE(requests.size() == 2);
                         /* First request (should be ok) */
                         req = requests[0];
                         REQUIRE(req.is_object());
                         REQUIRE((req["failure"] == nullptr));
                         REQUIRE((req["response"]["body"].is_string()));
                         REQUIRE((req["response"]["body"].size() > 0));
-                        // FIXME: response line not saved
-                        /*REQUIRE((req["response"]["response_line"] ==
-                                 "HTTP/1.1 200 OK"));*/
+                        REQUIRE((req["response"]["response_line"] ==
+                                 "HTTP/1.1 200 OK"));
                         int code = req["response"]["code"];
                         REQUIRE((code == 200));
                         REQUIRE((req["response"]["headers"].is_object()));


### PR DESCRIPTION
- make sure we include all requests and responses in OONI templates
  so that we see redirections in the results

- reduce the number of cases where issueing an HTTP request has
  as result an error coupled with a `nullptr` response

- fix regress to be compatible with both libevent 2.0 and 2.1

Closes #1143.