### PR TITLE
Only run coveralls if we know the token

### DIFF
--- a/build/docker/spec/coveralls
+++ b/build/docker/spec/coveralls
@@ -22,7 +22,8 @@ debian_deps="$debian_deps wget"
 pip_deps="$pip_deps cpp-coveralls"
 
 subr_finalize() {
-    $HOME/.local/bin/coveralls                                             \
+    if [ "$COVERALLS_REPO_TOKEN" != "" ]; then
+        $HOME/.local/bin/coveralls                                         \
                                --gcov-options '\-lp'                       \
                                --build-root .                              \
                                --exclude include/measurement_kit/ext       \
@@ -31,5 +32,6 @@ subr_finalize() {
                                --exclude src/measurement_kit               \
                                --exclude example                           \
                                --exclude third_party                       \
-      > /dev/null;
+            > /dev/null;
+    fi
 }


### PR DESCRIPTION
Otherwise the catch is that opening pull requests from non team
members will always fail the build because of missing token.

See during #1141.