### PR TITLE
Build using the `mk` spec

### DIFF
--- a/build/ios/library
+++ b/build/ios/library
@@ -15,5 +15,5 @@ echo "Downloading and verifying precompiled dependencies from github"
     rm $DEPS_FILE $DEPS_FILE.asc
 )
 
-$ROOTDIR/dependency embedded-mk
+$ROOTDIR/dependency mk
 $ROOTDIR/build-frameworks

--- a/build/spec/mk
+++ b/build/spec/mk
@@ -1,5 +1,5 @@
 pkg_name=measurement-kit
-pkg_branch_or_tag=v0.7.0-dev
+pkg_branch_or_tag=v0.6.0-beta
 _dd=${pkg_prefix}/${pkg_cross}/${pkg_cross_arch}
 pkg_configure_flags="--disable-examples --disable-shared --disable-binaries --with-openssl=${_dd} --with-libevent=${_dd} --with-geoip=${_dd} $pkg_configure_flags"
 pkg_make_install_rule=install-strip


### PR DESCRIPTION
The `embedded-mk` spec has long gone.