### PR TITLE
.travis.yml: add -Werror to CXXFLAGS and CFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,18 @@ matrix:
 
     - sudo: required
       env: DOCKER_SPEC=valgrind-clang pkg_make_flags="V=0 -j3"
+           CXXFLAGS="-Werror" CFLAGS="-Werror"
       services:
         - docker
 
     - sudo: required
       env: DOCKER_SPEC=valgrind-gcc pkg_make_flags="V=0 -j3"
+           CXXFLAGS="-Werror" CFLAGS="-Werror"
       services:
         - docker
 
     - sudo: required
       env: DOCKER_SPEC=coveralls pkg_make_flags="V=0 -j3"
+           CXXFLAGS="-Werror" CFLAGS="-Werror"
       services:
         - docker


### PR DESCRIPTION
At least on the CI environment, I would like the code not to
produce any warning. In other scenarios, there _may_ be a few
warnings caused by porting software. For example, I do see
a few warnings about chars that cannot be negative on Android
on platforms that are negative. The code triggering such
warnings is not from us but from third parties.