### PR TITLE
fix(test/nettests): avoid races and optimize duration

### DIFF
--- a/test/nettests/runnable.cpp
+++ b/test/nettests/runnable.cpp
@@ -192,6 +192,14 @@ TEST_CASE("Make sure that 'randomize_input' works") {
         test.reactor = Reactor::make();
         test.input_filepaths.push_back("./test/fixtures/hosts.txt");
         test.options["randomize_input"] = shuffle;
+        /*
+         * During #1297, I have experienced a lot of confusion because this
+         * test was not working correctly, but only under Valgrind, due to
+         * race conditions by which the order with which parallel tests were
+         * started was not the one in which they ended. Avoid this kind of
+         * unpredictable behavior by forcing no parallelism.
+         */
+        test.options["parallelism"] = 1;
         test.needs_input = true;
 
         test.reactor->loop_with_initial_event([&]() {

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -50,6 +50,12 @@ with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
         mk::ooni::collector::testing_collector_url();
     test.options["bouncer_base_url"] =
         mk::ooni::bouncer::production_bouncer_url();
+    /*
+     * The `with_runnable` function is used for tests for which we do not
+     * care to submit to a collector. So, disable the collector so that these
+     * tests are going to be much faster than otherwise.
+     */
+    test.options["no_collector"] = 1;
     test.logger->set_verbosity(MK_LOG_INFO);
     lambda(test);
 }


### PR DESCRIPTION
1. in `test/nettests/runnable.cpp` avoid the races that were so
   annoying when I was finishing #1297 up

2. in `test/nettests/utils.hpp` avoid doing collect for tests for
   which we really do not care about doing any collect