### PR TITLE
feature: use newly added reactor's worker

### DIFF
--- a/include/measurement_kit/common/reactor.hpp
+++ b/include/measurement_kit/common/reactor.hpp
@@ -23,6 +23,7 @@ class Reactor {
     static Var<Reactor> global();
     virtual ~Reactor();
 
+    virtual void run_in_background_thread(Callback<> &&cb) = 0;
     virtual void call_soon(Callback<> &&cb) = 0;
     virtual void call_later(double, Callback<> &&cb) = 0;
 

--- a/include/private/dns/getaddrinfo_async.hpp
+++ b/include/private/dns/getaddrinfo_async.hpp
@@ -81,13 +81,13 @@ std::vector<Answer> getaddrinfo_async_parse_response(const std::string &name,
 
 template <MK_MOCK(getaddrinfo), MK_MOCK(inet_ntop)>
 void getaddrinfo_async(std::string name, addrinfo hints, Var<Reactor> reactor,
-                       Var<Logger> logger, Var<Worker> worker,
+                       Var<Logger> logger,
                        Callback<Error, std::vector<Answer>> cb) {
     /*
      * Move everything down such that there is always just one function in
      * one specific thread having ownership of the state
      */
-    worker->run_in_background_thread([
+    reactor->run_in_background_thread([
         name = std::move(name), hints = std::move(hints),
         reactor = std::move(reactor), logger = std::move(logger),
         cb = std::move(cb)

--- a/include/private/dns/system_resolver.hpp
+++ b/include/private/dns/system_resolver.hpp
@@ -5,11 +5,6 @@
 #define PRIVATE_DNS_SYSTEM_RESOLVER_HPP
 
 #include "private/common/mock.hpp"
-#include "private/common/worker.hpp"
-
-#include "private/common/mock.hpp"
-#include "private/common/worker.hpp"
-
 #include <measurement_kit/dns.hpp>
 
 #include "../dns/getaddrinfo_async.hpp"
@@ -58,7 +53,7 @@ void system_resolver(QueryClass dns_class, QueryType dns_type, std::string name,
     message->queries.push_back(query);
 
     getaddrinfo_async<getaddrinfo, inet_ntop>(
-        name, hints, reactor, logger, Worker::global(),
+        name, hints, reactor, logger,
         [ message = std::move(message),
           cb = std::move(cb) ](Error error, std::vector<Answer> answers) {
             message->answers = std::move(answers);

--- a/include/private/libevent/poller.hpp
+++ b/include/private/libevent/poller.hpp
@@ -17,6 +17,7 @@
 /// \brief Header-only implementation of mk::Reactor based on libevent.
 
 #include "private/common/mock.hpp"                 // for MK_MOCK
+#include "private/common/worker.hpp"               // for mk::Worker
 #include <cassert>                                 // for assert
 #include <event2/event.h>                          // for event_base_*
 #include <event2/thread.h>                         // for evthread_use_*
@@ -190,6 +191,12 @@ class Poller : public Reactor, public NonCopyable, public NonMovable {
     */
     /// \subsubsection Call later
     /// \brief Here we have code schedule callbacks at a later time.
+
+    Worker worker;
+
+    void run_in_background_thread(Callback<> &&cb) override {
+        worker.run_in_background_thread(std::move(cb));
+    }
 
     void call_soon(Callback<> &&cb) override { call_later(0.0, std::move(cb)); }
 


### PR DESCRIPTION
Better that all the classes that mess with objects have the
same lifecycle. One way to do that is to put the worker into
the reactor, so bydef they have the same lifecycle.