### PR TITLE
Fix embarassing mk::endswith() bug

### DIFF
--- a/src/libmeasurement_kit/common/utils.cpp
+++ b/src/libmeasurement_kit/common/utils.cpp
@@ -154,8 +154,16 @@ bool startswith(std::string s, std::string p) {
     return s.find(p) == 0;
 }
 
+/*-
+ *     0 1 2 3 4 5 6
+ * s: |f|o|o|b|a|r|
+ * p:       |b|a|r|
+ *           0 1 2 3
+ *
+ * s.size() - p.size() = 3
+ */
 bool endswith(std::string s, std::string p) {
-    return s.rfind(p) != std::string::npos;
+    return s.size() >= p.size() ? s.rfind(p) == (s.size() - p.size()) : false;
 }
 
 } // namespace mk

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -320,6 +320,9 @@ TEST_CASE("mk::startswith() works as expected") {
     SECTION("For s longer than p") {
         REQUIRE(!!mk::startswith("antani", "ant"));
     }
+    SECTION("For p present in s but not at s's beginning") {
+        REQUIRE(!mk::startswith("antani", "nta"));
+    }
 }
 
 TEST_CASE("mk::endswith() works as expected") {
@@ -337,5 +340,9 @@ TEST_CASE("mk::endswith() works as expected") {
     }
     SECTION("For s longer than p") {
         REQUIRE(!!mk::endswith("antanix", "nix"));
+    }
+    // #TrueStory: this has been an embarassing bug
+    SECTION("For p present in s but not at s's end") {
+        REQUIRE(!mk::endswith("antanix", "tan"));
     }
 }


### PR DESCRIPTION
My eyes are still bleeding after I noticed what I did initially
commit to find end of string, not to mention how I did fail to
provide a solid regress case for catching that.

![2d6ee8c39c1dd4f8af6f8278127e7f47](https://cloud.githubusercontent.com/assets/337298/23824699/6b0adce8-067b-11e7-873f-710458989b46.jpg)
