### PR TITLE
Further refine the runner model

### DIFF
--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -139,7 +139,7 @@ not be destroyed *before* the chain of function calls that lead to invoking the
 function passed to `task` has been fully executed and returned. This means you
 can code `task` to perform cleanup operations without worrying about whether
 the order of operations performed can lead to *use after free* when the stack
-of functions that lead to the final state return.
+of functions that lead to the final state returns.
 
 # CAVEATS
 

--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -116,7 +116,7 @@ the GUARANTEES section for more information.
 
 The `~AsyncRunner` destructor calls `stop`.
 
-The `stop` method stops the runner I/O loop and terminates all the tests
+The `stop` method stops the runner I/O loop and terminates all the tasks
 that are currently running, without calling their callbacks. It waits for
 the background thread to be terminated before continuing.
 

--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -106,7 +106,7 @@ AsyncRunner::global()->start(
 ```
 
 The `task` passed as third argument is garbage collected by this method,
-such that it will be not destroyed immediately after the callback it receives
+such that it will not be destroyed immediately after the callback it receives
 as its first argument is called. Rather its destruction will be deferred to
 occur as part of a "call soon" scheduled in the `AsyncRunner`'s `Reactor`.
 

--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -118,7 +118,7 @@ The `~AsyncRunner` destructor calls `stop`.
 
 The `stop` method stops the runner I/O loop and terminates all the tasks
 that are currently running, without calling their callbacks. It waits for
-the background thread to be terminated before continuing.
+the background thread to terminate before continuing.
 
 The `active` method returns the number of tasks currently active.
 

--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -48,7 +48,6 @@ class AsyncRunner {
 
 The `AsyncRunner` class runs schedules deferred execution of specific tasks
 in a background I/O thread where a `Reactor` I/O loop is running.
-a `Reactor` I/O loop is running.
 
 The `start` method is the most important method of this class. It performs the
 following operations:

--- a/doc/api/common/async_runner.md
+++ b/doc/api/common/async_runner.md
@@ -1,0 +1,179 @@
+# NAME
+AsyncRunner &mdash; runs tasks in a background I/O thread
+
+# LIBRARY
+MeasurementKit (libmeasurement\_kit, -lmeasurement\_kit).
+
+# SYNOPSIS
+```C++
+#include <measurement_kit/common.hpp>
+
+namespace mk {
+
+class AsyncRunner {
+  public:
+    template <typename Task, typename Callable>
+    void start(std::string &&name, Var<Logger> logger,
+               Task &&task, Callback &&callback) {
+        // Roughly equivalent to (but more robust than):
+        task([=](const Error &&err) {
+            callback(err);
+        });
+    }
+
+    ~AsyncRunner();
+
+    void stop();
+
+    long long active();
+
+    bool running();
+
+    Var<Reactor> reactor();
+
+    static Var<AsyncRunner> make();
+
+    static Var<AsyncRunner> global();
+};
+
+} // namespace mk
+```
+
+# STABILITY
+
+2 - Stable
+
+# DESCRIPTION
+
+
+The `AsyncRunner` class runs schedules deferred execution of specific tasks
+in a background I/O thread where a `Reactor` I/O loop is running.
+a `Reactor` I/O loop is running.
+
+The `start` method is the most important method of this class. It performs the
+following operations:
+
+1. it schedules the deferred execution of `task` on a background thread where
+   a I/O `Reactor` loop is running;
+
+2. on the background I/O thread, executes `task` and captures its result;
+
+3. passes such result to `callback`;
+
+4. logs all operations under the task `name` and using `logger`.
+
+The `task` argument is a generic callable equivalent to
+`Continuation<Error>`. That is, `task` is a function taking
+a `Callback<Error>` in input. When done, `task` MUST call
+such `Callback<Error>` to pass it the final result.
+
+The `callback` argument is a generic callable equivalent
+to `Callback<Error>`. It is called with the result of `task`.
+
+The following snippet demonstrates the expected usage:
+
+```C++
+/*
+ * With lambda based wrappers:
+ */
+Var<Task> task = Var<State>::make();
+AsyncRunner::global()->start(
+    "dummy task", Logger::global(),
+    [task](Callback<Error &&> &&cb) {
+        task->do_async_operation(std::move(cb));
+    },
+    [](const Error &&error) {
+        // Execute code after the task is complete
+    });
+
+/*
+ * With callable objects
+ */
+class Task {
+  public:
+    void operator()(Callback<Error> &&cb) {
+    }
+
+    // ...
+};
+
+AsyncRunner::global()->start(
+    "another task",
+    Logger::global(),
+    Task{},
+    [](const Error &&error) {
+        // Execute code after the task is complete
+    });
+```
+
+The `task` passed as third argument is garbage collected by this method,
+such that it will be not destroyed immediately after the callback it receives
+as its first argument is called. Rather its destruction will be deferred to
+occur as part of a "call soon" scheduled in the `AsyncRunner`'s `Reactor`.
+
+This guarantees that the stack of functions that led to producing the result
+of `task` can unwind safely without causing any use after free hazard. See
+the GUARANTEES section for more information.
+
+The `~AsyncRunner` destructor calls `stop`.
+
+The `stop` method stops the runner I/O loop and terminates all the tests
+that are currently running, without calling their callbacks. It waits for
+the background thread to be terminated before continuing.
+
+The `active` method returns the number of tasks currently active.
+
+The `running` method tells you whether the background thread is running.
+
+The `reactor` method returns the reactor in use.
+
+The `make` factory constructs a shared instance of this object.
+
+The `global` factory returns the global shared `AsyncRunner`.
+
+# GUARANTEES
+
+The `start` method provides the following guarantees:
+
+1. The fourth argument `callback` will not be called immediately but
+   rather it will be deferred using `call_soon`
+
+2. The third argument `task` will be alive *at least* until the
+   `callback` passed as fourth argument returns
+
+The combination of this two guarantees avoids the following use after
+free hazard that we observed empirically:
+
+1. The `task` is only kept alive by the closure of the function passed to
+   it, since the prototype of `start` is such that it owns the `task`
+
+2. As such, `task` dies only the function passed to it exits from the scope
+
+3. Yet, `task` implementation may be such that it needs to perform some
+   cleanup after it has called the final function and, in such case, said
+   code will perform cleanup on an already-destroyed `this`
+
+# CAVEATS
+
+Since the fourth-argument `callback` will be called from a background
+thread, make sure you lock any shared resources before proceeding:
+
+```C++
+AsyncRunner::global()->start(
+    "dummy task", Logger::global(),
+    [](Callback<Error &&> &&) {
+        // SOMETHING...
+    },
+    [](Error &&error) {
+        // LOCK SHARED RESOURCES BEFORE PROCEEDING
+    });
+```
+
+# BUGS
+
+Altough it is a template, `start` does not allow for arbitrary arguments.
+
+# HISTORY
+
+The `AsyncRunner` appeared in MK v0.7.0. It is a generalized version
+of `nettests::Runner` that works on generic tasks.

--- a/doc/api/nettests/runner.md
+++ b/doc/api/nettests/runner.md
@@ -41,7 +41,7 @@ Since the callback will be called from a background thread, make sure
 you lock any shared resources before proceeding as in
 
 ```C++
-    Runner::global()->run(test, [=](Var<NetTest>) {
+    Runner::global()->start_test(test, [=](Var<NetTest>) {
         shared_resource.lock();
         // Now use the shared resource
     });

--- a/doc/api/nettests/runner.md
+++ b/doc/api/nettests/runner.md
@@ -15,16 +15,17 @@ class Runner {
   public:
     static Var<Runner> global();
     void start_test(Var<NetTest> test, Callback<Var<NetTest>> callback);
-    void Runner::start_generic_task(std::string &&name, Var<Logger> logger,
-                                    Continuation<> &&task, Callback<> &&done);
+    void stop();
+    bool empty();
 };
 
-}}
+} // namespace nettests
+} // namespace mk
 ```
 
 # STABILITY
 
-1 - Experimental
+2 - Stable
 
 # DESCRIPTION
 
@@ -46,16 +47,13 @@ you lock any shared resources before proceeding as in
     });
 ```
 
-The `start_generic_task` schedules the task identified by `name` for
-execution in a background thread. The provided `logger` will be used to
-emit diagnostic messages. The `task` argument is a continuation that
-implements the task: it receives as a single argument a `Callback<>` that
-is to be called when the task has finished its work. The code will make
-sure to call the final callback, `done`, when this happens.
+The `stop` method stops the runner I/O loop and terminates all the tests
+that are currently running, without calling their callbacks.
+
+The `empty` method returns true if no tests are running.
 
 # HISTORY
 
 The `Async` class appeared in MeasurementKit 0.1.0. It was renamed
 `Runner` in MeasurementKit 0.2.0. It was moved from the `common` to
-the `nettests` namespace in MeasurementKit 0.4.0. Support for running
-arbitrary lambdas was added in v0.7.0.
+the `nettests` namespace in MeasurementKit 0.4.0.

--- a/include/measurement_kit/common/async_runner.hpp
+++ b/include/measurement_kit/common/async_runner.hpp
@@ -1,0 +1,99 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+#ifndef MEASUREMENT_KIT_COMMON_ASYNC_RUNNER_HPP
+#define MEASUREMENT_KIT_COMMON_ASYNC_RUNNER_HPP
+
+// Documentation: doc/api/common/async_runner.md
+
+#include <measurement_kit/common/has_global_factory.hpp>
+#include <measurement_kit/common/has_make_factory.hpp>
+#include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common/non_copyable.hpp>
+#include <measurement_kit/common/non_movable.hpp>
+#include <measurement_kit/common/reactor.hpp>
+
+#include <atomic>
+#include <cassert>
+#include <future>
+#include <thread>
+
+namespace mk {
+
+class AsyncRunner : public HasMakeFactory<AsyncRunner>,
+                    public HasGlobalFactory<AsyncRunner>,
+                    public NonCopyable,
+                    public NonMovable {
+  public:
+    template <typename Task, typename Callback>
+    void start(std::string &&name, Var<Logger> logger, Task &&task,
+               Callback &&cb) {
+        assert(active_ >= 0);
+        if (!running_) {
+            std::promise<void> promise;
+            std::future<void> future = promise.get_future();
+            // WARNING: the destructor MUST wait for the thread because we
+            // are passing `this` to the thread's function.
+            logger->debug("runner: starting reactor in background...");
+            thread_ = std::thread([&promise, this, logger]() {
+                reactor_->run_with_initial_event([&promise, logger]() {
+                    logger->debug("runner: background reactor running...");
+                    promise.set_value();
+                });
+            });
+            future.wait();
+            running_ = true;
+        }
+        active_ += 1;
+        logger->debug("%s: scheduling", name.c_str());
+        // Give background thread exclusive ownership of arguments
+        reactor_->call_soon([
+            task = std::move(task), cb = std::move(cb), name = std::move(name),
+            logger, this
+        ]() {
+            logger->debug("%s: starting", name.c_str());
+            // Make sure the lambda's closure keeps the task alive
+            task([task, cb, name, logger, this](Error &&error) {
+                logger->debug("%s: finished", name.c_str());
+                // WARNING: this closure keeps task alive but it MAY be invoked
+                // by objects that MAY die after task is destroyed and that also
+                // MAY do some work after the closure returns. To avoid issues
+                // with use-after-free defer calling the final `cb`, and ensure
+                // the closure keeps the task alive until that point in time.
+                reactor_->call_soon([task, cb, name, logger, this, error]() {
+                    logger->debug("%s: callback", name.c_str());
+                    active_ -= 1;
+                    logger->debug("runner: #active: %lld", (long long)active_);
+                    cb(std::move(error));
+                });
+            });
+        });
+    }
+
+    void stop() {
+        if (running_) {
+            // WARNING: Make sure we stop the runner before we stop the
+            // thread otherwise we will most likely segfault.
+            reactor_->stop();
+            thread_.join();
+            running_ = false;
+        }
+    }
+
+    long long active() { return active_; }
+
+    bool running() { return running_; }
+
+    ~AsyncRunner() { stop(); }
+
+    Var<Reactor> reactor() { return reactor_; }
+
+  private:
+    std::atomic<long long> active_{0};
+    Var<Reactor> reactor_ = Reactor::make();
+    std::atomic<bool> running_{false};
+    std::thread thread_;
+};
+
+} // namespace mk
+#endif

--- a/include/measurement_kit/common/async_runner.hpp
+++ b/include/measurement_kit/common/async_runner.hpp
@@ -25,6 +25,8 @@ class AsyncRunner : public HasMakeFactory<AsyncRunner>,
                     public NonCopyable,
                     public NonMovable {
   public:
+
+    // Adapted from src/libmeasurement_kit/nettests/runner.cpp
     template <typename Task, typename Callback>
     void start(std::string &&name, Var<Logger> logger, Task &&task,
                Callback &&cb) {

--- a/include/measurement_kit/common/has_global_factory.hpp
+++ b/include/measurement_kit/common/has_global_factory.hpp
@@ -4,6 +4,7 @@
 #ifndef MEASUREMENT_KIT_COMMON_HAS_GLOBAL_FACTORY_HPP
 #define MEASUREMENT_KIT_COMMON_HAS_GLOBAL_FACTORY_HPP
 
+#include <measurement_kit/common/locked.hpp>
 #include <measurement_kit/common/var.hpp>
 
 namespace mk {
@@ -11,11 +12,13 @@ namespace mk {
 template <typename T> class HasGlobalFactory {
   public:
     template <typename... A> static Var<T> global(A &&... a) {
-        static Var<T> singleton;
-        if (!singleton) {
-            singleton = Var<T>::make(std::forward<A>(a)...);
-        }
-        return singleton;
+        return locked_global([&]() {
+            static Var<T> singleton;
+            if (!singleton) {
+                singleton = Var<T>::make(std::forward<A>(a)...);
+            }
+            return singleton;
+        });
     }
 };
 

--- a/include/measurement_kit/nettests/runner.hpp
+++ b/include/measurement_kit/nettests/runner.hpp
@@ -8,23 +8,16 @@
 
 namespace mk {
 namespace nettests {
-struct RunnerCtx;
 class Runnable;
 
-class Runner {
+class Runner : public HasGlobalFactory<Runner> {
   public:
-    Runner();
     void start_test(Var<Runnable> test, Callback<Var<Runnable>> func);
-    void start_generic_task(std::string &&name, Var<Logger> logger,
-                            Continuation<> &&task, Callback<> &&done);
-    void break_loop_();
+    void stop();
     bool empty();
-    void join_();
-    ~Runner();
-    static Var<Runner> global();
 
   private:
-    Var<RunnerCtx> ctx_;
+    AsyncRunner impl_;
 };
 
 } // namespace nettests

--- a/src/libmeasurement_kit/nettests/runner.cpp
+++ b/src/libmeasurement_kit/nettests/runner.cpp
@@ -12,103 +12,27 @@
 namespace mk {
 namespace nettests {
 
-struct RunnerCtx {
-    std::atomic<int> active{0};
-    Var<Reactor> reactor = Reactor::global();
-    std::atomic<bool> running{false};
-    std::thread thread;
-};
-
-Runner::Runner() { ctx_.reset(new RunnerCtx); }
-
 void Runner::start_test(Var<Runnable> test, Callback<Var<Runnable>> fn) {
     // Note: here we MUST force the runnable's reactor to be our reactor
     // otherwise we cannot run the specified test...
     assert(not test->reactor);
-    test->reactor = ctx_->reactor;
-    start_generic_task(std::to_string((unsigned long long)test.get()),
-                       test->logger,
-                       [=](Callback<> &&cb) {
-                           test->begin([=](Error) {
-                               // TODO: do not ignore the error
-                               test->end([=](Error) {
-                                   // TODO: do not ignore the error
-                                   cb();
-                               });
-                           });
-                       },
-                       [=]() { fn(test); });
+    test->reactor = impl_.reactor();
+    impl_.start(std::to_string((unsigned long long)test.get()), test->logger,
+                [test](Callback<Error> &&cb) {
+                    test->begin([=](Error) {
+                        // TODO: do not ignore the error
+                        test->end([=](Error) {
+                            // TODO: do not ignore the error
+                            cb(NoError());
+                        });
+                    });
+                },
+                [fn, test](const Error && /*error*/) { fn(test); });
 }
 
-void Runner::start_generic_task(std::string &&name, Var<Logger> logger,
-                                Continuation<> &&task, Callback<> &&done) {
-    assert(ctx_->active >= 0);
-    if (not ctx_->running) {
-        std::promise<bool> promise;
-        std::future<bool> future = promise.get_future();
-        // WARNING: below we're passing `this` to the thread, which means that
-        // the destructor MUST wait the thread. Otherwise, when the thread dies
-        // many strange things could happen (I have seen SIGABRT).
-        logger->debug("runner: starting reactor in background...");
-        ctx_->thread = std::thread([&promise, this, logger]() {
-            ctx_->reactor->loop_with_initial_event([&promise, logger]() {
-                logger->debug("runner: starting reactor in background... ok");
-                promise.set_value(true);
-            });
-        });
-        future.wait();
-        ctx_->running = true;
-    }
-    ctx_->active += 1;
-    logger->debug("runner: scheduling '%s'", name.c_str());
-    // Make sure we explicitly keep alive `task`, which must not be
-    // deleted until the `done` callback has been called.
-    ctx_->reactor->call_soon([name, logger, task, done, this]() {
-        logger->debug("runner: starting '%s'", name.c_str());
-        task([name, logger, task, done, this]() {
-            logger->debug("runner: cleaning-up '%s'", name.c_str());
-            // For robustness, delay the final callback to the beginning of
-            // next I/O cycle to prevent possible user after frees. This
-            // could happen because, in our current position on the stack,
-            // we have been called by `Runnable` code that may use `this`
-            // after calling the callback. But this would be a problem
-            // because `test` is most likely to be destroyed after `fn()`
-            // returns. Thus, when unwinding the stack, the use after free
-            // would happen.
-            ctx_->reactor->call_soon([name, logger, task, done, this]() {
-                logger->debug("runner: callbacking '%s'", name.c_str());
-                ctx_->active -= 1;
-                logger->debug("runner: #active tasks: %d", (int)ctx_->active);
-                done();
-            });
-        });
-    });
-}
+void Runner::stop() { impl_.stop(); }
 
-void Runner::break_loop_() { ctx_->reactor->break_loop(); }
-
-bool Runner::empty() { return ctx_->active == 0; }
-
-void Runner::join_() {
-    if (ctx_->running) {
-        ctx_->thread.join();
-        ctx_->running = false;
-    }
-}
-
-Runner::~Runner() {
-    // WARNING: This MUST be here to make sure we break the loop before we
-    // stop the thread. Not doing that leads to undefined behavior.
-    break_loop_();
-    join_();
-}
-
-/*static*/ Var<Runner> Runner::global() {
-    return locked_global([&]() {
-        static Var<Runner> singleton(new Runner);
-        return singleton;
-    });
-}
+bool Runner::empty() { return impl_.active() == 0; }
 
 } // namespace nettests
 } // namespace mk

--- a/test/nettests/runner.cpp
+++ b/test/nettests/runner.cpp
@@ -74,8 +74,7 @@ TEST_CASE("The destructor work as expected if the thread was already joined") {
     while (!runner.empty()) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-    runner.break_loop_();
-    runner.join_();
+    runner.stop();
 }
 
 TEST_CASE("Nothing strange happens if no thread is bound to Runner") {


### PR DESCRIPTION
Extract a generic runner from the existing nettests::Runner
implementation and move it into the common module.