### PR TITLE
fix(geoip): remove all refs to GeoLiteCity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@
 /CTestTestfile.cmake
 /GeoIP.dat
 /GeoIPASNum.dat
-/GeoLiteCity.dat
 /build/android/jni/conf
 /build/android/jni/spec
 /citizenlab-test-lists.*.csv

--- a/autogen.sh
+++ b/autogen.sh
@@ -103,7 +103,6 @@ gen_executables() {
 grep -v -E "^/(test|example){1}/.*" .gitignore > .gitignore.new
 echo /GeoIP.dat >> .gitignore.new
 echo /GeoIPASNum.dat >> .gitignore.new
-echo /GeoLiteCity.dat >> .gitignore.new
 mv .gitignore.new .gitignore
 
 echo "* Generating automatic includes: include/measurement_kit/*.hpp"

--- a/build/autogen.d/geoip
+++ b/build/autogen.d/geoip
@@ -8,10 +8,6 @@ autogen_get_geoip() {
         wget $base/GeoLiteCountry/GeoIP.dat.gz -O GeoIP.dat.gz
         gzip -d GeoIP.dat.gz
     fi
-    if [ ! -f "GeoLiteCity.dat" ]; then
-        wget $base/GeoLiteCity.dat.gz -O GeoLiteCity.dat.gz
-        gzip -d GeoLiteCity.dat.gz
-    fi
     if [ ! -f "GeoIPASNum.dat" ]; then
         wget $base/asnum/GeoIPASNum.dat.gz -O GeoIPASNum.dat.gz
         gzip -d GeoIPASNum.dat.gz

--- a/test/ooni/utils.cpp
+++ b/test/ooni/utils.cpp
@@ -149,14 +149,9 @@ TEST_CASE("geoip works") {
             "GeoIP.dat",
             "130.192.16.172"
     );
-    auto city = ooni::GeoipCache::thread_local_instance()->resolve_city_name(
-            "GeoLiteCity.dat",
-            "130.192.16.172"
-    );
     REQUIRE(*asn == std::string{"AS137"});
     REQUIRE(*cc == std::string{"IT"});
     REQUIRE(*cname == std::string{"Italy"});
-    REQUIRE(*city == std::string{"Turin"});
 }
 
 TEST_CASE("geoip memoization works") {
@@ -165,9 +160,8 @@ TEST_CASE("geoip memoization works") {
     // Open more then once. After the first open we should not really open.
     auto gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat");
-    bool first_open;
 
-    first_open = true;
+    bool first_open = true;
     gi = ooni::GeoipCache::thread_local_instance()->get(
         "GeoIP.dat", first_open);
     REQUIRE(first_open == false);
@@ -188,7 +182,7 @@ TEST_CASE("geoip memoization works") {
 
     first_open = false;
     gi = ooni::GeoipCache::thread_local_instance()->get(
-        "GeoLiteCity.dat", first_open);
+        "GeoIPASNum.dat", first_open);
     REQUIRE(first_open == true);
 
     // Make sure that, if we close, then of course we reopen
@@ -197,7 +191,7 @@ TEST_CASE("geoip memoization works") {
 
     first_open = false;
     gi = ooni::GeoipCache::thread_local_instance()->get(
-        "GeoLiteCity.dat", first_open);
+        "GeoIPASNum.dat", first_open);
     REQUIRE(first_open == true);
 
 }


### PR DESCRIPTION
This file is huge and unused by OONI or by anyone else. We fetch
it every time we compile. And this is a waste.