### PR TITLE
travis: make sure we honour -Werror for C++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ matrix:
 
     - sudo: required
       env: DOCKER_SPEC=valgrind-clang pkg_make_flags="V=0 -j3"
-           CXXFLAGS="-Werror"
+           CXXFLAGS="-Werror" CFLAGS="-Werror"
       services:
         - docker
 
+    # Note: with CFLAGS="-Werror" ./configure fails for this job (see #1318)
     - sudo: required
       env: DOCKER_SPEC=valgrind-gcc pkg_make_flags="V=0 -j3"
            CXXFLAGS="-Werror"
       services:
         - docker
 
+    # Note: with CFLAGS="-Werror" ./configure fails for this job (see #1318)
     - sudo: required
       env: DOCKER_SPEC=coveralls pkg_make_flags="V=0 -j3"
            CXXFLAGS="-Werror"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,18 @@ matrix:
 
     - sudo: required
       env: DOCKER_SPEC=valgrind-clang pkg_make_flags="V=0 -j3"
-           CXXFLAGS="-Werror" CFLAGS="-Werror"
+           CXXFLAGS="-Werror"
       services:
         - docker
 
     - sudo: required
       env: DOCKER_SPEC=valgrind-gcc pkg_make_flags="V=0 -j3"
-           CXXFLAGS="-Werror" CFLAGS="-Werror"
+           CXXFLAGS="-Werror"
       services:
         - docker
 
     - sudo: required
       env: DOCKER_SPEC=coveralls pkg_make_flags="V=0 -j3"
-           CXXFLAGS="-Werror" CFLAGS="-Werror"
+           CXXFLAGS="-Werror"
       services:
         - docker

--- a/build/docker/script/setup
+++ b/build/docker/script/setup
@@ -12,6 +12,9 @@ shift
 docker run                                                                 \
     -e "pkg_configure_flags=$pkg_configure_flags"                          \
     -e "pkg_make_flags=$pkg_make_flags"                                    \
+    -e "CPPFLAGS=$CPPFLAGS"                                                \
+    -e "CFLAGS=$CFLAGS"                                                    \
+    -e "CXXFLAGS=$CXXFLAGS"                                                \
     -e "COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN"                        \
     -e "TRAVIS_BRANCH=$TRAVIS_BRANCH"                                      \
     -v $REPOROOT:/mk                                                       \

--- a/build/docker/spec/valgrind-clang
+++ b/build/docker/spec/valgrind-clang
@@ -4,7 +4,7 @@ set -e
 export CPP="clang -E"
 export CC="clang"
 export CXX="clang++"
-export CXXFLAGS="-stdlib=libc++"
+export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
 export pkg_make_check_rule="run-valgrind-docker"
 
 debian_deps="$debian_deps autoconf"


### PR DESCRIPTION
Based on #1316. The rationale for having `-Werror` for C++ only is that we _only_ write C++ code and the C code we have in tree is from third parties. As such, I guess it's okay to require that only our code does not produce any warning only. `-Werror` for C is disabled because [configure fails with -Werror and GCC]( https://travis-ci.org/measurement-kit/measurement-kit/jobs/270364007 ).

Closes #1317