### PR TITLE
rename(libevent): poller -> reactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@
 /test/http/response_parser
 /test/libevent/connection
 /test/libevent/dns_error
-/test/libevent/poller
+/test/libevent/reactor
 /test/mlabns/mlabns
 /test/ndt/measure_speed
 /test/ndt/messages

--- a/include/private/libevent/reactor.hpp
+++ b/include/private/libevent/reactor.hpp
@@ -1,19 +1,18 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
-#ifndef PRIVATE_LIBEVENT_POLLER_HPP
-#define PRIVATE_LIBEVENT_POLLER_HPP
+#ifndef PRIVATE_LIBEVENT_REACTOR_HPP
+#define PRIVATE_LIBEVENT_REACTOR_HPP
 
-// # Libevent/poller
+// # Libevent/reactor
 /*-
-     _     _ _                          _                 _ _
-    | |   (_) |__   _____   _____ _ __ | |_   _ __   ___ | | | ___ _ __
-    | |   | | '_ \ / _ \ \ / / _ \ '_ \| __| | '_ \ / _ \| | |/ _ \ '__|
-    | |___| | |_) |  __/\ V /  __/ | | | |_  | |_) | (_) | | |  __/ |
-    |_____|_|_.__/ \___| \_/ \___|_| |_|\__| | .__/ \___/|_|_|\___|_|
-                                             |_|
+     _     _ _                          _                         _
+    | |   (_) |__   _____   _____ _ __ | |_   _ __ ___  __ _  ___| |_ ___  _ __
+    | |   | | '_ \ / _ \ \ / / _ \ '_ \| __| | '__/ _ \/ _` |/ __| __/ _ \| '__|
+    | |___| | |_) |  __/\ V /  __/ | | | |_  | | |  __/ (_| | (__| || (_) | |
+    |_____|_|_.__/ \___| \_/ \___|_| |_|\__| |_|  \___|\__,_|\___|\__\___/|_|
 */
-/// \section Libevent/poller
+/// \section Libevent/reactor
 /// \brief Header-only implementation of mk::Reactor based on libevent.
 
 #include "private/common/mock.hpp"                 // for MK_MOCK
@@ -70,7 +69,7 @@ struct EventDeleter {
 };
 using EventUptr = std::unique_ptr<event, EventDeleter>;
 
-// ## Poller
+// ## Reactor
 /*-
      ____       _ _
     |  _ \ ___ | | | ___ _ __
@@ -78,14 +77,14 @@ using EventUptr = std::unique_ptr<event, EventDeleter>;
     |  __/ (_) | | |  __/ |
     |_|   \___/|_|_|\___|_|
 */
-/// \subsection Poller
+/// \subsection Reactor
 /// \brief Here we have our main class.
 
 /// \brief mk::Reactor implementation using libevent.
 template <MK_MOCK(event_base_new), MK_MOCK(event_base_once),
           MK_MOCK(event_base_dispatch), MK_MOCK(event_base_loopbreak),
           MK_MOCK(event_new), MK_MOCK(event_add)>
-class Poller : public Reactor, public NonCopyable, public NonMovable {
+class Reactor : public mk::Reactor, public NonCopyable, public NonMovable {
   public:
     // ### Library
     /*-
@@ -133,13 +132,13 @@ class Poller : public Reactor, public NonCopyable, public NonMovable {
 
     event_base *evbase = nullptr;
 
-    Poller() {
+    Reactor() {
         if ((evbase = event_base_new()) == nullptr) {
             throw std::runtime_error("event_base_new");
         }
     }
 
-    ~Poller() override { event_base_free(evbase); }
+    ~Reactor() override { event_base_free(evbase); }
 
     event_base *get_event_base() override { return evbase; }
 
@@ -150,7 +149,7 @@ class Poller : public Reactor, public NonCopyable, public NonMovable {
         // thread without typically having any event in the event loop which
         // will exit. To avoid this, here's the persistent event hack. Another
         // possible fix (more elegant), would be to move the worker into the
-        // poller and consider the poller not done as long as we have pending
+        // reactor and consider the poller not done as long as we have pending
         // callbacks, pending I/O (this checked by libevent) and pending
         // worker threads to work on.
         //

--- a/src/libmeasurement_kit/common/reactor.cpp
+++ b/src/libmeasurement_kit/common/reactor.cpp
@@ -2,13 +2,13 @@
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
 
-#include "private/libevent/poller.hpp"
+#include "private/libevent/reactor.hpp"
 #include <measurement_kit/common/locked.hpp>
 
 namespace mk {
 
 /*static*/ Var<Reactor> Reactor::make() {
-    return locked_global([]() { return Var<Reactor>{new libevent::Poller<>}; });
+    return locked_global([]() { return Var<Reactor>{new libevent::Reactor<>}; });
 }
 
 Reactor::~Reactor() {}

--- a/test/libevent/reactor.cpp
+++ b/test/libevent/reactor.cpp
@@ -23,13 +23,15 @@ static int sigaction_fail(int, const struct sigaction *, struct sigaction *) {
 
 TEST_CASE("LibeventLibrary") {
     SECTION("We deal with evthread_use_pthreads() failure") {
-        REQUIRE_THROWS((Reactor<>::LibeventLibrary<evthread_use_pthreads_fail,
-                                                 sigaction>{}));
+        REQUIRE_THROWS(
+              (libevent::Reactor<>::LibeventLibrary<evthread_use_pthreads_fail,
+                                                    sigaction>{}));
     }
 
     SECTION("We deal with sigaction() failure") {
-        REQUIRE_THROWS((Reactor<>::LibeventLibrary<evthread_use_pthreads,
-                                                 sigaction_fail>{}));
+        REQUIRE_THROWS(
+              (libevent::Reactor<>::LibeventLibrary<evthread_use_pthreads,
+                                                    sigaction_fail>{}));
     }
 }
 
@@ -47,28 +49,31 @@ static int event_base_loopbreak_fail(event_base *) { return -1; }
 
 TEST_CASE("Reactor: basic functionality") {
     SECTION("We deal with event_base_new() failure") {
-        REQUIRE_THROWS((Reactor<event_base_new_fail, event_base_once,
-                               event_base_dispatch, event_base_loopbreak,
-                               event_new, event_add>{}));
+        REQUIRE_THROWS(
+              (libevent::Reactor<event_base_new_fail, event_base_once,
+                                 event_base_dispatch, event_base_loopbreak,
+                                 event_new, event_add>{}));
     }
 
     SECTION("We deal with event_base_dispatch() failure") {
-        Reactor<event_base_new, event_base_once, event_base_dispatch_fail,
-               event_base_loopbreak, event_new, event_add>
+        libevent::Reactor<event_base_new, event_base_once,
+                          event_base_dispatch_fail, event_base_loopbreak,
+                          event_new, event_add>
               reactor;
         REQUIRE_THROWS(reactor.run());
     }
 
     SECTION("We deal with event_base_dispatch() running out of events") {
-        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
-               event_base_loopbreak, event_new, event_add>
+        libevent::Reactor<event_base_new, event_base_once,
+                          event_base_dispatch_no_events, event_base_loopbreak,
+                          event_new, event_add>
               reactor;
         reactor.run();
     }
 
     SECTION("We deal with event_base_loopbreak() failure") {
-        Reactor<event_base_new, event_base_once, event_base_dispatch,
-               event_base_loopbreak_fail, event_new, event_add>
+        libevent::Reactor<event_base_new, event_base_once, event_base_dispatch,
+                          event_base_loopbreak_fail, event_new, event_add>
               reactor;
         REQUIRE_THROWS(reactor.stop());
     }
@@ -81,23 +86,23 @@ static event *event_new_fail(event_base *, evutil_socket_t, short,
     return nullptr;
 }
 
-static int event_add_fail(event *, const timeval *) {
-    return -1;
-}
+static int event_add_fail(event *, const timeval *) { return -1; }
 
 } // extern "C"
 
 TEST_CASE("Reactor: periodic event") {
     SECTION("We deal with event_new() failure") {
-        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
-               event_base_loopbreak, event_new_fail, event_add>
+        libevent::Reactor<event_base_new, event_base_once,
+                          event_base_dispatch_no_events, event_base_loopbreak,
+                          event_new_fail, event_add>
               reactor;
         REQUIRE_THROWS(reactor.run());
     }
 
     SECTION("We deal with event_add() failure") {
-        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
-               event_base_loopbreak, event_new, event_add_fail>
+        libevent::Reactor<event_base_new, event_base_once,
+                          event_base_dispatch_no_events, event_base_loopbreak,
+                          event_new, event_add_fail>
               reactor;
         REQUIRE_THROWS(reactor.run());
     }
@@ -114,8 +119,8 @@ static int event_base_once_fail(event_base *, evutil_socket_t, short,
 
 TEST_CASE("Reactor: call_later") {
     SECTION("We deal with event_base_once() failure") {
-        Reactor<event_base_new, event_base_once_fail, event_base_dispatch,
-               event_base_loopbreak>
+        libevent::Reactor<event_base_new, event_base_once_fail,
+                          event_base_dispatch, event_base_loopbreak>
               reactor;
         REQUIRE_THROWS(reactor.call_later(0.0, []() {}));
     }
@@ -123,8 +128,8 @@ TEST_CASE("Reactor: call_later") {
 
 TEST_CASE("Reactor: pollfd") {
     SECTION("We deal with event_base_once() failure") {
-        Reactor<event_base_new, event_base_once_fail, event_base_dispatch,
-               event_base_loopbreak>
+        libevent::Reactor<event_base_new, event_base_once_fail,
+                          event_base_dispatch, event_base_loopbreak>
               reactor;
         REQUIRE_THROWS(reactor.pollfd(0, 0, 0.0, [](Error, short) {}));
     }

--- a/test/libevent/reactor.cpp
+++ b/test/libevent/reactor.cpp
@@ -6,7 +6,7 @@
 #include "private/ext/catch.hpp"
 
 #include "private/common/utils.hpp"
-#include "private/libevent/poller.hpp"
+#include "private/libevent/reactor.hpp"
 #include <measurement_kit/common.hpp>
 
 using namespace mk;
@@ -23,12 +23,12 @@ static int sigaction_fail(int, const struct sigaction *, struct sigaction *) {
 
 TEST_CASE("LibeventLibrary") {
     SECTION("We deal with evthread_use_pthreads() failure") {
-        REQUIRE_THROWS((Poller<>::LibeventLibrary<evthread_use_pthreads_fail,
+        REQUIRE_THROWS((Reactor<>::LibeventLibrary<evthread_use_pthreads_fail,
                                                  sigaction>{}));
     }
 
     SECTION("We deal with sigaction() failure") {
-        REQUIRE_THROWS((Poller<>::LibeventLibrary<evthread_use_pthreads,
+        REQUIRE_THROWS((Reactor<>::LibeventLibrary<evthread_use_pthreads,
                                                  sigaction_fail>{}));
     }
 }
@@ -45,32 +45,32 @@ static int event_base_loopbreak_fail(event_base *) { return -1; }
 
 } // extern "C"
 
-TEST_CASE("Poller: basic functionality") {
+TEST_CASE("Reactor: basic functionality") {
     SECTION("We deal with event_base_new() failure") {
-        REQUIRE_THROWS((Poller<event_base_new_fail, event_base_once,
+        REQUIRE_THROWS((Reactor<event_base_new_fail, event_base_once,
                                event_base_dispatch, event_base_loopbreak,
                                event_new, event_add>{}));
     }
 
     SECTION("We deal with event_base_dispatch() failure") {
-        Poller<event_base_new, event_base_once, event_base_dispatch_fail,
+        Reactor<event_base_new, event_base_once, event_base_dispatch_fail,
                event_base_loopbreak, event_new, event_add>
-              poller;
-        REQUIRE_THROWS(poller.run());
+              reactor;
+        REQUIRE_THROWS(reactor.run());
     }
 
     SECTION("We deal with event_base_dispatch() running out of events") {
-        Poller<event_base_new, event_base_once, event_base_dispatch_no_events,
+        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
                event_base_loopbreak, event_new, event_add>
-              poller;
-        poller.run();
+              reactor;
+        reactor.run();
     }
 
     SECTION("We deal with event_base_loopbreak() failure") {
-        Poller<event_base_new, event_base_once, event_base_dispatch,
+        Reactor<event_base_new, event_base_once, event_base_dispatch,
                event_base_loopbreak_fail, event_new, event_add>
-              poller;
-        REQUIRE_THROWS(poller.stop());
+              reactor;
+        REQUIRE_THROWS(reactor.stop());
     }
 }
 
@@ -87,19 +87,19 @@ static int event_add_fail(event *, const timeval *) {
 
 } // extern "C"
 
-TEST_CASE("Poller: periodic event") {
+TEST_CASE("Reactor: periodic event") {
     SECTION("We deal with event_new() failure") {
-        Poller<event_base_new, event_base_once, event_base_dispatch_no_events,
+        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
                event_base_loopbreak, event_new_fail, event_add>
-              poller;
-        REQUIRE_THROWS(poller.run());
+              reactor;
+        REQUIRE_THROWS(reactor.run());
     }
 
     SECTION("We deal with event_add() failure") {
-        Poller<event_base_new, event_base_once, event_base_dispatch_no_events,
+        Reactor<event_base_new, event_base_once, event_base_dispatch_no_events,
                event_base_loopbreak, event_new, event_add_fail>
-              poller;
-        REQUIRE_THROWS(poller.run());
+              reactor;
+        REQUIRE_THROWS(reactor.run());
     }
 }
 
@@ -112,20 +112,20 @@ static int event_base_once_fail(event_base *, evutil_socket_t, short,
 
 } // extern "C"
 
-TEST_CASE("Poller: call_later") {
+TEST_CASE("Reactor: call_later") {
     SECTION("We deal with event_base_once() failure") {
-        Poller<event_base_new, event_base_once_fail, event_base_dispatch,
+        Reactor<event_base_new, event_base_once_fail, event_base_dispatch,
                event_base_loopbreak>
-              poller;
-        REQUIRE_THROWS(poller.call_later(0.0, []() {}));
+              reactor;
+        REQUIRE_THROWS(reactor.call_later(0.0, []() {}));
     }
 }
 
-TEST_CASE("Poller: pollfd") {
+TEST_CASE("Reactor: pollfd") {
     SECTION("We deal with event_base_once() failure") {
-        Poller<event_base_new, event_base_once_fail, event_base_dispatch,
+        Reactor<event_base_new, event_base_once_fail, event_base_dispatch,
                event_base_loopbreak>
-              poller;
-        REQUIRE_THROWS(poller.pollfd(0, 0, 0.0, [](Error, short) {}));
+              reactor;
+        REQUIRE_THROWS(reactor.pollfd(0, 0, 0.0, [](Error, short) {}));
     }
 }


### PR DESCRIPTION
Use less confusing name. That class implements reactor, so
call it reactor in the mk::libevent namespace.