### PR TITLE
fix(t/n/utils.hpp): use the testing bouncer

### DIFF
--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -17,17 +17,11 @@ namespace nettests {
 
 template <typename T> mk::nettests::BaseTest make_test() {
     return T{}
-        .set_options("geoip_country_path", "GeoIP.dat")
-        .set_options("geoip_asn_path", "GeoIPASNum.dat")
-        .set_verbosity(MK_LOG_INFO)
-        /*
-         * FIXME: the testing bouncer is not working. So use the testing
-         * collector with the production bouncer.
-         */
-        .set_options("collector_base_url",
-                mk::ooni::collector::testing_collector_url())
-        .set_options("bouncer_base_url",
-                mk::ooni::bouncer::production_bouncer_url());
+          .set_options("geoip_country_path", "GeoIP.dat")
+          .set_options("geoip_asn_path", "GeoIPASNum.dat")
+          .set_verbosity(MK_LOG_INFO)
+          .set_options("bouncer_base_url",
+                       mk::ooni::bouncer::testing_bouncer_url());
 }
 
 template <typename T> mk::nettests::BaseTest make_test(std::string s) {
@@ -45,11 +39,7 @@ static inline void run_async(mk::nettests::BaseTest test) {
 static inline void
 with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
-    // FIXME: see above comment regarding collector and bouncer
-    test.options["collector_base_url"] =
-        mk::ooni::collector::testing_collector_url();
-    test.options["bouncer_base_url"] =
-        mk::ooni::bouncer::production_bouncer_url();
+    test.options["bouncer_base_url"] = mk::ooni::bouncer::testing_bouncer_url();
     /*
      * The `with_runnable` function is used for tests for which we do not
      * care to submit to a collector. So, disable the collector so that these


### PR DESCRIPTION
This is optimistic. As of now the testing bouncer is not working
yet, but, in the event that it is restored to work, this should
remove some cruft from the regress tests and use that rather than
coupling the production bouncer with the testing collector.

Cc: @hellais @darkk

Example run that fails (also posted on IRC):

```
./measurement_kit -b https://bouncer.test.ooni.io -v http_invalid_request_line
Contacting bouncer: https://bouncer.test.ooni.io
[D] POSTing to 'https://bouncer.test.ooni.io/bouncer/net-tests' data '{"net-tests":[{"input-hashes":null,"name":"http_invalid_request_line","test-helpers":["tcp-echo"],"version":"0.0.2"}]}'
[D] http::request: {
[D] http::request:     bouncer_base_url => https://bouncer.test.ooni.io
[D] http::request:     geoip_asn_path => GeoIPASNum.dat
[D] http::request:     geoip_country_path => GeoIP.dat
[D] http::request:     http/method => POST
[D] http::request:     http/url => https://bouncer.test.ooni.io/bouncer/net-tests
[D] http::request: }
[...]
[D] connect_first_of success
[D] ca_bundle_path: '/etc/ssl/cert.pem'
[D] connect ssl...
[D] connect ssl... callback (error: 0)
[D] SSL version: TLSv1
[D] connection: got bufferevent event: ztFrw
[!] libevent has detected an SSL dirty shutdown
[!] Got error: ssl_dirty_shutdown
[D] Received error ssl_dirty_shutdown on connection
[D] Now reacting to delivered error 1058
[!] Bouncer error: {ssl_dirty_shutdown}
95%: ending the test
100%: test complete
```