### PR TITLE
feature(reactor): stay alive longer but not forever

### DIFF
--- a/include/private/libevent/poller.hpp
+++ b/include/private/libevent/poller.hpp
@@ -147,7 +147,7 @@ class Poller : public Reactor, public NonCopyable, public NonMovable {
         do {
             auto ev_status = event_base_dispatch(evbase);
             if (ev_status < 0) {
-                throw std::runtime_error("event_base_loop");
+                throw std::runtime_error("event_base_dispatch");
             }
             /*
                 Explanation: event_base_loop() returns one when there are no

--- a/include/private/libevent/poller.hpp
+++ b/include/private/libevent/poller.hpp
@@ -144,36 +144,32 @@ class Poller : public Reactor, public NonCopyable, public NonMovable {
     event_base *get_event_base() override { return evbase; }
 
     void run() override {
-        // Register a persistent periodic event to make sure that the event
-        // loop is not going to exit if we run out of events. This is required
-        // because, when we're resolving DNS, we do that in a background
-        // thread without typically having any event in the event loop which
-        // will exit. To avoid this, here's the persistent event hack. Another
-        // possible fix (more elegant), would be to move the worker into the
-        // poller and consider the poller not done as long as we have pending
-        // callbacks, pending I/O (this checked by libevent) and pending
-        // worker threads to work on.
-        //
-        // Note that the libevent v2.1.x has a flag to obtain the behavior
-        // described above, but the v2.0.x libevent doesn't.
+        do {
+            auto ev_status = event_base_dispatch(evbase);
+            if (ev_status < 0) {
+                throw std::runtime_error("event_base_loop");
+            }
+            /*
+                Explanation: event_base_loop() returns one when there are no
+                pending events. In such case, before leaving the event loop, we
+                make sure we have no pending background threads. They are, as
+                of now, mostly used to perform DNS queries with getaddrinfo(),
+                which is blocking. If there are threads running, treat them
+                like pending events, even though they are not managed by
+                libevent, and continue running the loop. To avoid spawning
+                and to be sure we're ready to deal /pronto/ with any upcoming
+                libevent event, schedule a call for the near future so to
+                keep the libevent loop active, and ready to react.
 
-        timeval ten_seconds;
-        EventUptr persist{event_new(evbase, -1, EV_PERSIST | EV_TIMEOUT,
-                                    mk_periodic_cb, nullptr)};
-        if (!persist) {
-            throw std::runtime_error("event_new");
-        }
-        if (event_add(persist.get(), timeval_init(&ten_seconds, 10.0)) != 0) {
-            throw std::runtime_error("event_add");
-        }
-
-        auto rv = event_base_dispatch(evbase);
-        if (rv < 0) {
-            throw std::runtime_error("event_base_dispatch");
-        }
-        if (rv > 1) {
-            mk::warn("loop: no pending and/or active events");
-        }
+                The exact possible values for `ev_status` are -1, 0, and +1, but
+                I have coded more broad checks for robustness.
+            */
+            if (ev_status > 0 && worker.concurrency() <= 0) {
+                mk::warn("reactor: no pending and/or active events");
+                break;
+            }
+            call_later(0.250, []() {});
+        } while (true);
     }
 
     void stop() override {


### PR DESCRIPTION
The reason by which the code was registering a persistent event
of timer type was to keep the loop alive even when technically it
should have exited because there were no events.

This was meant as a band aid, because during getaddrinfo()
resolutions, which are performed in a background thread, we
MAY have no pending I/O event or call in the event loop.

The solution proposed in this diff is much more cleaner and
natural and incorporates in the concept of pending events also
the pending threads that are running getaddrinfo() calls or,
for that mattern, any blocking call whatsoever.

With this fix, it's not necessary anymore to keep the loop
alive forever because we know it will be alive as long as
we have some work to do. This may seem to be a big change, but
it actually has some big implications like:

- we can schedule units of work (e.g. entire tests) on a specific
  event loop and be sure that, when the test is "done" (as in
  "we have completed all the I/O actions and delayed calls that
  were scheduled at the beginning of the test") the loop will
  break

- suddenly, with this schema, we will no longer have the halting
  problem that has plagued as so far, where we needed to ensure
  that we really reached the end of the test so to call the final
  callback and, most importanlty,

- now, all the resources that are bound to the lifecycle of the
  test can be allocated in the context of the poller used as
  a context manager (like an apr_pool) and we can be sure that
  such initial context is alive as long as we're operating
  on it, if we arrange for its destruction when the reactor
  object goes out of scope, by definition

- additionally, this 1:1 binding between tests and reactors
  opens up other interesting possibilities like, it will
  become trivial to cancel a running test, as it just suffices
  to kill the poller loop

- also, it will become easy to limit the maximum amount of
  concurrent tests, by setting up a queue of tests that need
  to be served, and by allocating a fixed number of threads
  to pick up each test, setup a reactor, and fire the initial
  function.