### PR TITLE
Cherry pick nodejs/http-parser#364

### DIFF
--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -31,7 +31,7 @@ TEST_CASE("ResponseParserNg deals with an UPGRADE request") {
     std::string data;
 
     data = "";
-    data += "HTTP/1.1 200 Ok\r\n";
+    data += "HTTP/1.1 101 Switching Protocols\r\n";
     data += "Content-Type: text/plain\r\n";
     data += "Connection: upgrade\r\n";
     data += "Upgrade: websockets\r\n";


### PR DESCRIPTION
Fixes advertising possible protocol upgrade to, e.g., `http2`
such as the case noticed with `http://www.aseansec.org`.