### PR TITLE
Backport #1225 from master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,11 @@ CPPFLAGS="-I \$(top_srcdir)/include $CPPFLAGS"
 CFLAGS="-Wall -Wextra -pedantic $CFLAGS"
 CXXFLAGS="-Wall -Wextra -pedantic $CXXFLAGS"
 
+# Force compiling the http_parser in non-strict mode. This allows us to test
+# partially broken sites like mail.voila.fr that send spaces between the header
+# key and the separator (i.e. ':').
+CPPFLAGS="-DHTTP_PARSER_STRICT=0 $CPPFLAGS"
+
 MK_AM_REQUIRE_C99
 MK_AM_REQUIRE_CXX11
 MK_AM_REQUIRE_CXX11_LIBCXX


### PR DESCRIPTION
configure.ac: force non-strict http-parser (#1225)

This should fix web_connectivity of `mail.voila.fr`.

See #1196.