### PR TITLE
Backports from master: MK_MOCK() + small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ libtool
 ltmain.sh
 m4/*.m4
 missing
+node_modules/
 site
 src/libmeasurement_kit/ext/Catch/
 src/libmeasurement_kit/ext/http-parser/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,63 @@
 - Backport #1163 to stable branch
 - Backport #1179 to stable branch
 
+# MeasurementKit 0.5.0-alpha [2017-04-11]
+
+- Force the library to use the system resolver (#972)
+- Add OONI bouncer support (#967)
+- Refine and finish bouncer implementation (#1014)
+- Add documentation for OONI's bouncer (#1032)
+- Move dns resolution function from net to dns (#1022)
+- Simple refactoring of system resolver (#1040)
+- Forward port patch #1066 to master (#1067)
+- build/dependency: implement quick git clone (#1068)
+- build/dependency: factor more operations (#1069)
+- Start cleaning up docker build system (#1070)
+- Finish cleaning up docker build system (#1071)
+- README.md: attempt to fix coveralls badge (#1072)
+- travis: conditional build depending on branch (#1074)
+- More cleanups of the CI subsystem (#1075)
+- Increase code coverage a bit (#1036)
+- Attempt to fix issue with case sensitive drive (#1076) (#1077)
+- Backport simple hotfixes from #1017 (#1091)
+- Tweak build/ios/cross (#1094)
+- http: extract interesting stuff from #929 (#1095)
+- Repair regress tests (#1117)
+- Tweak README.md and ChangeLog.md (#1119)
+- Fix uninitialized values according to Valgrind (#1118)
+- Remove bashism (#1145)
+- configure.ac: add /usr/local by default on macOS (#1151)
+- test/net/connect.cpp: libevent 2.1.8 compat (#1152)
+- Make Transport more OO (#1153)
+- net: move most close logic in emitter (#1154)
+- ooni/templates http: include all request/responses (#1149)
+- replace short PGP key fingerprint with long one (#1157)
+- Refactor cmdline to have OONI-like interface (#1156)
+- net: further tweak the transport model (#1155)
+- Repair broken test/ooni/utils.cpp (#1164)
+- Fix `unknown_failure 3` bug (#1162)
+- Repair regress tests after travis failure (#1166)
+- build/ci/travis: fix branch name detection logic (#1167)
+- http: refactor redirect logic (#1168)
+- ooni/template.cpp: don't assume `!!response->request` (#1170)
+- Finish fixing travis branch handling (#1171)
+- common: add {start,end}swith (#1172)
+- http::Response: init numbers to know value (#1174)
+- http: treat EOF instead of response as error (#1175)
+- Fix embarassing mk::endswith() bug (#1173)
+- Fix `unknown_error_3009` bug (#1176)
+- Fix report/entry.hpp w/ new NDK, nlohmann::json (#1177)
+- Only run coveralls if we know the token (#1181)
+- meek fronting nettest (#1141)
+- Update to nlohmann/json v2.1.1 (#1179)
+- mock.hpp: reduce implicit `MK_MOCK_NAMESPACE` magic (#1142)
+- Start updating dependencies: the easy part (#1163)
+- Update valgrind suppression files (#1186)
+- Build and archive dependencies separately (#1185)
+- Update README, license, badges (#1188)
+- Refactor and improve build scripts (#1017)
+- HTTP header fields manipulation test (#1146)
+
 # MeasurementKit 0.4.3 [2017-03-14]
 
 - Backport 5d88cf9ff (#1177) to stable branch
@@ -43,8 +100,8 @@
 # MeasurementKit 0.4.0-beta.3 [2017-02-01]
 
 - `ip_lookup()`: validate result as IP address (#1108)
-- `web_connectivity`: do not *request unconditionally
-- runnable: progress now accounts for max_runtime
+- `web_connectivity`: do not `*request` unconditionally
+- runnable: progress now accounts for `max_runtime`
 - progress: also track opening/closing report
 - The header key comparison MUST be done with the lowercase version
 - Use std::transform to convert to lowercase

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,74 @@
+The following copyright statement applies to the scripts in build/ios,
+which are a derivative work of ursachec/CPAProxy.
+
+Portions Copyright (c) 2013, Claudiu-Vlad Ursache
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Portions Copyright (c) 2010, Pierre-Olivier Latour
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of Pierre-Olivier Latour may not be used to endorse or
+      promote products derived from this software without specific prior
+      written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+- - -
+
+The following copyright statement applies to portions of acinclude.m4 that
+search for a default CA bundle; they derive from curl code.
+
+Copyright (c) 1996 - 2016, Daniel Stenberg, daniel@haxx.se, and many
+contributors, see the THANKS file.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not be
+used in advertising or otherwise to promote the sale, use or other dealings in
+this Software without prior written authorization of the copyright holder.

--- a/doc/api/common/mock.md
+++ b/doc/api/common/mock.md
@@ -10,11 +10,7 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 #include <measurement_kit/common.hpp>
 
 #define MK_MOCK(name_) decltype(name_) name_ = name_
-#define MK_MOCK_SUFFIX(name_, suffix_) decltype(name_) name_##_##suffix_ = name_
-define MK_MOCK_NAMESPACE(ns_, name_)                                          \
-    decltype(ns_::name_) ns_##_##name_ = ns_::name_
-#define MK_MOCK_NAMESPACE_SUFFIX(ns_, name_, suffix_)                          \
-    decltype(ns_::name_) ns_##_##name_##_##suffix_ = ns_::name_
+#define MK_MOCK_AS(name_, alias_) decltype(name_) alias_ = name_
 ```
 
 # DESCRIPTION
@@ -39,23 +35,16 @@ which is arguably faster than writing the following:
       ...
 ```
 
-`MK_MOCK_SUFFIX` is similar to `MOCK` but also takes a suffix that
-is appended to the function name within the template. This is useful
-when you want to distinguish the N-th and the N+1-th invocation of
-a function within another function.
-
-The `MK_MOCK_NAMESPACE` and `MK_MOCK_NAMESPACE_SUFFIX` macros are
-equal to `MK_MOCK` and `MK_MOCK_SUFFIX` respectively, except that you
-get also to specify a namespace and that such namespace plus underscore
-are prefixed to the function name. For example:
+`MK_MOCK_ALIAS` is similar to `MOCK` but allow you to explicitly specify
+the alias with which you want the specified name to be available. For example:
 
 ```C++
   namespace foo {
   void bar();
   }
 
-  template<MK_MOCK_SUFFIX(foo, bar, 123)> void func() {
-    foo_bar_123();
+  template<MK_MOCK_AS(foo::bar, jarjar)> void func() {
+    jarjar();
   }
 ```
 
@@ -90,8 +79,8 @@ void bar();
 
 namespace foo {
 
-template<MK_MOCK_NAMESPACE_SUFFIX(foobar, bbbaz, 1),
-         MK_MOCK_NAMESPACE_SUFFIX(foobar, bbbaz, 2)>
+template<MK_MOCK_AS(foobar, foobar_bbbaz_1),
+         MK_MOCK_AS(foobar, foobar_bbbaz_2)>
 void bar_impl() {
     // With default arguments is equal to calling foobar::bbbaz()
     foobar_bbbaaz_1([=](Error err) {
@@ -154,4 +143,5 @@ TEST_CASE("Foo deals with second error") {
 
 # HISTORY
 
-The `Mock` macros appeared in MeasurementKit 0.2.0.
+The `Mock` macros appeared in MeasurementKit 0.2.0. It was significantly
+reworked in MeasurementKit 0.5.0.

--- a/include/measurement_kit/common/mock.hpp
+++ b/include/measurement_kit/common/mock.hpp
@@ -18,17 +18,9 @@ Which is arguably faster than writing the following:
     template <decltype(event_base_new) event_base_new = ::event_base_new>
     void foobar() { ...
 */
-#define MK_MOCK(name_) decltype(name_) name_ = name_
+#define MK_MOCK(name_) MK_MOCK_AS(name_, name_)
 
-// Same as MK_MOCK but with suffix
-#define MK_MOCK_SUFFIX(name_, suffix_) decltype(name_) name_##_##suffix_ = name_
-
-// Same as MK_MOCK but with namespace
-#define MK_MOCK_NAMESPACE(ns_, name_)                                          \
-    decltype(ns_::name_) ns_##_##name_ = ns_::name_
-
-// Same as MK_MOCK_NAMESPACE but with suffix
-#define MK_MOCK_NAMESPACE_SUFFIX(ns_, name_, suffix_)                          \
-    decltype(ns_::name_) ns_##_##name_##_##suffix_ = ns_::name_
+// Similar to MK_MOCK but with alias
+#define MK_MOCK_AS(name_, alias_) decltype(name_) alias_ = name_
 
 #endif

--- a/src/libmeasurement_kit/common/utils_impl.hpp
+++ b/src/libmeasurement_kit/common/utils_impl.hpp
@@ -18,11 +18,12 @@ namespace mk {
  *
  * See <http://stackoverflow.com/questions/116038/what-is-the-best-way-to-read-an-entire-file-into-a-stdstring-in-c>.
  */
-template <typename T, MK_MOCK_NAMESPACE(std, fopen),
-          MK_MOCK_NAMESPACE_SUFFIX(std, fseek, 1),
-          MK_MOCK_NAMESPACE(std, ftell),
-          MK_MOCK_NAMESPACE_SUFFIX(std, fseek, 2),
-          MK_MOCK_NAMESPACE(std, fread), MK_MOCK_NAMESPACE(std, fclose)>
+template <typename T, MK_MOCK_AS(std::fopen, std_fopen),
+          MK_MOCK_AS(std::fseek, std_fseek_1),
+          MK_MOCK_AS(std::ftell, std_ftell),
+          MK_MOCK_AS(std::fseek, std_fseek_2),
+          MK_MOCK_AS(std::fread, std_fread),
+          MK_MOCK_AS(std::fclose, std_fclose)>
 ErrorOr<std::vector<T>> slurpv_impl(std::string p) {
     FILE *filep = std_fopen(p.c_str(), "rb");
     if (filep == nullptr) {

--- a/src/libmeasurement_kit/http/request_impl.hpp
+++ b/src/libmeasurement_kit/http/request_impl.hpp
@@ -13,7 +13,7 @@ namespace http {
 
 // TODO: mock more functions in request.cpp
 
-template <MK_MOCK_NAMESPACE(net, connect)>
+template <MK_MOCK_AS(net::connect, net_connect)>
 void request_connect_impl(Settings settings, Callback<Error, Var<Transport>> cb,
                           Var<Reactor> reactor = Reactor::global(),
                           Var<Logger> logger = Logger::global()) {

--- a/src/libmeasurement_kit/mlabns/mlabns_impl.hpp
+++ b/src/libmeasurement_kit/mlabns/mlabns_impl.hpp
@@ -53,7 +53,7 @@ static inline ErrorOr<std::string> as_query(Settings &settings) {
     return query;
 }
 
-template <MK_MOCK_NAMESPACE(http, get)>
+template <MK_MOCK_AS(http::get, http_get)>
 void query_impl(std::string tool, Callback<Error, Reply> callback,
                 Settings settings, Var<Reactor> reactor, Var<Logger> logger) {
     ErrorOr<std::string> query = as_query(settings);

--- a/src/libmeasurement_kit/ndt/messages_impl.hpp
+++ b/src/libmeasurement_kit/ndt/messages_impl.hpp
@@ -23,8 +23,8 @@ namespace messages {
     | type (1) | length (2) | payload (0-65535) |
     +----------+------------+-------------------+
 */
-template <MK_MOCK_NAMESPACE_SUFFIX(net, readn, first),
-          MK_MOCK_NAMESPACE_SUFFIX(net, readn, second)>
+template <MK_MOCK_AS(net::readn, net_readn_first),
+          MK_MOCK_AS(net::readn, net_readn_second)>
 void read_ll_impl(Var<Context> ctx,
                   Callback<Error, uint8_t, std::string> callback,
                   Var<Reactor> reactor) {

--- a/src/libmeasurement_kit/ndt/protocol_impl.hpp
+++ b/src/libmeasurement_kit/ndt/protocol_impl.hpp
@@ -10,7 +10,7 @@ namespace mk {
 namespace ndt {
 namespace protocol {
 
-template <MK_MOCK_NAMESPACE(net, connect)>
+template <MK_MOCK_AS(net::connect, net_connect)>
 void connect_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: connect ...");
     net_connect(ctx->address, ctx->port,
@@ -29,8 +29,9 @@ void connect_impl(Var<Context> ctx, Callback<Error> callback) {
                 ctx->settings, ctx->reactor, ctx->logger);
 }
 
-template <MK_MOCK_NAMESPACE(messages, format_msg_extended_login),
-          MK_MOCK_NAMESPACE(messages, write)>
+template <MK_MOCK_AS(messages::format_msg_extended_login,
+                     messages_format_msg_extended_login),
+          MK_MOCK_AS(messages::write, messages_write)>
 void send_extended_login_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: send login ...");
     ErrorOr<Buffer> out = messages_format_msg_extended_login(ctx->test_suite);
@@ -50,7 +51,7 @@ void send_extended_login_impl(Var<Context> ctx, Callback<Error> callback) {
     });
 }
 
-template <MK_MOCK_NAMESPACE(net, readn)>
+template <MK_MOCK_AS(net::readn, net_readn)>
 void recv_and_ignore_kickoff_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: recv and ignore kickoff ...");
     net_readn(ctx->txp, ctx->buff, KICKOFF_MESSAGE_SIZE, [=](Error err) {
@@ -69,9 +70,9 @@ void recv_and_ignore_kickoff_impl(Var<Context> ctx, Callback<Error> callback) {
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE(messages, read_msg),
-          MK_MOCK_NAMESPACE(messages, format_msg_waiting),
-          MK_MOCK_NAMESPACE(messages, write_noasync),
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg),
+          MK_MOCK_AS(messages::format_msg_waiting, messages_format_msg_waiting),
+          MK_MOCK_AS(messages::write_noasync, messages_write_noasync),
           MK_MOCK(call_soon)>
 void wait_in_queue_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: wait in queue ...");
@@ -129,7 +130,7 @@ void wait_in_queue_impl(Var<Context> ctx, Callback<Error> callback) {
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE(messages, read_msg)>
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
 void recv_version_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: recv server version ...");
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
@@ -149,7 +150,7 @@ void recv_version_impl(Var<Context> ctx, Callback<Error> callback) {
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE(messages, read_msg)>
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
 void recv_tests_id_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: recv tests ID ...");
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
@@ -169,8 +170,9 @@ void recv_tests_id_impl(Var<Context> ctx, Callback<Error> callback) {
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE(test_c2s, run), MK_MOCK_NAMESPACE(test_meta, run),
-          MK_MOCK_NAMESPACE(test_s2c, run)>
+template <MK_MOCK_AS(test_c2s::run, test_c2s_run),
+          MK_MOCK_AS(test_meta::run, test_meta_run),
+          MK_MOCK_AS(test_s2c::run, test_s2c_run)>
 void run_tests_impl(Var<Context> ctx, Callback<Error> callback) {
 
     if (ctx->granted_suite.size() <= 0) {
@@ -235,7 +237,7 @@ void run_tests_impl(Var<Context> ctx, Callback<Error> callback) {
     });
 }
 
-template <MK_MOCK_NAMESPACE(messages, read_msg)>
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
 void recv_results_and_logout_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: recv RESULTS ...");
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
@@ -265,7 +267,7 @@ void recv_results_and_logout_impl(Var<Context> ctx, Callback<Error> callback) {
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE(net, read)>
+template <MK_MOCK_AS(net::read, net_read)>
 void wait_close_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: wait close ...");
     ctx->txp->set_timeout(1.0);

--- a/src/libmeasurement_kit/ndt/run_impl.hpp
+++ b/src/libmeasurement_kit/ndt/run_impl.hpp
@@ -111,7 +111,8 @@ void run_with_specific_server_impl(Var<Entry> entry, std::string address, int po
 #undef TRAP_ERRORS
 }
 
-template <MK_MOCK(run_with_specific_server), MK_MOCK_NAMESPACE(mlabns, query)>
+template <MK_MOCK(run_with_specific_server),
+          MK_MOCK_AS(mlabns::query, mlabns_query)>
 void run_impl(Var<Entry> entry, Callback<Error> callback, Settings settings,
               Var<Reactor> reactor, Var<Logger> logger) {
     ErrorOr<int> port = settings.get_noexcept<int>("port", NDT_PORT);

--- a/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
@@ -10,7 +10,7 @@ namespace mk {
 namespace ndt {
 namespace test_c2s {
 
-template <MK_MOCK_NAMESPACE(net, connect)>
+template <MK_MOCK_AS(net::connect, net_connect)>
 void coroutine_impl(Var<Entry> report_entry, std::string address, int port, double runtime,
                     Callback<Error, Continuation<Error>> cb, double timeout,
                     Settings settings, Var<Reactor> reactor,
@@ -81,11 +81,11 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, int port, doub
                 settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, first),
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg_first),
           MK_MOCK(coroutine),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, second),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, third),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, fourth)>
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_second),
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_third),
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_fourth)>
 void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
     // The server sends us the PREPARE message containing the port number

--- a/src/libmeasurement_kit/ndt/test_meta_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_meta_impl.hpp
@@ -10,13 +10,13 @@ namespace mk {
 namespace ndt {
 namespace test_meta {
 
-template <MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, first),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, second),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, format_test_msg, first),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, format_test_msg, second),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, format_test_msg, third),
-          MK_MOCK_NAMESPACE(messages, write),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, third)>
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg_first),
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_second),
+          MK_MOCK_AS(messages::format_test_msg, messages_format_test_msg_first),
+          MK_MOCK_AS(messages::format_test_msg, messages_format_test_msg_second),
+          MK_MOCK_AS(messages::format_test_msg, messages_format_test_msg_third),
+          MK_MOCK_AS(messages::write, messages_write),
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_third)>
 void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
     // The server sends the PREPARE and START messages back to back

--- a/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
@@ -12,7 +12,7 @@ namespace test_s2c {
 
 using namespace mk::report;
 
-template <MK_MOCK_NAMESPACE(net, connect_many)>
+template <MK_MOCK_AS(net::connect_many, net_connect_many)>
 void coroutine_impl(Var<Entry> report_entry, std::string address, Params params,
                     Callback<Error, Continuation<Error, double>> cb,
                     double timeout, Settings settings, Var<Reactor> reactor,
@@ -104,7 +104,7 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, Params params,
         settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(messages, read_msg)>
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
 void finalizing_test_impl(Var<Context> ctx, Var<Entry> cur_entry,
                           Callback<Error> callback) {
 
@@ -137,12 +137,13 @@ void finalizing_test_impl(Var<Context> ctx, Var<Entry> cur_entry,
     }, ctx->reactor);
 }
 
-template <MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, first),
+template <MK_MOCK_AS(messages::read_msg, messages_read_msg_first),
           MK_MOCK(coroutine),
-          MK_MOCK_NAMESPACE_SUFFIX(messages, read_msg, second),
-          MK_MOCK_NAMESPACE(messages, read_json),
-          MK_MOCK_NAMESPACE(messages, format_test_msg),
-          MK_MOCK_NAMESPACE(messages, write), MK_MOCK(finalizing_test)>
+          MK_MOCK_AS(messages::read_msg, messages_read_msg_second),
+          MK_MOCK_AS(messages::read_json, messages_read_json),
+          MK_MOCK_AS(messages::format_test_msg, messages_format_test_msg),
+          MK_MOCK_AS(messages::write, messages_write),
+          MK_MOCK(finalizing_test)>
 void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
     // The server sends us the PREPARE message containing the port number

--- a/src/libmeasurement_kit/net/connect_impl.hpp
+++ b/src/libmeasurement_kit/net/connect_impl.hpp
@@ -120,7 +120,7 @@ void connect_base(std::string address, int port,
         }));
 }
 
-template <MK_MOCK_NAMESPACE(net, connect)>
+template <MK_MOCK_AS(net::connect, net_connect)>
 void connect_many_impl(Var<ConnectManyCtx> ctx) {
     // Implementation note: this function connects sequentially, which
     // is slower but also much simpler to implement and verify

--- a/src/libmeasurement_kit/ooni/collector_client_impl.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client_impl.hpp
@@ -32,7 +32,7 @@ void post(Var<Transport> transport, std::string url_extra, std::string body,
           Callback<Error, nlohmann::json> callback, Settings conf = {},
           Var<Reactor> = Reactor::global(), Var<Logger> = Logger::global());
 
-template <MK_MOCK_NAMESPACE(http, request_sendrecv)>
+template <MK_MOCK_AS(http::request_sendrecv, http_request_sendrecv)>
 void post_impl(Var<Transport> transport, std::string append_to_url,
                std::string body, Callback<Error, nlohmann::json> callback,
                Settings settings, Var<Reactor> reactor, Var<Logger> logger) {
@@ -102,7 +102,7 @@ Error valid_entry(Entry entry);
       |_|
 */
 
-template <MK_MOCK_NAMESPACE(http, request_connect)>
+template <MK_MOCK_AS(http::request_connect, http_request_connect)>
 void connect_impl(Settings settings, Callback<Error, Var<Transport>> callback,
                   Var<Reactor> reactor, Var<Logger> logger) {
     std::string url;
@@ -122,7 +122,7 @@ void connect_impl(Settings settings, Callback<Error, Var<Transport>> callback,
     http_request_connect(settings, callback, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, post)>
+template <MK_MOCK_AS(collector::post, collector_post)>
 void create_report_impl(Var<Transport> transport, Entry entry,
                         Callback<Error, std::string> callback,
                         Settings settings, Var<Reactor> reactor,
@@ -171,8 +171,8 @@ void create_report_impl(Var<Transport> transport, Entry entry,
                    settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, connect),
-          MK_MOCK_NAMESPACE(collector, create_report)>
+template <MK_MOCK_AS(collector::connect, collector_connect),
+          MK_MOCK_AS(collector::create_report, collector_create_report)>
 void connect_and_create_report_impl(report::Entry entry,
                                     Callback<Error, std::string> callback,
                                     Settings settings, Var<Reactor> reactor,
@@ -190,7 +190,7 @@ void connect_and_create_report_impl(report::Entry entry,
     }, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, post)>
+template <MK_MOCK_AS(collector::post, collector_post)>
 void update_report_impl(Var<Transport> transport, std::string report_id,
                         Entry entry, Callback<Error> callback,
                         Settings settings, Var<Reactor> reactor,
@@ -229,8 +229,8 @@ void update_report_impl(Var<Transport> transport, std::string report_id,
                    settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, connect),
-          MK_MOCK_NAMESPACE(collector, update_report)>
+template <MK_MOCK_AS(collector::connect, collector_connect),
+          MK_MOCK_AS(collector::update_report, collector_update_report)>
 void connect_and_update_report_impl(std::string report_id, report::Entry entry,
                                     Callback<Error> callback,
                                     Settings settings, Var<Reactor> reactor,
@@ -248,7 +248,7 @@ void connect_and_update_report_impl(std::string report_id, report::Entry entry,
     }, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, post)>
+template <MK_MOCK_AS(collector::post, collector_post)>
 void close_report_impl(Var<Transport> transport, std::string report_id,
                        Callback<Error> callback, Settings settings,
                        Var<Reactor> reactor, Var<Logger> logger) {
@@ -259,8 +259,8 @@ void close_report_impl(Var<Transport> transport, std::string report_id,
                    settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, connect),
-          MK_MOCK_NAMESPACE(collector, close_report)>
+template <MK_MOCK_AS(collector::connect, collector_connect),
+          MK_MOCK_AS(collector::close_report, collector_close_report)>
 void connect_and_close_report_impl(std::string report_id,
                                    Callback<Error> callback,
                                    Settings settings, Var<Reactor> reactor,
@@ -280,8 +280,8 @@ void connect_and_close_report_impl(std::string report_id,
 
 ErrorOr<Entry> get_next_entry(Var<std::istream> file, Var<Logger> logger);
 
-template <MK_MOCK_NAMESPACE(collector, update_report),
-          MK_MOCK_NAMESPACE(collector, get_next_entry)>
+template <MK_MOCK_AS(collector::update_report, collector_update_report),
+          MK_MOCK_AS(collector::get_next_entry, collector_get_next_entry)>
 void update_and_fetch_next_impl(Var<std::istream> file, Var<Transport> txp,
                                 std::string report_id, int line, Entry entry,
                                 Callback<Error> callback, Settings settings,
@@ -323,9 +323,9 @@ void update_and_fetch_next_impl(Var<std::istream> file, Var<Transport> txp,
         settings, reactor, logger);
 }
 
-template <MK_MOCK_NAMESPACE(collector, get_next_entry),
-          MK_MOCK_NAMESPACE(collector, connect),
-          MK_MOCK_NAMESPACE(collector, create_report)>
+template <MK_MOCK_AS(collector::get_next_entry, collector_get_next_entry),
+          MK_MOCK_AS(collector::connect, collector_connect),
+          MK_MOCK_AS(collector::create_report, collector_create_report)>
 void submit_report_impl(std::string filepath, std::string collector_base_url,
                         std::string collector_front_domain,
                         Callback<Error> callback, Settings settings,

--- a/src/libmeasurement_kit/ooni/resources_impl.hpp
+++ b/src/libmeasurement_kit/ooni/resources_impl.hpp
@@ -34,7 +34,7 @@ static inline std::string sanitize_version(const std::string &s) {
     return std::regex_replace(s, std::regex{R"xx([\ \t\r\n]+)xx"}, "");
 }
 
-template <MK_MOCK_NAMESPACE(http, get)>
+template <MK_MOCK_AS(http::get, http_get)>
 void get_latest_release_impl(Callback<Error, std::string> callback,
                              Settings settings, Var<Reactor> reactor,
                              Var<Logger> logger) {
@@ -66,7 +66,7 @@ void get_latest_release_impl(Callback<Error, std::string> callback,
     }, {}, settings, reactor, logger, nullptr, 0);
 }
 
-template <MK_MOCK_NAMESPACE(http, get)>
+template <MK_MOCK_AS(http::get, http_get)>
 void get_manifest_as_json_impl(
         std::string latest, Callback<Error, nlohmann::json> callback,
         Settings settings, Var<Reactor> reactor, Var<Logger> logger) {
@@ -105,7 +105,7 @@ static inline std::string sanitize_path(const std::string &s) {
     return std::regex_replace(s, std::regex{R"xx([/\\]+)xx"}, ".");
 }
 
-template <MK_MOCK_NAMESPACE(http, get), MK_MOCK(ostream_bad)>
+template <MK_MOCK_AS(http::get, http_get), MK_MOCK(ostream_bad)>
 void get_resources_for_country_impl(std::string latest, nlohmann::json manifest,
                                     std::string country, Callback<Error> cb,
                                     Settings settings, Var<Reactor> reactor,

--- a/src/libmeasurement_kit/ooni/utils_impl.hpp
+++ b/src/libmeasurement_kit/ooni/utils_impl.hpp
@@ -11,7 +11,7 @@ using json = nlohmann::json;
 namespace mk {
 namespace ooni {
 
-template <MK_MOCK_NAMESPACE(http, get)>
+template <MK_MOCK_AS(http::get, http_get)>
 void ip_lookup_impl(Callback<Error, std::string> callback, Settings settings = {},
                Var<Reactor> reactor = Reactor::global(),
                Var<Logger> logger = Logger::global()) {
@@ -40,7 +40,7 @@ void ip_lookup_impl(Callback<Error, std::string> callback, Settings settings = {
             {}, settings, reactor, logger, nullptr, 0);
 }
 
-template <MK_MOCK_NAMESPACE(dns, query)>
+template <MK_MOCK_AS(dns::query, dns_query)>
 void resolver_lookup_impl(Callback<Error, std::string> callback,
                           Settings settings = {},
                           Var<Reactor> reactor = Reactor::global(),


### PR DESCRIPTION
Basically:

- MK_MOCK() simplification
- Add `node_modules` to `.gitignore`
- Add NOTICE file
- Sync up the ChangeLog.md file