### PR TITLE
net: move most close logic in emitter

### DIFF
--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -22,6 +22,8 @@ class TransportEmitter {
     virtual void on_data(Callback<Buffer>) = 0;
     virtual void on_flush(Callback<>) = 0;
     virtual void on_error(Callback<Error>) = 0;
+
+    virtual void close(Callback<>) = 0;
 };
 
 class TransportRecorder {
@@ -59,7 +61,7 @@ class TransportPollable {
     virtual void set_timeout(double) = 0;
     virtual void clear_timeout() = 0;
 
-    virtual void close(Callback<>) = 0;
+    virtual void shutdown() = 0;
 
     /*
      * Writing is stopped automatically when the send buffer is empty

--- a/src/libmeasurement_kit/libevent/connection.cpp
+++ b/src/libmeasurement_kit/libevent/connection.cpp
@@ -90,20 +90,11 @@ Connection::Connection(bufferevent *buffev, Var<Reactor> reactor, Var<Logger> lo
                       handle_libevent_event, this);
 }
 
-void Connection::close(std::function<void()> cb) {
-    if (isclosed) {
-        throw std::runtime_error("already closed");
+void Connection::shutdown() {
+    if (close_pending) {
+        return; // Just for extra safety
     }
-    isclosed = true;
-
-    on_connect(nullptr);
-    on_data(nullptr);
-    on_flush(nullptr);
-    on_error(nullptr);
     bufferevent_setcb(bev, nullptr, nullptr, nullptr, nullptr);
-    stop_reading();
-
-    close_cb = cb;
     reactor->call_soon([=]() {
         this->self = nullptr;
     });

--- a/src/libmeasurement_kit/libevent/connection.hpp
+++ b/src/libmeasurement_kit/libevent/connection.hpp
@@ -30,12 +30,12 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
         if (bev != nullptr) {
             bufferevent_free(bev);
         }
-        if (close_cb) {
-            close_cb();
-        }
     }
 
     void set_timeout(double timeout) override {
+        if (close_pending) {
+            return;
+        }
         timeval tv, *tvp = mk::timeval_init(&tv, timeout);
         bufferevent *underlying = bufferevent_get_underlying(this->bev);
         if (underlying) {
@@ -71,7 +71,7 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
         }
     }
 
-    void close(Callback<>) override;
+    void shutdown() override;
 
     void handle_event_(short);
     void handle_read_();

--- a/src/libmeasurement_kit/net/emitter.cpp
+++ b/src/libmeasurement_kit/net/emitter.cpp
@@ -7,7 +7,25 @@
 namespace mk {
 namespace net {
 
-EmitterBase::~EmitterBase() {}
+EmitterBase::~EmitterBase() {
+    if (close_cb) {
+        close_cb();
+    }
+}
+
+void EmitterBase::close(Callback<> cb) {
+    if (close_pending) {
+        return;
+    }
+    shutdown();
+    close_pending = true;  // Must be after shutdown()
+    on_connect(nullptr);
+    on_data(nullptr);
+    on_flush(nullptr);
+    on_error(nullptr);
+    close_cb = cb;
+}
+
 Emitter::~Emitter() {}
 
 } // namespace net

--- a/src/libmeasurement_kit/net/socks5.hpp
+++ b/src/libmeasurement_kit/net/socks5.hpp
@@ -12,9 +12,10 @@ namespace mk {
 namespace net {
 
 /*
- * TODO: to continue refactoring here we should probably inherit from
- * emitter-base rather than emitter. I am not doing it as part of this
- * diff, because that is more than hotfix refactoring.
+ * TODO: now that events are not emitted after close, we can safely
+ * refactor this as a factory function, because we do not need to
+ * worry about whether the `on_connect` callback has invoked `close`
+ * before emitting `DATA` with extra data that we may have read.
  */
 class Socks5 : public Emitter {
   public:


### PR DESCRIPTION
This refactoring makes the whole close logic model more consistent
and in particular it ensures that, after close, we do not emit events,
which will help to refactor socks5 as a factory.

While doing that, update documentation and especially make sure
we list limitations of the current model under BUGS.