### PR TITLE
Fix "unknown_failure 3" bug

### DIFF
--- a/build/valgrind/openssl.supp
+++ b/build/valgrind/openssl.supp
@@ -2,7 +2,6 @@
    <probably-false-positive-warning-on-travis>
    Memcheck:Addr4
    fun:tls_check_name
-   fun:_ZZN2mk3net11connect_sslEP11buffereventP6ssl_stSsSt8functionIFvNS_5ErrorES2_EENS_3VarINS_7ReactorEEENS9_INS_6LoggerEEEENKUlS6_S2_E_clES6_S2_
    fun:_ZNSt17_Function_handlerIFvN2mk5ErrorEP11buffereventEZNS0_3net11connect_sslES3_P6ssl_stSsSt8functionIS4_ENS0_3VarINS0_7ReactorEEENSA_INS0_6LoggerEEEEUlS1_S3_E_E9_M_invokeERKSt9_Any_dataOS1_OS3_
    fun:mk_bufferevent_on_event
    fun:bufferevent_run_deferred_callbacks_locked
@@ -12,4 +11,5 @@
    fun:_ZN2mk7Reactor23loop_with_initial_eventESt8functionIFvvEE
    fun:_ZL31____C_A_T_C_H____T_E_S_T____*
    fun:_ZN5Catch8runTestsERKNS_3PtrINS_6ConfigEEE
+   fun:main
 }

--- a/doc/api/net/connect.md
+++ b/doc/api/net/connect.md
@@ -89,11 +89,9 @@ were successful.
 
 # BUGS
 
-Most MeasurementKit functions receive the `reactor` argument before the `logger`
-argument, but `connect()` uses the opposite convention.
-
-As of MeasurementKit v0.4, `connect()` does not correctly deal with scoped
-link-local IPv6 addresses (e.g. `fe80::1%lo0`).
+As of MeasurementKit v0.4, `connect()` does not implement SSLv2 and SSLv3,
+therefore secure connection will fail with sites that use such deprecated
+versions of the protocol.
 
 # HISTORY
 

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -34,7 +34,20 @@ void mk_bufferevent_on_event(bufferevent *bev, short what, void *ptr) {
     } else if ((what & BEV_EVENT_TIMEOUT) != 0) {
         (*cb)(mk::net::TimeoutError(), bev);
     } else {
-        (*cb)(mk::net::map_errno(errno), bev);
+        mk::Error err;
+        /*
+         * If there's not network error, assume it's going to be a SSL error,
+         * which is reasonable because currently we only use this function
+         * as callback for either socket or SSL connect.
+         */
+        if (errno != 0) {
+            err = mk::net::map_errno(errno);
+        } else {
+            long ssl_err = bufferevent_get_openssl_error(bev);
+            std::string s = ERR_error_string(ssl_err, nullptr);
+            err = mk::net::SslError(s);
+        }
+        (*cb)(err, bev);
     }
     delete cb;
 }
@@ -139,19 +152,18 @@ void connect_ssl(bufferevent *orig_bev, ssl_st *ssl, std::string hostname,
             [cb, logger, hostname](Error err, bufferevent *bev) {
                 int hostname_validate_err = 0;
 
-                logger->debug("connect ssl... callback");
+                logger->debug("connect ssl... callback (error: %d)", err.code);
                 ssl_st *ssl = bufferevent_openssl_get_ssl(bev);
 
                 if (err) {
-                    logger->debug("error in connection.");
-                    if (err == mk::net::NetworkError()) {
-                        long ssl_err = bufferevent_get_openssl_error(bev);
-                        err = SslError(ERR_error_string(ssl_err, nullptr));
-                    }
+                    std::string s = err.explain();
+                    logger->debug("error in connection: %s", s.c_str());
                     bufferevent_free(bev);
                     cb(err, nullptr);
                     return;
                 }
+
+                logger->debug("SSL version: %s", SSL_get_version(ssl));
 
                 long verify_err = SSL_get_verify_result(ssl);
                 if (verify_err != X509_V_OK) {


### PR DESCRIPTION
1. it turns out the new code to map to errno returned ValueError when
   errno was equal to zero, which happens in the connect() path in case
   of SSL error, however the code receiving the error code expected to
   receive NetworkError

2. we were using TLSv1 as method, under the expectation that it covers
   all above TLSv1, which is wrong; SSLv23 should be used instead, coupled
   with disabling SSLv2 and SSLv3 that are deprecated (actually SSLv2 is
   disabled by default but I wanted to be very explicit in new code)