### PR TITLE
fix(t/c/worker.cpp): silence compiler warning

### DIFF
--- a/test/common/worker.cpp
+++ b/test/common/worker.cpp
@@ -30,7 +30,6 @@ TEST_CASE("The worker is robust to submitting many tasks in a row") {
         std::this_thread::sleep_for(1s);
         auto concurrency = worker->concurrency();
         std::cout << "Concurrency: " << concurrency << "\n";
-        REQUIRE(concurrency >= 0);
         // Cast to unsigned safe because of the above REQUIRE()
         REQUIRE((unsigned short)concurrency <= worker->parallelism());
         if (concurrency == 0) {


### PR DESCRIPTION
Now concurrency is unsigned, so checking for it being greater
or equal than zero is clearly redundant.