### PR TITLE
Allow writing report on the stdout

### DIFF
--- a/doc/api/report/file_reporter.md
+++ b/doc/api/report/file_reporter.md
@@ -34,6 +34,9 @@ class FileReporter : public BaseReporter {
 The `FileReporter` class is a `BaseReporter` that writes the report onto the
 file passed as first argument of the `make` factory.
 
+If the file passed as first argument is `-` then the report will be
+written on the standard output rather than on a file named `-`.
+
 A report file will consist of zero or more entries. Each entry is a JSON
 document serialized on a single line of text. Newlines could either be `\n`
 or `\r\n`.

--- a/src/libmeasurement_kit/report/file_reporter.cpp
+++ b/src/libmeasurement_kit/report/file_reporter.cpp
@@ -7,7 +7,7 @@
 namespace mk {
 namespace report {
 
-static Error map_error(std::ofstream &file) {
+static Error map_error(std::ostream &file) {
     if (file.eof()) {
         return ReportEofError();
     }
@@ -28,6 +28,10 @@ static Error map_error(std::ofstream &file) {
 
 Continuation<Error> FileReporter::open(Report &) {
     return do_open_([=](Callback<Error> cb) {
+        if (filename == "-") {
+            cb(NoError());
+            return;
+        }
         file.open(filename);
         if (!file.good()) {
             cb(map_error(file));
@@ -39,9 +43,10 @@ Continuation<Error> FileReporter::open(Report &) {
 
 Continuation<Error> FileReporter::write_entry(Entry entry) {
     return do_write_entry_(entry, [=](Callback<Error> cb) {
-        file << entry.dump() << std::endl;
-        if (!file.good()) {
-            cb(map_error(file));
+        std::ostream &frf = (filename == "-") ? std::cout : file;
+        frf << entry.dump() << std::endl;
+        if (!frf.good()) {
+            cb(map_error(frf));
             return;
         }
         cb(NoError());
@@ -50,6 +55,10 @@ Continuation<Error> FileReporter::write_entry(Entry entry) {
 
 Continuation<Error> FileReporter::close() {
     return do_close_([=](Callback<Error> cb) {
+        if (filename == "-") {
+            cb(NoError());
+            return;
+        }
         file.close();
         if (!file.good()) {
             cb(map_error(file));


### PR DESCRIPTION
Closes #866.

I have decided not to go fancy and always check for filename
being equal to "-" because there was no need to be more complex
than that: the function to write the entry is called once for
every test, and this event does not occur very frequently.