### PR TITLE
fix(geoip): make cache thread local

### DIFF
--- a/build/ios/cross
+++ b/build/ios/cross
@@ -12,7 +12,7 @@ shift
 ARCH=$1
 shift
 
-MINIOSVERSION="8.0"
+MINIOSVERSION="9.0"
 if [ "$PLATFORM" = "iphoneos" ]; then
     EXTRA_CONFIG="--host=arm-apple-darwin --target=arm-apple-darwin --disable-shared"
     MINVERSION="-miphoneos-version-min=$MINIOSVERSION"

--- a/include/private/ooni/utils.hpp
+++ b/include/private/ooni/utils.hpp
@@ -42,7 +42,7 @@ class GeoipDatabase {
 
 class GeoipCache {
   public:
-    static Var<GeoipCache> global();
+    static Var<GeoipCache> thread_local_instance();
 
     Var<GeoipDatabase> get(std::string path, bool &did_open);
 

--- a/measurement_kit.podspec
+++ b/measurement_kit.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-CMD
     ./build/ios/library
   CMD
-  s.platform = :ios, "7.1"
+  s.platform = :ios, "9.0"
   s.vendored_framework = "build/ios/Frameworks/*.framework"
 end

--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -205,7 +205,7 @@ void Runnable::geoip_lookup(Callback<> cb) {
                                             std::string{});
             if (save_cc and country_path != "") {
                 try {
-                    probe_cc = *GeoipCache::global()
+                    probe_cc = *GeoipCache::thread_local_instance()
                        ->resolve_country_code(country_path, ip, logger);
                 } catch (const Error &err) {
                     logger->warn("cannot lookup country code: %s",
@@ -221,7 +221,7 @@ void Runnable::geoip_lookup(Callback<> cb) {
             auto asn_path = options.get("geoip_asn_path", std::string{});
             if (save_asn and asn_path != "") {
                 try {
-                    probe_asn = *GeoipCache::global()
+                    probe_asn = *GeoipCache::thread_local_instance()
                         ->resolve_asn(asn_path, ip, logger);
                 } catch (const Error &err) {
                     logger->warn("cannot lookup asn: %s",

--- a/src/libmeasurement_kit/ooni/utils.cpp
+++ b/src/libmeasurement_kit/ooni/utils.cpp
@@ -18,8 +18,8 @@ void resolver_lookup(Callback<Error, std::string> callback, Settings settings,
     resolver_lookup_impl(callback, settings, reactor, logger);
 }
 
-/* static */ Var<GeoipCache> GeoipCache::global() {
-    static Var<GeoipCache> singleton(new GeoipCache);
+/* static */ Var<GeoipCache> GeoipCache::thread_local_instance() {
+    static thread_local Var<GeoipCache> singleton(new GeoipCache);
     return singleton;
 }
 

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -190,19 +190,15 @@ static void compare_dns_queries(Var<Entry> entry,
     std::set<std::string> ctrl_asns;
 
     std::string asn_p = options.get("geoip_asn_path", std::string{});
-    logger->debug("Creating..");
-    // TODO: perhaps here we could use GeoipCache::global()
-    GeoipDatabase ip_location(asn_p);
+    auto ip_location = GeoipCache::thread_local_instance()->get(asn_p);
     for (auto exp_addr : exp_addresses) {
-        logger->debug("expaddr");
-        ErrorOr<std::string> asn = ip_location.resolve_asn(exp_addr);
+        ErrorOr<std::string> asn = ip_location->resolve_asn(exp_addr);
         if (asn && asn.as_value() != "AS0") {
             exp_asns.insert(asn.as_value());
         }
     }
-    logger->debug("control");
     for (auto ctrl_addr : ctrl_addresses) {
-        ErrorOr<std::string> asn = ip_location.resolve_asn(ctrl_addr);
+        ErrorOr<std::string> asn = ip_location->resolve_asn(ctrl_addr);
         if (asn && asn.as_value() != "AS0") {
             ctrl_asns.insert(asn.as_value());
         }

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -137,19 +137,19 @@ TEST_CASE("ip lookup works") {
 }
 
 TEST_CASE("geoip works") {
-    auto asn = ooni::GeoipCache::global()->resolve_asn(
+    auto asn = ooni::GeoipCache::thread_local_instance()->resolve_asn(
             "GeoIPASNum.dat",
             "130.192.16.172"
     );
-    auto cname = ooni::GeoipCache::global()->resolve_country_name(
+    auto cname = ooni::GeoipCache::thread_local_instance()->resolve_country_name(
             "GeoIP.dat",
             "130.192.16.172"
     );
-    auto cc = ooni::GeoipCache::global()->resolve_country_code(
+    auto cc = ooni::GeoipCache::thread_local_instance()->resolve_country_code(
             "GeoIP.dat",
             "130.192.16.172"
     );
-    auto city = ooni::GeoipCache::global()->resolve_city_name(
+    auto city = ooni::GeoipCache::thread_local_instance()->resolve_city_name(
             "GeoLiteCity.dat",
             "130.192.16.172"
     );
@@ -160,64 +160,64 @@ TEST_CASE("geoip works") {
 }
 
 TEST_CASE("geoip memoization works") {
-    ooni::GeoipCache::global()->invalidate(); // Start clean
+    ooni::GeoipCache::thread_local_instance()->invalidate(); // Start clean
 
     // Open more then once. After the first open we should not really open.
-    auto gi = ooni::GeoipCache::global()->get(
+    auto gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat");
     bool first_open;
 
     first_open = true;
-    gi = ooni::GeoipCache::global()->get(
+    gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat", first_open);
     REQUIRE(first_open == false);
 
     // Repeat two more times to make sure behavior is consistent
 
     first_open = true;
-    gi = ooni::GeoipCache::global()->get(
+    gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat", first_open);
     REQUIRE(first_open == false);
 
     first_open = true;
-    gi = ooni::GeoipCache::global()->get(
+    gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat", first_open);
     REQUIRE(first_open == false);
 
     // Make sure that, if we change at least one file name, we reopen all
 
     first_open = false;
-    gi = ooni::GeoipCache::global()->get(
+    gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoLiteCity.dat", first_open);
     REQUIRE(first_open == true);
 
     // Make sure that, if we close, then of course we reopen
 
-    ooni::GeoipCache::global()->invalidate();
+    ooni::GeoipCache::thread_local_instance()->invalidate();
 
     first_open = false;
-    gi = ooni::GeoipCache::global()->get(
+    gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoLiteCity.dat", first_open);
     REQUIRE(first_open == true);
 
 }
 
 TEST_CASE("IpLocation::resolve_countr_code() deals with nonexistent database") {
-    REQUIRE((ooni::GeoipCache::global()->resolve_country_code(
+    REQUIRE((ooni::GeoipCache::thread_local_instance()->resolve_country_code(
                     "invalid.dat", "8.8.8.8"
                 ).as_error()
              == ooni::GeoipDatabaseOpenError()));
 }
 
 TEST_CASE("IpLocation::resolve_countr_name() deals with nonexistent database") {
-    REQUIRE((ooni::GeoipCache::global()->resolve_country_name(
+    REQUIRE((ooni::GeoipCache::thread_local_instance()->resolve_country_name(
                     "invalid.dat", "8.8.8.8"
                 ).as_error()
              == ooni::GeoipDatabaseOpenError()));
 }
 
 TEST_CASE("IpLocation::resolve_asn() deals with nonexistent database") {
-    REQUIRE((ooni::GeoipCache::global()->resolve_asn(
+    REQUIRE((ooni::GeoipCache::thread_local_instance()->resolve_asn(
                     "invalid.dat", "8.8.8.8"
                 ).as_error()
              == ooni::GeoipDatabaseOpenError()));


### PR DESCRIPTION
This was initially submitted as #1314. Then it was reverted in #1321, because iOS does not support `thread_local` (#1319).

However, [research](https://stackoverflow.com/a/29929949) suggests that it is actually supported for iOS >= 9.0.

As of today, the market share of iOS >= 9.0 is 98.58% (data gathered from [apteligent](https://data.apteligent.com/ios/) and subject to change in the future, of course).

It seems to me it makes a lot of sense to remove support for iOS < 9 and have the `thread_local` feature. If we _really_ need iOS 8 support, I can write some iOS 8 specific code using pthreads.

I really prefer a solution based on `thread_local` storage rather than one with a global cache for which we should maintain locking and for which we should have destruction from possibly multiple threads.

Compared to #1314, this diff contains the following changes:

- removed support for iOS < 9

Closes #1319.
Closes #1209.