### PR TITLE
http::Response: init numbers to know value

### DIFF
--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -119,9 +119,9 @@ struct Response {
     Var<Request> request;
     Var<Response> previous;
     std::string response_line;
-    unsigned short http_major;
-    unsigned short http_minor;
-    unsigned int status_code;
+    unsigned short http_major = 0; // Initialize to know value
+    unsigned short http_minor = 0; // Initialize to know value
+    unsigned int status_code = 0;  // Initialize to know value
     std::string reason;
     Headers headers;
     std::string body;


### PR DESCRIPTION
Previously, numbers need not to be initialized because we were returning
a response only when we successfully received one.

However, recently we started returning non-nullptr responses also on error,
providing how much information as we could.

Still, some assumptions that held before are not true after that change.

So, for example, as we've seen [in a recently failed travis-ci build](
https://travis-ci.org/measurement-kit/measurement-kit/jobs/210072026#L1980),
having http::Response numeric fields not initialized can lead to
undefined behavior, as reported by lovely Valgrind.

The fix is as simple as setting these fields to a known value.

Another question, however, would be how come that we have fields that
are not initialized but no error has been reported by parser.

That is quite simple actually. This can happen if we receive EOF as soon
as we connect. More specifically, this is what would happen:

0. [A response object is allocated but not fully initialized, and handlers for data and EOF are registered](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/request.cpp#L123)

1. [EOF is emitted](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/libevent/connection.cpp#L70)

2. EOF is handled, [the error is cleared](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/request.cpp#L156), and then the parser's `eof()` method is invoked

3. [`eof()` calls `parser_execute()` with empty input](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/response_parser.hpp#L50)

4. in turn, [this calls `http_parser_execute()` with empty input](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/response_parser.hpp#L173)

5. [since input is empty and state is initial, zero is returned](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/ext/http_parser.c#L668)

6. [the remainder of the `execute()` method continues smoothly because zero is also the number of bytes to parse](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/response_parser.hpp#L177)

7. [the allocated-but-not-fully-initialized Response is passed to the callback](https://github.com/measurement-kit/measurement-kit/blob/297be71b43f1cafea5042e36ac8439de3ee15608/src/libmeasurement_kit/http/request.cpp#L171)

This is a bug that we should probably deal with separately from the one
fixed by the current diff.