### PR TITLE
fix: ios build

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -270,6 +270,8 @@ AC_DEFUN([MK_CHECK_CA_BUNDLE], [
   elif test "x$cross_compiling" == "xyes"; then
     AC_MSG_RESULT([skipped (cross compiling)])
     AC_MSG_WARN([skipped the ca-bundle detection when cross-compiling])
+    AC_DEFINE_UNQUOTED(MK_CA_BUNDLE, "", [Location of default ca bundle])
+    AC_SUBST(MK_CA_BUNDLE)
   else
     AC_MSG_RESULT([no])
     AC_MSG_ERROR([you should give a ca-bundle location])

--- a/build/ios/cross
+++ b/build/ios/cross
@@ -42,6 +42,7 @@ export CXXFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --
 export LDFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 
 export pkg_configure_flags="$EXTRA_CONFIG"
+export pkg_make_flags="V=0 $pkg_make_flags"
 export pkg_prefix="$DESTDIR"
 export pkg_cross="${PLATFORM}"
 export pkg_cross_arch="${ARCH}"

--- a/include/private/net/libssl.hpp
+++ b/include/private/net/libssl.hpp
@@ -17,6 +17,7 @@
 
 #include "private/common/mock.hpp"
 #include "private/ext/tls_internal.h"
+#include "private/net/builtin_ca_bundle.hpp"
 #include <cassert>
 #include <map>
 #include <measurement_kit/common/locked.hpp>


### PR DESCRIPTION
- fix(i/p/n/libssl.hpp): include default CA bundle

- fix(acinclude.m4): default CA bundle when cross compiling

- feature(build/ios/cross): make build quiet