### PR TITLE
Fix unknown_error_3009 bug

### DIFF
--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -744,4 +744,20 @@ TEST_CASE("http::redirect() works as expected") {
                                "http://b.org/b")
                     ->str() == "http://b.org/b");
     }
+    SECTION("When location is a relative URL") {
+        REQUIRE(http::redirect(*http::parse_url_noexcept("http://a.org/f"), "g")
+                    ->str() == "http://a.org/f/g");
+        REQUIRE(
+            http::redirect(*http::parse_url_noexcept("http://a.org/f/"), "g")
+                ->str() == "http://a.org/f/g");
+        /*
+         * Explicitly make sure that the old query is cleared.
+         */
+        REQUIRE(
+            http::redirect(*http::parse_url_noexcept("https://a.org/f?x"), "g")
+                ->str() == "https://a.org/f/g");
+        REQUIRE(http::redirect(*http::parse_url_noexcept("https://a.org/f?x"),
+                               "g?h")
+                    ->str() == "https://a.org/f/g?h");
+    }
 }


### PR DESCRIPTION
To this end, we need to add code for the case where the redirection is
towards a relative, rather than absolute, path.

As said in a comment, I thought this should not happen, but we've seen
cases in the wild where it does, so here we are with a patch.

While there, make use of mk::startswith() and mk::endswith() for
additional clarity.