### PR TITLE
fix(libevent): better initialize once code

### DIFF
--- a/include/private/libevent/reactor.hpp
+++ b/include/private/libevent/reactor.hpp
@@ -99,7 +99,7 @@ class Reactor : public mk::Reactor, public NonCopyable, public NonMovable {
     /// \brief Code to make sure libevent is correctly configured.
 
     template <MK_MOCK(evthread_use_pthreads), MK_MOCK(sigaction)>
-    static inline void init_libevent_once() {
+    static inline void libevent_init_once() {
         return locked_global([]() {
             static bool initialized = false;
             if (initialized) {
@@ -132,7 +132,7 @@ class Reactor : public mk::Reactor, public NonCopyable, public NonMovable {
     event_base *evbase = nullptr;
 
     Reactor() {
-        init_libevent_once();
+        libevent_init_once();
         if ((evbase = event_base_new()) == nullptr) {
             throw std::runtime_error("event_base_new");
         }

--- a/include/private/libevent/reactor.hpp
+++ b/include/private/libevent/reactor.hpp
@@ -24,6 +24,7 @@
 #include <functional>                              // for std::function
 #include <measurement_kit/common/callback.hpp>     // for mk::Callback
 #include <measurement_kit/common/error.hpp>        // for mk::Error
+#include <measurement_kit/common/locked.hpp>       // for mk::locked_global
 #include <measurement_kit/common/logger.hpp>       // for mk::warn
 #include <measurement_kit/common/non_copyable.hpp> // for mk::NonCopyable
 #include <measurement_kit/common/non_movable.hpp>  // for mk::NonMovable
@@ -98,26 +99,24 @@ class Reactor : public mk::Reactor, public NonCopyable, public NonMovable {
     /// \brief Code to make sure libevent is correctly configured.
 
     template <MK_MOCK(evthread_use_pthreads), MK_MOCK(sigaction)>
-    class LibeventLibrary {
-      public:
-        static LibeventLibrary *global() {
-            static LibeventLibrary singleton;
-            return &singleton;
-        }
-
-        LibeventLibrary() {
+    static inline void init_libevent_once() {
+        return locked_global([]() {
+            static bool initialized = false;
+            if (initialized) {
+                return;
+            }
+            mk::debug("initializing libevent once");
             if (evthread_use_pthreads() != 0) {
                 throw std::runtime_error("evthread_use_pthreads");
             }
-            struct sigaction sa {};
+            struct sigaction sa{};
             sa.sa_handler = SIG_IGN;
             if (sigaction(SIGPIPE, &sa, nullptr) != 0) {
                 throw std::runtime_error("sigaction");
             }
-        }
-    };
-
-    LibeventLibrary<> *library = LibeventLibrary<>::global();
+            initialized = true;
+        });
+    }
 
     // ### Event loop
     /*-
@@ -133,6 +132,7 @@ class Reactor : public mk::Reactor, public NonCopyable, public NonMovable {
     event_base *evbase = nullptr;
 
     Reactor() {
+        init_libevent_once();
         if ((evbase = event_base_new()) == nullptr) {
             throw std::runtime_error("event_base_new");
         }

--- a/test/libevent/reactor.cpp
+++ b/test/libevent/reactor.cpp
@@ -21,17 +21,16 @@ static int sigaction_fail(int, const struct sigaction *, struct sigaction *) {
 
 } // extern "C"
 
-TEST_CASE("LibeventLibrary") {
+TEST_CASE("libevent_init_once") {
     SECTION("We deal with evthread_use_pthreads() failure") {
-        REQUIRE_THROWS(
-              (libevent::Reactor<>::LibeventLibrary<evthread_use_pthreads_fail,
-                                                    sigaction>{}));
+        REQUIRE_THROWS((libevent::Reactor<>::libevent_init_once<
+                        evthread_use_pthreads_fail, sigaction>{}));
     }
 
     SECTION("We deal with sigaction() failure") {
         REQUIRE_THROWS(
-              (libevent::Reactor<>::LibeventLibrary<evthread_use_pthreads,
-                                                    sigaction_fail>{}));
+              (libevent::Reactor<>::libevent_init_once<evthread_use_pthreads,
+                                                       sigaction_fail>{}));
     }
 }
 

--- a/test/libevent/reactor.cpp
+++ b/test/libevent/reactor.cpp
@@ -24,13 +24,13 @@ static int sigaction_fail(int, const struct sigaction *, struct sigaction *) {
 TEST_CASE("libevent_init_once") {
     SECTION("We deal with evthread_use_pthreads() failure") {
         REQUIRE_THROWS((libevent::Reactor<>::libevent_init_once<
-                        evthread_use_pthreads_fail, sigaction>{}));
+                        evthread_use_pthreads_fail, sigaction>()));
     }
 
     SECTION("We deal with sigaction() failure") {
         REQUIRE_THROWS(
               (libevent::Reactor<>::libevent_init_once<evthread_use_pthreads,
-                                                       sigaction_fail>{}));
+                                                       sigaction_fail>()));
     }
 }
 


### PR DESCRIPTION
Do not relay on side effect of a constructor of an unused
object to initialize libevent once.

Rather, have explicit initialization function.

The paranoia here is that a compiler may optimize away
initialization because the compiler sees that the object
is actually unused.

Use a proper initialization function, instead.