### PR TITLE
Make Transport more OO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,11 +37,15 @@ MK_AM_DISABLE_TRACEROUTE
 # See above comment
 AC_PROG_CXX
 
-# Must set -pthread before testing for -levent_pthreads
 if test "`uname`" != "Darwin"; then
+  # Must set -pthread before testing for -levent_pthreads
   CFLAGS="$CFLAGS -pthread"
   CXXFLAGS="$CXXFLAGS -pthread"
   LDFLAGS="$LDFLAGS -pthread"
+else
+  # On my macOS, /usr/local is not added automatically
+  CPPFLAGS="$CPPFLAGS -I/usr/local/include"
+  LDFLAGS="$LDFLAGS -L/usr/local/lib"
 fi
 
 MK_AM_CHECK_LIBC_FUNCS

--- a/example/libevent/discard.cpp
+++ b/example/libevent/discard.cpp
@@ -43,7 +43,8 @@ int main(int argc, char **argv) {
 
     loop_with_initial_event([&addr, &port]() {
         listen4(addr, port, [](bufferevent *bev) {
-            Var<Transport> transport(Connection::make(bev));
+            Var<Transport> transport(Connection::make(bev,
+                Reactor::global(), Logger::global()));
             transport->on_data([transport](Buffer) {
                 /* nothing */
             });

--- a/example/libevent/listen.cpp
+++ b/example/libevent/listen.cpp
@@ -43,7 +43,8 @@ int main(int argc, char **argv) {
 
     loop_with_initial_event([&addr, &port]() {
         listen4(addr, port, [](bufferevent *bev) {
-            Var<Transport> transport = Connection::make(bev);
+            Var<Transport> transport = Connection::make(bev,
+                Reactor::global(), Logger::global());
             transport->on_data([transport](Buffer data) {
                 transport->write(data);
             });

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -9,19 +9,24 @@
 namespace mk {
 namespace net {
 
-class Transport {
+class TransportEmitter {
   public:
+    virtual ~TransportEmitter();
+
     virtual void emit_connect() = 0;
     virtual void emit_data(Buffer buf) = 0;
     virtual void emit_flush() = 0;
     virtual void emit_error(Error err) = 0;
 
-    virtual ~Transport() {}
-
     virtual void on_connect(Callback<>) = 0;
     virtual void on_data(Callback<Buffer>) = 0;
     virtual void on_flush(Callback<>) = 0;
     virtual void on_error(Callback<Error>) = 0;
+};
+
+class TransportRecorder {
+  public:
+    virtual ~TransportRecorder();
 
     virtual void record_received_data() = 0;
     virtual void dont_record_received_data() = 0;
@@ -30,18 +35,48 @@ class Transport {
     virtual void record_sent_data() = 0;
     virtual void dont_record_sent_data() = 0;
     virtual Buffer &sent_data() = 0;
+};
+
+class TransportWriter {
+  public:
+    virtual ~TransportWriter();
+    virtual void write(const void *, size_t) = 0;
+    virtual void write(std::string) = 0;
+    virtual void write(Buffer) = 0;
+};
+
+class TransportSocks5 {
+  public:
+    virtual ~TransportSocks5();
+    virtual std::string socks5_address() = 0;
+    virtual std::string socks5_port() = 0;
+};
+
+class TransportPollable {
+  public:
+    virtual ~TransportPollable();
 
     virtual void set_timeout(double) = 0;
     virtual void clear_timeout() = 0;
 
-    virtual void write(const void *, size_t) = 0;
-    virtual void write(std::string) = 0;
-    virtual void write(Buffer) = 0;
-
     virtual void close(Callback<>) = 0;
 
-    virtual std::string socks5_address() = 0;
-    virtual std::string socks5_port() = 0;
+    /*
+     * Writing is stopped automatically when the send buffer is empty
+     * and, when this happens, the FLUSH event is emitted.
+     */
+    virtual void start_reading() = 0;
+    virtual void stop_reading() = 0;
+    virtual void start_writing() = 0;
+};
+
+class Transport : public TransportEmitter,
+                  public TransportRecorder,
+                  public TransportWriter,
+                  public TransportSocks5,
+                  public TransportPollable {
+  public:
+    virtual ~Transport();
 };
 
 /*

--- a/src/libmeasurement_kit/libevent/connection.cpp
+++ b/src/libmeasurement_kit/libevent/connection.cpp
@@ -82,7 +82,7 @@ void Connection::handle_event_(short what) {
 }
 
 Connection::Connection(bufferevent *buffev, Var<Reactor> reactor, Var<Logger> logger)
-        : Emitter(logger), reactor(reactor) {
+        : EmitterBase(reactor, logger) {
     this->bev = buffev;
 
     // The following makes this non copyable and non movable.
@@ -101,7 +101,7 @@ void Connection::close(std::function<void()> cb) {
     on_flush(nullptr);
     on_error(nullptr);
     bufferevent_setcb(bev, nullptr, nullptr, nullptr, nullptr);
-    disable_read();
+    stop_reading();
 
     close_cb = cb;
     reactor->call_soon([=]() {

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -196,7 +196,7 @@ void connect(std::string address, int port,
              Callback<Error, Var<Transport>> callback, Settings settings,
              Var<Reactor> reactor, Var<Logger> logger) {
     if (settings.find("net/dumb_transport") != settings.end()) {
-        callback(NoError(), Var<Transport>(new Emitter(logger)));
+        callback(NoError(), Var<Transport>(new Emitter(reactor, logger)));
         return;
     }
     if (settings.find("net/socks5_proxy") != settings.end()) {

--- a/src/libmeasurement_kit/net/emitter.cpp
+++ b/src/libmeasurement_kit/net/emitter.cpp
@@ -7,6 +7,7 @@
 namespace mk {
 namespace net {
 
+EmitterBase::~EmitterBase() {}
 Emitter::~Emitter() {}
 
 } // namespace net

--- a/src/libmeasurement_kit/net/socks5.cpp
+++ b/src/libmeasurement_kit/net/socks5.cpp
@@ -10,8 +10,8 @@
 namespace mk {
 namespace net {
 
-Socks5::Socks5(Var<Transport> tx, Settings s, Var<Reactor>, Var<Logger> lp)
-    : Emitter(lp), settings(s), conn(tx),
+Socks5::Socks5(Var<Transport> tx, Settings s, Var<Reactor> r, Var<Logger> lp)
+    : Emitter(r, lp), settings(s), conn(tx),
       proxy_address(settings["net/socks5_address"]),
       proxy_port(settings["net/socks5_port"]) {
     socks5_connect_();

--- a/src/libmeasurement_kit/net/socks5.hpp
+++ b/src/libmeasurement_kit/net/socks5.hpp
@@ -11,17 +11,21 @@
 namespace mk {
 namespace net {
 
+/*
+ * TODO: to continue refactoring here we should probably inherit from
+ * emitter-base rather than emitter. I am not doing it as part of this
+ * diff, because that is more than hotfix refactoring.
+ */
 class Socks5 : public Emitter {
   public:
     // Constructor that attaches to already existing transport
-    Socks5(Var<Transport>, Settings, Var<Reactor> = Reactor::global(),
-            Var<Logger> = Logger::global());
+    Socks5(Var<Transport>, Settings, Var<Reactor>, Var<Logger>);
 
     void set_timeout(double timeout) override { conn->set_timeout(timeout); }
 
     void clear_timeout() override { conn->clear_timeout(); }
 
-    void do_send(Buffer data) override { conn->write(data); }
+    void start_writing() override { conn->write(output_buff); }
 
     void close(std::function<void()> callback) override {
         isclosed = true;

--- a/src/libmeasurement_kit/net/transport.cpp
+++ b/src/libmeasurement_kit/net/transport.cpp
@@ -11,6 +11,13 @@
 namespace mk {
 namespace net {
 
+TransportEmitter::~TransportEmitter() {}
+TransportRecorder::~TransportRecorder() {}
+TransportWriter::~TransportWriter() {}
+TransportSocks5::~TransportSocks5() {}
+TransportPollable::~TransportPollable() {}
+Transport::~Transport() {}
+
 void write(Var<Transport> txp, Buffer buf, Callback<Error> cb) {
     txp->on_flush([=]() {
         txp->on_flush(nullptr);

--- a/test/ndt/protocol.cpp
+++ b/test/ndt/protocol.cpp
@@ -299,7 +299,7 @@ static void eof_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
 
 TEST_CASE("wait_close() deals with EofError") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     protocol::wait_close_impl<eof_error>(
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
@@ -311,7 +311,7 @@ static void timeout_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
 
 TEST_CASE("wait_close() deals with TimeoutError") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     protocol::wait_close_impl<timeout_error>(
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
@@ -323,7 +323,7 @@ static void mocked_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
 
 TEST_CASE("wait_close() deals with an error") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     protocol::wait_close_impl<mocked_error>(
         ctx, [](Error err) { REQUIRE(err == WaitingCloseError()); });
 }
@@ -335,7 +335,7 @@ static void no_error(Var<Transport>, Var<Buffer>, Callback<Error> cb,
 
 TEST_CASE("wait_close() deals with a extra data") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     protocol::wait_close_impl<no_error>(
         ctx, [](Error err) { REQUIRE(err == DataAfterLogoutError()); });
 }
@@ -350,7 +350,7 @@ TEST_CASE("disconnect_and_callback_impl() without transport") {
 // To increase coverage
 TEST_CASE("disconnect_and_callback_impl() with transport") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     ctx->callback = [](Error e) { REQUIRE(e == MockedError()); };
     protocol::disconnect_and_callback_impl(ctx, MockedError());
 }

--- a/test/ndt/test_meta.cpp
+++ b/test/ndt/test_meta.cpp
@@ -75,7 +75,7 @@ TEST_CASE("run() deals with first format_test_msg() error") {
 
 TEST_CASE("run() deals with second format_test_msg() error") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     test_meta::run_impl<test_prepare, test_start, success, fail>(
         ctx,
         [](Error err) { REQUIRE(err == SerializingClientApplicationError()); });
@@ -83,7 +83,7 @@ TEST_CASE("run() deals with second format_test_msg() error") {
 
 TEST_CASE("run() deals with third format_test_msg() error") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     test_meta::run_impl<test_prepare, test_start, success, success, fail>(
         ctx, [](Error err) { REQUIRE(err == SerializingFinalMetaError()); });
 }
@@ -94,7 +94,7 @@ static void fail(Var<Context>, Buffer, Callback<Error> cb) {
 
 TEST_CASE("run() deals with write error") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         fail>(
         ctx, [](Error err) { REQUIRE(err == WritingMetaError()); });
@@ -104,7 +104,7 @@ static void success(Var<Context>, Buffer, Callback<Error> cb) { cb(NoError()); }
 
 TEST_CASE("run() deals with third read() error") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         success, fail>(
         ctx, [](Error err) { REQUIRE(err == ReadingTestFinalizeError()); });
@@ -112,7 +112,7 @@ TEST_CASE("run() deals with third read() error") {
 
 TEST_CASE("run() deals with unexpected message on third read") {
     Var<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter);
+    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         success, unexpected>(
         ctx, [](Error err) { REQUIRE(err == NotTestFinalizeError()); });

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -88,8 +88,8 @@ TEST_CASE("connect_base deals with bufferevent_socket_connect error") {
 }
 
 static void success(std::string, int, Callback<Error, Var<Transport>> cb,
-                    Settings, Var<Reactor>, Var<Logger> logger) {
-    cb(NoError(), Var<Transport>(new Emitter(logger)));
+                    Settings, Var<Reactor> r, Var<Logger> logger) {
+    cb(NoError(), Var<Transport>(new Emitter(r, logger)));
 }
 
 TEST_CASE("net::connect_many() correctly handles net::connect() success") {

--- a/test/net/emitter.cpp
+++ b/test/net/emitter.cpp
@@ -12,14 +12,14 @@ using namespace mk::net;
 
 TEST_CASE("The record-received-data feature works") {
     SECTION("By default recording is disabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.emit_data(Buffer("foobar"));
         REQUIRE(transport.received_data().length() == 0);
     }
 
     SECTION("Recording works correctly when enabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.emit_data(Buffer("foobar"));
@@ -27,7 +27,7 @@ TEST_CASE("The record-received-data feature works") {
     }
 
     SECTION("Recording can also be disabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.emit_data(Buffer("foobar"));
@@ -37,7 +37,7 @@ TEST_CASE("The record-received-data feature works") {
     }
 
     SECTION("Recording input data does not modify input data") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.on_data([](Buffer data) { REQUIRE(data.read() == "foo"); });
@@ -48,19 +48,25 @@ TEST_CASE("The record-received-data feature works") {
 
 class Helper : public Emitter {
   public:
-    void do_send(Buffer data) override { REQUIRE(data.read() == "foo"); }
+    void start_writing() override {
+        REQUIRE(output_buff.read() == "foo");
+    }
+    Helper(Var<Reactor> r, Var<Logger> l) : Emitter(r, l) {}
+    ~Helper() override;
 };
+
+Helper::~Helper() {}
 
 TEST_CASE("The record-sent-data feature works") {
     SECTION("By default recording is disabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.write("foobar");
         REQUIRE(transport.sent_data().length() == 0);
     }
 
     SECTION("Recording works correctly when enabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foobar");
@@ -68,7 +74,7 @@ TEST_CASE("The record-sent-data feature works") {
     }
 
     SECTION("Recording can also be disabled") {
-        Emitter emitter;
+        Emitter emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foobar");
@@ -78,7 +84,7 @@ TEST_CASE("The record-sent-data feature works") {
     }
 
     SECTION("Recording output data does not modify output data") {
-        Helper emitter;
+        Helper emitter(Reactor::global(), Logger::global());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foo");

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -47,10 +47,9 @@ class MockConnection : public Emitter, public NonCopyable, public NonMovable {
   private:
     bool isclosed = false;
     Callback<> close_cb;
-    Var<Reactor> reactor = Reactor::global();
     Var<Transport> self;
 
-    MockConnection() {}
+    MockConnection() : Emitter(Reactor::global(), Logger::global()) {}
 };
 
 void MockConnection::close(Callback<> cb) {


### PR DESCRIPTION
- Use a number of interfaces to clearly indicate what are the
  different functionality that a Transport must implement

- Specify more clearly the interface between the generic network
  code and the specific libevent (for now) code

- Distinguish between the base skeleton of an Emitter and the
  actual Emitter class sometimes used for testing