### PR TITLE
Fix report/entry.hpp w/ new NDK, nlohmann::json

### DIFF
--- a/src/libmeasurement_kit/report/entry.cpp
+++ b/src/libmeasurement_kit/report/entry.cpp
@@ -25,10 +25,23 @@ namespace report {
     return entry;
 }
 
+Entry &Entry::operator=(std::initializer_list<nlohmann::json> t) {
+    nlohmann::json::operator=(t);
+    return *this;
+}
+
 void Entry::push_back(Entry value) {
     try {
         nlohmann::json::push_back(value);
-    } catch (std::domain_error &) {
+    } catch (const std::domain_error &) {
+        throw JsonDomainError();
+    }
+}
+
+void Entry::push_back(std::initializer_list<nlohmann::json> j) {
+    try {
+        nlohmann::json::push_back(j);
+    } catch (const std::domain_error &) {
         throw JsonDomainError();
     }
 }
@@ -41,12 +54,12 @@ Entry Entry::parse(const std::string &s) {
   return static_cast<Entry>(nlohmann::json::parse(s));
 }
 
-bool Entry::operator==(std::nullptr_t right) {
-    return static_cast<nlohmann::json &>(*this) == right;
+bool Entry::operator==(std::nullptr_t right) const noexcept {
+    return static_cast<const nlohmann::json &>(*this) == right;
 }
 
-bool Entry::operator!=(std::nullptr_t right) {
-    return static_cast<nlohmann::json &>(*this) != right;
+bool Entry::operator!=(std::nullptr_t right) const noexcept {
+    return static_cast<const nlohmann::json &>(*this) != right;
 }
 
 } // namespace report


### PR DESCRIPTION
This diff, which costed me more fatigue than it seems, stops using
the constructor of `nlohmann::json` for implementing `report::Entry`,
because of the following reasons:

1. the latest version of the NDK fails to build `report::Entry`
   with this interestingly not-so-clear error:

> In file included from .../include/measurement_kit/report/report.hpp:8:
> .../include/measurement_kit/report/entry.hpp:16:27: error: recursive
>     evaluation of default argument
>   using nlohmann::json::json;

2. upgrading to the latest version (2.1.1) of nlohmann::json breaks
   `report::Entry` build in several places

Instead, with this diff applied (and with further small tweaks for 2.1.1),
I have seen both NDK and with-v2.1.1 builds terminating, including at
least a build using Valgrind:

>   https://travis-ci.org/measurement-kit/measurement-kit/builds/210762213

It's still unclear whether we should crank minor after this diff is
applied to `stable` or whether we can consider this a non-API-changing
change considering that code using `Entry` does not require changes
once this diff has been applied. I'll think at this later.