### PR TITLE
fix(*): use `gpg` rather than `gpg2`

### DIFF
--- a/build/fetch-dep
+++ b/build/fetch-dep
@@ -39,7 +39,7 @@ npm install download-github-release
 ./node_modules/.bin/download-github-release $arguments                     \
         measurement-kit dependencies
 for file in *.tgz; do
-    gpg2 --verify $file.asc $file
+    gpg --verify $file.asc $file
     install -d $pkg_prefix
     tar -C $pkg_prefix -xf $file
 done

--- a/build/ios/library
+++ b/build/ios/library
@@ -6,7 +6,7 @@ RELEASE_URL=https://github.com/measurement-kit/measurement-kit/releases/download
 RELEASE_FILE=$(basename $RELEASE_URL)
 if wget $RELEASE_URL; then
     wget $RELEASE_URL.asc
-    gpg2 --verify $RELEASE_FILE.asc
+    gpg --verify $RELEASE_FILE.asc
     tar xzf $RELEASE_FILE
     rm $RELEASE_FILE $RELEASE_FILE.asc
     $ROOTDIR/build-frameworks
@@ -21,7 +21,7 @@ echo "Downloading and verifying precompiled dependencies from github"
     DEPS_FILE=$(basename $DEPS_URL)
     curl --progress-bar -LO $DEPS_URL
     curl --progress-bar -LO $DEPS_URL.asc
-    gpg2 --verify $DEPS_FILE.asc
+    gpg --verify $DEPS_FILE.asc
     tar -xzf $DEPS_FILE
     rm $DEPS_FILE $DEPS_FILE.asc
 )

--- a/build/sign
+++ b/build/sign
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 while [ $# -gt 0 ]; do
-    gpg2 -u 738877AA6C829F26A431C5F480B691277733D95B -b --armor $1
+    gpg -u 738877AA6C829F26A431C5F480B691277733D95B -b --armor $1
     shift
 done

--- a/build/tarball
+++ b/build/tarball
@@ -22,7 +22,7 @@ install -d a/b/c
     ./autogen.sh --no-geoip  # do not distribute the GeoIP database
     cd ..
     tar -czf measurement-kit-$v.tar.gz measurement-kit-$v
-    gpg2 -u 738877AA6C829F26A431C5F480B691277733D95B -b --armor measurement-kit-$v.tar.gz
+    gpg -u 738877AA6C829F26A431C5F480B691277733D95B -b --armor measurement-kit-$v.tar.gz
 )
 mv a/b/c/measurement-kit-$v.tar.gz.asc .
 mv a/b/c/measurement-kit-$v.tar.gz .

--- a/doc/tutorial/unix.md
+++ b/doc/tutorial/unix.md
@@ -90,17 +90,17 @@ with a PGP key having this fingerprint:
 7388 77AA 6C82 9F26 A431  C5F4 80B6 9127 7733 D95B
 ```
 
-To verify the PGP signature, you need `gpg2` installed. Then, fetch the
+To verify the PGP signature, you need `gpg` installed. Then, fetch the
 aforementioned public key with:
 
 ```
-gpg2 --recv-keys 738877AA6C829F26A431C5F480B691277733D95B
+gpg --recv-keys 738877AA6C829F26A431C5F480B691277733D95B
 ```
 
 Finally, verify the digital signature with:
 
 ```
-gpg2 --verify measurement-kit-$version.tar.gz.asc
+gpg --verify measurement-kit-$version.tar.gz.asc
 ```
 
 The result should indicate that the signature is good.


### PR DESCRIPTION
It seems now `gpg2` is simply shipped as `gpg`.