### PR TITLE
refactor(net): ongoing work

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
 BasedOnStyle: LLVM
 IndentWidth: 4
-ContinuationIndentWidth: 6
 ---

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -81,10 +81,13 @@ class TransportPollable {
     /*
      * Writing is stopped automatically when the send buffer is empty
      * and, when this happens, the FLUSH event is emitted.
+     *
+     * But you can also trigger it manually, if you wish to do so.
      */
     virtual void start_reading() = 0;
     virtual void stop_reading() = 0;
     virtual void start_writing() = 0;
+    virtual void stop_writing() = 0;
 };
 
 class TransportConnectable {
@@ -123,6 +126,9 @@ class Transport : public TransportEmitter,
 
 void write(Var<Transport> txp, Buffer buf, Callback<Error> cb);
 
+void continue_writing(Var<Transport> txp,
+                      Callback<Error, std::function<void()> &> cancel);
+
 void readn_into(Var<Transport> txp, Var<Buffer>, size_t n, Callback<Error> cb);
 
 void readn(Var<Transport> txp, size_t n, Callback<Error, Buffer> cb);
@@ -132,11 +138,11 @@ void read_into(Var<Transport> txp, Var<Buffer>, Callback<Error> cb);
 void read(Var<Transport> t, Callback<Error, Buffer> callback);
 
 void continue_reading_into(Var<Transport> txp, Var<Buffer> buff,
-                           Callback<Error, std::function<void()> &> callback);
+                           Callback<Error, std::function<void()> &> cancel);
 
 void continue_reading(
       Var<Transport> txp,
-      Callback<Error, Buffer, std::function<void()> &> callback);
+      Callback<Error, Buffer, std::function<void()> &> cancel);
 
 } // namespace net
 } // namespace mk

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -30,6 +30,8 @@ class TransportEmitter {
     virtual void on_error(Callback<Error>) = 0;
 
     virtual void close(Callback<>) = 0;
+
+    virtual Var<Reactor> get_reactor() = 0;
 };
 
 class TransportRecorder {
@@ -121,11 +123,9 @@ class Transport : public TransportEmitter,
 
 void write(Var<Transport> txp, Buffer buf, Callback<Error> cb);
 
-void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
-           Var<Reactor> reactor = Reactor::global());
+void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb);
 
-void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback,
-          Var<Reactor> reactor = Reactor::global());
+void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback);
 
 void continue_reading(
       Var<Transport> txp,

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -127,6 +127,10 @@ void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
 void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback,
           Var<Reactor> reactor = Reactor::global());
 
+void continue_reading(
+      Var<Transport> txp,
+      Callback<Error, Buffer, std::function<void()> &> callback);
+
 } // namespace net
 } // namespace mk
 #endif

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -19,15 +19,13 @@ class TransportEmitter {
   public:
     virtual ~TransportEmitter();
 
-    virtual void emit_connect() = 0;
-    virtual void emit_data(Buffer buf) = 0;
-    virtual void emit_flush() = 0;
-    virtual void emit_error(Error err) = 0;
+    virtual void emit_connect(Error err) = 0;
+    virtual void emit_data(Error err, Buffer buf) = 0;
+    virtual void emit_flush(Error err) = 0;
 
-    virtual void on_connect(Callback<>) = 0;
-    virtual void on_data(Callback<Buffer>) = 0;
-    virtual void on_flush(Callback<>) = 0;
-    virtual void on_error(Callback<Error>) = 0;
+    virtual void on_connect(Callback<Error>) = 0;
+    virtual void on_data(Callback<Error, Buffer>) = 0;
+    virtual void on_flush(Callback<Error>) = 0;
 
     virtual void close(Callback<>) = 0;
 

--- a/include/measurement_kit/net/transport.hpp
+++ b/include/measurement_kit/net/transport.hpp
@@ -123,9 +123,16 @@ class Transport : public TransportEmitter,
 
 void write(Var<Transport> txp, Buffer buf, Callback<Error> cb);
 
-void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb);
+void readn_into(Var<Transport> txp, Var<Buffer>, size_t n, Callback<Error> cb);
 
-void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback);
+void readn(Var<Transport> txp, size_t n, Callback<Error, Buffer> cb);
+
+void read_into(Var<Transport> txp, Var<Buffer>, Callback<Error> cb);
+
+void read(Var<Transport> t, Callback<Error, Buffer> callback);
+
+void continue_reading_into(Var<Transport> txp, Var<Buffer> buff,
+                           Callback<Error, std::function<void()> &> callback);
 
 void continue_reading(
       Var<Transport> txp,

--- a/include/private/libevent/connect.hpp
+++ b/include/private/libevent/connect.hpp
@@ -1,0 +1,243 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+#ifndef PRIVATE_NET_CONNECT_IMPL_HPP
+#define PRIVATE_NET_CONNECT_IMPL_HPP
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#ifndef MK_CA_BUNDLE
+#error "Missing MK_CA_BUNDLE definition"
+#endif
+
+#include "private/common/mock.hpp"
+#include "private/libevent/connection.hpp"
+#include "private/net/emitter.hpp"
+#include "private/net/libssl.hpp"
+#include <cerrno>
+#include <event2/bufferevent.h>
+#include <measurement_kit/common/callback.hpp>
+#include <measurement_kit/common/error.hpp>
+#include <measurement_kit/common/error_or.hpp>
+#include <measurement_kit/common/logger.hpp>
+#include <measurement_kit/common/non_copyable.hpp>
+#include <measurement_kit/common/non_movable.hpp>
+#include <measurement_kit/common/reactor.hpp>
+#include <measurement_kit/common/settings.hpp>
+#include <measurement_kit/common/var.hpp>
+#include <measurement_kit/common/utils.hpp>
+#include <measurement_kit/net/error.hpp>
+#include <measurement_kit/net/transport.hpp>
+#include <measurement_kit/net/transport.hpp>
+#include <measurement_kit/portable/sys/socket.h>
+#include <sstream>
+
+extern "C" {
+static inline void mk_libevent_connect(bufferevent *, short, void *);
+}
+
+namespace mk {
+namespace libevent {
+
+class Bev : public NonCopyable, public NonMovable {
+  public:
+    Bev(bufferevent *bev) : bev_{bev} {}
+
+    ~Bev() {
+        if (bev_ != nullptr) {
+            bufferevent_free(bev_);
+        }
+    }
+
+    bufferevent *get() const { return bev_; }
+
+    bufferevent *release() {
+        auto bev = bev_;
+        bev_ = nullptr;
+        return bev;
+    }
+
+    void set(bufferevent *bev) { bev_ = bev; }
+
+  private:
+    bufferevent *bev_ = nullptr;
+};
+
+template <MK_MOCK(bufferevent_socket_new), MK_MOCK(bufferevent_set_timeouts),
+          MK_MOCK(bufferevent_socket_connect),
+          MK_MOCK(bufferevent_openssl_filter_new),
+          MK_MOCK_AS(libssl::verify_peer<>, libssl_verify_peer)>
+void connect(sockaddr *saddr, socklen_t salen, Settings settings,
+             Var<Reactor> reactor, Var<Logger> logger,
+             Callback<Error, Var<net::Transport>> &&cb) {
+    Var<Transport> txp{new Emitter{reactor, logger}};
+    ErrorOr<double> timeout = settings.get_noexcept("net/timeout", 30.0);
+    if (!timeout) {
+        reactor->call_soon([=]() { cb(ValueError(), txp); });
+        return;
+    }
+    /*
+     *  Rationale for deferring callbacks:
+     *
+     *  When using IOCP on Windows, the kernel calls callbacks when selected
+     *  events occur (i.e., there is no loop that guarantees callbacks run in
+     *  the same thread); set DEFER_CALLBACKS to tell libevent to serialize
+     *  bufferevent's callbacks into the event loop to avoid creating MT issues
+     *  in code that otherwise (on Unices) is single threaded.
+     *
+     *  Yes, the current implementation forces serializing the callbacks also
+     *  on Unix where this wouldn't be needed thus adding some overhead. For
+     *  uniformity, I am for serializing for all platforms and then, if we see
+     *  that there's too much overhead, to only enable that on Windows.
+     */
+    constexpr int flags = BEV_OPT_CLOSE_ON_FREE | BEV_OPT_DEFER_CALLBACKS;
+    auto evbase = reactor->get_event_base();
+    auto bev = Var<Bev>::make(bufferevent_socket_new(evbase, -1, flags));
+    if (bev->get() == nullptr) {
+        throw GenericError(); // This should not happen
+    }
+    timeval tv, *tvp = timeval_init(&tv, timeout);
+    if (bufferevent_set_timeouts(bev->get(), tvp, tvp) != 0) {
+        throw GenericError(); // This should not happen
+    }
+    double begin = mk::time_now();
+    if (bufferevent_socket_connect(bev->get(), saddr, salen) != 0) {
+        Error err = mk::net::map_errno(errno);
+        if (err == NoError()) {
+            err = GenericError(); /* We must report an error */
+        }
+        logger->warn("connect() failed: %s", err.as_ooni_error().c_str());
+        reactor->call_soon([=]() { cb(err, txp); });
+        return;
+    }
+    // NOTE: in case of `new` failure we let the stack unwind
+    auto pcb = new Callback<short>{[=](short what) {
+        double elapsed = mk::time_now() - begin;
+        txp->set_connect_time_(elapsed);
+        logger->debug("connect() callback; elapsed time: %f; bufferevent "
+                      "event",
+                      elapsed, map_bufferevent_event(what).c_str());
+        if ((what & (BEV_EVENT_ERROR | BEV_EVENT_TIMEOUT)) != 0) {
+            Error err = ((what & BEV_EVENT_TIMEOUT) != 0)
+                            ? TimeoutError()
+                            : (errno) ? net::map_errno(errno) : GenericError();
+            logger->warn("connect() error: %s", err.as_ooni_error().c_str());
+            cb(err, txp);
+            return;
+        }
+        ErrorOr<bool> ssl_enabled = settings.get_noexcept("net/ssl", false);
+        if (!ssl_enabled) {
+            logger->debug("connect() successful");
+            cb(ValueError(), txp);
+            return;
+        }
+        auto success = [elapsed]( //
+                           Var<Bev> bev, Var<Reactor> reactor,
+                           Var<Logger> logger,
+                           Callback<Error, Var<net::Transport>> cb) {
+            auto txp = Connection::make(bev->get(), reactor, logger);
+            (void)bev->release();
+            txp->set_connect_time_(elapsed);
+            cb(NoError(), txp);
+        };
+        if (*ssl_enabled == false) {
+            success(bev, reactor, logger, cb);
+            return;
+        }
+        std::string bundle = settings.get("net/ca_bundle_path", MK_CA_BUNDLE);
+        std::string hostname = settings.get("net/ssl_hostname", "");
+        if (hostname == "") {
+            cb(ValueError("missing 'net/ssl_hostname' setting"), txp);
+            return;
+        }
+        ErrorOr<SSL *> ssl =
+            libssl::Cache<>::thread_local_instance().get_client_ssl(
+                bundle, hostname, logger);
+        if (!ssl) {
+            cb(ValueError(), txp);
+            return;
+        }
+        ErrorOr<bool> allow23 = settings.get_noexcept("net/allow_ssl23", false);
+        if (!allow23) {
+            cb(ValueError(), txp);
+            return;
+        }
+        if (*allow23 == true) {
+            logger->info("Re-enabling SSLv2 and SSLv3");
+            libssl::enable_v23(*ssl);
+        }
+        auto sslbev = bufferevent_openssl_filter_new(
+            evbase, bev->get(), *ssl, BUFFEREVENT_SSL_CONNECTING, flags);
+        if (sslbev == nullptr) {
+            cb(GenericError(), txp);
+            return;
+        }
+        (void)bev->release();
+        bev->set(sslbev);
+        auto x = new Callback<short>{[=](short what) {
+            logger->debug("ssl handshake callback; bufferevent event: %s",
+                          map_bufferevent_event(what).c_str());
+            Error err;
+            if ((what & (BEV_EVENT_ERROR | BEV_EVENT_TIMEOUT)) != 0) {
+                if ((what & BEV_EVENT_TIMEOUT) != 0) {
+                    err = TimeoutError();
+                } else {
+                    err = net::map_errno(errno);
+                    if (!err) {
+                        long ssle = bufferevent_get_openssl_error(bev->get());
+                        std::string s = ERR_error_string(ssle, nullptr);
+                        err = mk::net::SslError(s);
+                    }
+                }
+                logger->warn("ssl hanshake error: %s",
+                             err.as_ooni_error().c_str());
+                cb(err, txp);
+                return;
+            }
+            err = libssl_verify_peer(hostname, *ssl, logger);
+            if (err) {
+                cb(err, txp);
+                return;
+            }
+            ErrorOr<bool> allow_dirty_shutdown =
+                settings.get_noexcept("net/ssl_allow_dirty_shutdown", false);
+            if (!allow_dirty_shutdown) {
+                cb(ValueError(), txp);
+                return;
+            }
+            if (*allow_dirty_shutdown == true) {
+#ifdef HAVE_BUFFEREVENT_OPENSSL_SET_ALLOW_DIRTY_SHUTDOWN
+                bufferevent_openssl_set_allow_dirty_shutdown(bev, 1);
+                logger->info("Allowing dirty SSL shutdown");
+#else
+                logger->warn("Cannot tell libevent to allow SSL dirty "
+                             "shutdowns as requested by the programmer: as a "
+                             "result some SSL connections may interrupt "
+                             "abruptly with an error. This happens because you "
+                             "are not using version 2.1.x of libevent.");
+#endif
+            }
+            logger->debug("ssl: handshake... complete");
+            success(bev, reactor, logger, cb);
+        }};
+        bufferevent_setcb(bev->get(), nullptr, nullptr, mk_libevent_connect, x);
+        logger->debug("ssl handshake in progress...");
+    }};
+    // NOTE: we set callback after `connect()` because we want the event to
+    // be delivered after and not before we are out of this function.
+    bufferevent_setcb(bev->get(), nullptr, nullptr, mk_libevent_connect, pcb);
+    logger->debug("connect() in progress...");
+}
+
+} // namespace libevent
+} // namespace mk
+#endif
+
+static inline void mk_libevent_connect(bufferevent *, short what, void *p) {
+    auto pp = static_cast<std::function<void(short)> *>(p);
+    std::function<void(short)> func;
+    std::swap(func, *pp);
+    delete pp;
+    func(what);
+}

--- a/include/private/libevent/connection.hpp
+++ b/include/private/libevent/connection.hpp
@@ -31,6 +31,8 @@
 #include <stdexcept>
 #include <utility>
 
+// TODO: we should probably rename this file `transport`.
+
 extern "C" {
 
 static inline void handle_libevent_read(bufferevent *, void *);
@@ -44,6 +46,7 @@ namespace libevent {
 
 using namespace mk::net;
 
+// TODO: we should extend to support the connect event
 static inline std::string map_bufferevent_event(short what) {
     std::stringstream ss;
     ss << ((what & BEV_EVENT_EOF) ? "Z" : "z")
@@ -54,6 +57,8 @@ static inline std::string map_bufferevent_event(short what) {
     return ss.str();
 }
 
+// TODO: we should write tests for this class
+template <MK_MOCK(bufferevent_enable), MK_MOCK(bufferevent_disable)>
 class Connection : public EmitterBase, public NonMovable, public NonCopyable {
   public:
     static Var<Transport> make(bufferevent *bev, Var<Reactor> reactor,

--- a/include/private/libevent/connection.hpp
+++ b/include/private/libevent/connection.hpp
@@ -89,7 +89,12 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
     }
 
     void start_writing() override {
+        // Note: in theory writing _nonzero_ bytes into the output
+        // bufferevent should be enough to start writing
         output_buff >> bufferevent_get_output(bev);
+        if (bufferevent_enable(this->bev, EV_WRITE) != 0) {
+            throw std::runtime_error("cannot enable write");
+        }
     }
 
     void start_reading() override {
@@ -101,6 +106,12 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
     void stop_reading() override {
         if (bufferevent_disable(this->bev, EV_READ) != 0) {
             throw std::runtime_error("cannot disable read");
+        }
+    }
+
+    void stop_writing() override {
+        if (bufferevent_disable(this->bev, EV_WRITE) != 0) {
+            throw std::runtime_error("cannot disable write");
         }
     }
 

--- a/include/private/libevent/connection.hpp
+++ b/include/private/libevent/connection.hpp
@@ -156,11 +156,29 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
     // They MUST be public because they're called by C code
 
     void handle_event_(short what) {
+        // Implementation note: The event for which we're called are:
+        //
+        // 1. EOF while reading with `(what & BEV_EVENT_EOF) != 0`
+        // 2. libevent timeout with `(what & BEV_EVENT_TIMEOUT) != 0`
+        // 3. SSL or socket error with `(what & BEV_EVENT_ERROR) != 0`
+        // 4. successful read with `what == BEV_EVENT_READING`
+        // 5. successful flush with `what == BEV_EVENT_WRITING`
+        // 6. successful connect with `what == BEV_EVENT_CONNECTED`
+        //
+        // In cases 1-3, only one of the reading, writing, and connected flags
+        // should bet set. But sometimes the filters forget about that.
+
+        Error err = NoError();
 
         logger->debug("connection: got bufferevent event: %s",
                       map_bufferevent_event(what).c_str());
 
         if ((what & BEV_EVENT_EOF) != 0) {
+            // Implementation note: the following is a fix because we have seen
+            // filter SSL bufferevents deliver EOF _before_ data. It was with
+            // the v2.0.x branch of libevent and _may_ now be fixed. IIRC,
+            // to test we need to run against a server that performs a "dirty"
+            // SSL shutdown (i.e. just closes the socket, no SSL_shutdown).
             auto input = bufferevent_get_input(bev);
             if (evbuffer_get_length(input) > 0) {
                 logger->debug(
@@ -168,63 +186,67 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
                 suppressed_eof = true;
                 return;
             }
-            emit_error(EofError());
-            return;
+            err = EofError();
         }
 
         if ((what & BEV_EVENT_TIMEOUT) != 0) {
-            emit_error(TimeoutError());
-            return;
+            err = TimeoutError();
         }
 
-        Error sys_error = net::map_errno(errno);
-
-        if (sys_error == NoError()) {
-            unsigned long openssl_error;
-            char buff[128];
-            while ((openssl_error = bufferevent_get_openssl_error(bev)) != 0) {
-                if (sys_error == NoError()) {
-                    sys_error = SslError();
+        if ((what & BEV_EVENT_ERROR) != 0) {
+            err = net::map_errno(errno);
+            if (err == NoError()) {
+                unsigned long ossl_err;
+                char buff[128];
+                while ((ossl_err = bufferevent_get_openssl_error(bev)) != 0) {
+                    err = (!!err) ? err : SslError();
+                    ERR_error_string_n(ossl_err, buff, sizeof(buff));
+                    err.add_child_error(SslError(buff));
                 }
-                ERR_error_string_n(openssl_error, buff, sizeof(buff));
-                sys_error.add_child_error(SslError(buff));
+                if (err != SslError()) {
+                    /*
+                     * This is the case of the SSL dirty shutdown:
+                     *
+                     * The connection was not closed cleanly from the other end.
+                     * In theory this could also be the effect of an attack.
+                     */
+                    logger->warn("libevent has detected an SSL dirty shutdown");
+                    err = SslDirtyShutdownError();
+                }
             }
-            if (sys_error != SslError()) {
-                /*
-                 * This is the case of the SSL dirty shutdown. The connection
-                 * was not closed cleanly from the other end and in theory this
-                 * could also be the effect of an attack.
-                 */
-                logger->warn("libevent has detected an SSL dirty shutdown");
-                sys_error = SslDirtyShutdownError();
-            }
+            logger->warn("Got error: %s", err.as_ooni_error().c_str());
         }
 
-        logger->warn("Got error: %s", sys_error.as_ooni_error().c_str());
-        emit_error(sys_error);
-    }
-
-    void handle_read_() {
-        Buffer buff(bufferevent_get_input(bev));
-        try {
-            emit_data(buff);
-        } catch (Error &error) {
-            emit_error(error);
+        // Implementation note: for now, we don't handle the connect event
+        // in this callback. When we will do that, we will have the problem
+        // that in some cases libevent does not set operation flags, so we
+        // may end up emitting connect when it doesn't make sense.
+        if ((what & BEV_EVENT_CONNECTED) != 0) {
+            logger->warn("received unexpected connected event");
             return;
         }
-        if (suppressed_eof) {
-            suppressed_eof = false;
-            logger->debug("Deliver previously suppressed EOF");
-            emit_error(EofError());
-            return;
-        }
-    }
 
-    void handle_write_() {
-        try {
-            emit_flush();
-        } catch (Error &error) {
-            emit_error(error);
+        // If we have got an error and libevent doesn't know what it was doing,
+        // wake up both the read and the flush handlers. Of course, if the
+        // programmer didn't register any handler, nothing will really happen.
+        if (!!err && (what & (BEV_EVENT_READING | BEV_EVENT_WRITING)) == 0) {
+            what |= BEV_EVENT_READING | BEV_EVENT_WRITING;
+        }
+
+        if ((what & BEV_EVENT_READING) != 0) {
+            Buffer buff(bufferevent_get_input(bev));
+            if (suppressed_eof) {
+                suppressed_eof = false;
+                logger->debug("Deliver previously suppressed EOF");
+                err = (!!err) ? err : EofError();
+            }
+            // XXX previously here we were catching errors
+            emit_data(err, buff);
+        }
+        
+        if ((what & BEV_EVENT_WRITING) != 0) {
+            // XXX previously here we were catching errors
+            emit_flush(err);
         }
     }
 
@@ -253,11 +275,13 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
 extern "C" {
 
 static inline void handle_libevent_read(bufferevent *, void *opaque) {
-    static_cast<mk::libevent::Connection *>(opaque)->handle_read_();
+    static_cast<mk::libevent::Connection *>(opaque)->handle_event_(
+        BEV_EVENT_READING);
 }
 
 static inline void handle_libevent_write(bufferevent *, void *opaque) {
-    static_cast<mk::libevent::Connection *>(opaque)->handle_write_();
+    static_cast<mk::libevent::Connection *>(opaque)->handle_event_(
+        BEV_EVENT_WRITING);
 }
 
 static inline void handle_libevent_event(bufferevent *, short what,

--- a/include/private/ndt/internal.hpp
+++ b/include/private/ndt/internal.hpp
@@ -138,12 +138,9 @@ struct Context {
 */
 namespace messages {
 
-void read_ll(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback,
-             Var<Reactor> reactor = Reactor::global());
-void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
-               Var<Reactor> reactor = Reactor::global());
-void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback,
-              Var<Reactor> reactor = Reactor::global());
+void read_ll(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback);
+void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback);
+void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> callback);
 
 ErrorOr<Buffer> format_msg_extended_login(unsigned char tests);
 ErrorOr<Buffer> format_test_msg(std::string s);

--- a/include/private/ndt/messages_impl.hpp
+++ b/include/private/ndt/messages_impl.hpp
@@ -25,8 +25,8 @@ namespace messages {
     | type (1) | length (2) | payload (0-65535) |
     +----------+------------+-------------------+
 */
-template <MK_MOCK_AS(net::readn, net_readn_first),
-          MK_MOCK_AS(net::readn, net_readn_second)>
+template <MK_MOCK_AS(net::readn_into, net_readn_first),
+          MK_MOCK_AS(net::readn_into, net_readn_second)>
 void read_ll_impl(Var<Context> ctx,
                   Callback<Error, uint8_t, std::string> callback) {
 

--- a/include/private/ndt/messages_impl.hpp
+++ b/include/private/ndt/messages_impl.hpp
@@ -28,8 +28,7 @@ namespace messages {
 template <MK_MOCK_AS(net::readn, net_readn_first),
           MK_MOCK_AS(net::readn, net_readn_second)>
 void read_ll_impl(Var<Context> ctx,
-                  Callback<Error, uint8_t, std::string> callback,
-                  Var<Reactor> reactor) {
+                  Callback<Error, uint8_t, std::string> callback) {
 
     // Receive message type (1 byte) and length (2 bytes)
     net_readn_first(ctx->txp, ctx->buff, 3, [=](Error err) {
@@ -55,14 +54,13 @@ void read_ll_impl(Var<Context> ctx,
             assert(s.size() == *length);
             ctx->logger->debug("< [%d]: (%d) %s", *length, *type, s.c_str());
             callback(NoError(), *type, s);
-        }, reactor);
-    }, reactor);
+        });
+    });
 }
 
 // Like `read_ll()` but decode the payload using JSON
 template <MK_MOCK(read_ll)>
-void read_json_impl(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
-                    Var<Reactor> reactor) {
+void read_json_impl(Var<Context> ctx, Callback<Error, uint8_t, json> callback) {
     read_ll(ctx, [=](Error err, uint8_t type, std::string m) {
         json message;
         if (err) {
@@ -76,14 +74,13 @@ void read_json_impl(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
             return;
         }
         callback(NoError(), type, message);
-    }, reactor);
+    });
 }
 
 // Like `read_json()` but return the `msg` field only
 template <MK_MOCK(read_json)>
 void read_msg_impl(Var<Context> ctx,
-                   Callback<Error, uint8_t, std::string> callback,
-                   Var<Reactor> reactor) {
+                   Callback<Error, uint8_t, std::string> callback) {
     read_json(ctx, [=](Error error, uint8_t type, json message) {
         if (error) {
             callback(error, 0, "");
@@ -100,7 +97,7 @@ void read_msg_impl(Var<Context> ctx,
             return;
         }
         callback(NoError(), type, s);
-    }, reactor);
+    });
 }
 
 static inline ErrorOr<Buffer> format_any(unsigned char type, json message) {

--- a/include/private/ndt/protocol_impl.hpp
+++ b/include/private/ndt/protocol_impl.hpp
@@ -55,7 +55,7 @@ void send_extended_login_impl(Var<Context> ctx, Callback<Error> callback) {
     });
 }
 
-template <MK_MOCK_AS(net::readn, net_readn)>
+template <MK_MOCK_AS(net::readn_into, net_readn)>
 void recv_and_ignore_kickoff_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: recv and ignore kickoff ...");
     net_readn(ctx->txp, ctx->buff, KICKOFF_MESSAGE_SIZE, [=](Error err) {
@@ -253,7 +253,7 @@ void recv_results_and_logout_impl(Var<Context> ctx, Callback<Error> callback) {
     });
 }
 
-template <MK_MOCK_AS(net::read, net_read)>
+template <MK_MOCK_AS(net::read_into, net_read)>
 void wait_close_impl(Var<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("ndt: wait close ...");
     ctx->txp->set_timeout(1.0);

--- a/include/private/ndt/protocol_impl.hpp
+++ b/include/private/ndt/protocol_impl.hpp
@@ -71,7 +71,7 @@ void recv_and_ignore_kickoff_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->debug("Got legacy KICKOFF message (ignored)");
         callback(NoError());
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(messages::read_msg, messages_read_msg),
@@ -131,7 +131,7 @@ void wait_in_queue_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->debug("Authorized to run the test");
         callback(NoError());
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
@@ -151,7 +151,7 @@ void recv_version_impl(Var<Context> ctx, Callback<Error> callback) {
         (*ctx->entry)["server_version"] = s;
         // TODO: validate the server version?
         callback(NoError());
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(messages::read_msg, messages_read_msg)>
@@ -171,7 +171,7 @@ void recv_tests_id_impl(Var<Context> ctx, Callback<Error> callback) {
         ctx->granted_suite = split(s);
         ctx->granted_suite_count = ctx->granted_suite.size();
         callback(NoError());
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(test_c2s::run, test_c2s_run),
@@ -250,7 +250,7 @@ void recv_results_and_logout_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->debug("Got LOGOUT");
         callback(NoError());
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(net::read, net_read)>
@@ -278,7 +278,7 @@ void wait_close_impl(Var<Context> ctx, Callback<Error> callback) {
         }
         ctx->logger->debug("ndt: got extra data: %s", buffer->read().c_str());
         callback(DataAfterLogoutError());
-    }, ctx->reactor);
+    });
 }
 
 static inline void disconnect_and_callback_impl(Var<Context> ctx, Error err) {

--- a/include/private/ndt/test_c2s_impl.hpp
+++ b/include/private/ndt/test_c2s_impl.hpp
@@ -15,9 +15,9 @@ namespace ndt {
 namespace test_c2s {
 
 template <MK_MOCK_AS(net::connect, net_connect)>
-void coroutine_impl(Var<Entry> report_entry, std::string address, int port, double runtime,
-                    Callback<Error, Continuation<Error>> cb, double timeout,
-                    Settings settings, Var<Reactor> reactor,
+void coroutine_impl(Var<Entry> report_entry, std::string address, int port,
+                    double runtime, Callback<Error, Continuation<Error>> cb,
+                    double timeout, Settings settings, Var<Reactor> reactor,
                     Var<Logger> logger) {
 
     // Performance note: This implementation does some string copies
@@ -36,59 +36,57 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, int port, doub
     std::string str = random_printable(8192);
 
     logger->debug("ndt: connect ...");
-    net_connect(address, port,
-                [=](Error err, Var<Transport> txp) {
-                    logger->debug("ndt: connect ... %d", (int)err);
-                    if (err) {
-                        cb(err, nullptr);
-                        return;
-                    }
-                    (*report_entry)["connect_times"].push_back(txp->connect_time());
-                    logger->info("Connected to %s:%d", address.c_str(), port);
-                    logger->debug("ndt: suspend coroutine");
-                    cb(NoError(), [=](Callback<Error> cb) {
-                        double begin = time_now();
-                        Var<MeasureSpeed> snap(new MeasureSpeed(0.5));
-                        logger->debug("ndt: resume coroutine");
-                        logger->info("Starting upload");
-                        txp->set_timeout(timeout);
-                        net::continue_writing(
-                            txp, [=](Error err, std::function<void()> &cancel) {
-                        // TODO: refactor this piece of code
-                        if (!err) {
-                            double now = time_now();
-                            snap->maybe_speed(now, [&](double el, double x) {
-                                log_speed(logger, "upload-speed", 1, el, x);
-                                (*report_entry)["sender_data"].push_back({
-                                    el, x
-                                });
-                            });
-                            if (now - begin > runtime) {
-                                logger->info("Elapsed enough time");
-                                cancel(); // Do it explicitly
-                                txp->close(nullptr);
-                                cb(NoError());
-                                return;
-                            }
-                            txp->write(str.data(), str.size());
-                            snap->total += str.size();
+    net_connect(
+        address, port,
+        [=](Error err, Var<Transport> txp) {
+            logger->debug("ndt: connect ... %d", (int)err);
+            if (err) {
+                cb(err, nullptr);
+                return;
+            }
+            (*report_entry)["connect_times"].push_back(txp->connect_time());
+            logger->info("Connected to %s:%d", address.c_str(), port);
+            logger->debug("ndt: suspend coroutine");
+            cb(NoError(), [=](Callback<Error> cb) {
+                double begin = time_now();
+                Var<MeasureSpeed> snap(new MeasureSpeed(0.5));
+                logger->debug("ndt: resume coroutine");
+                logger->info("Starting upload");
+                txp->set_timeout(timeout);
+                net::continue_writing(txp, [=](Error err,
+                                               std::function<void()> &cancel) {
+                    if (!err) {
+                        double now = time_now();
+                        snap->maybe_speed(now, [&](double el, double x) {
+                            log_speed(logger, "upload-speed", 1, el, x);
+                            (*report_entry)["sender_data"].push_back({el, x});
+                        });
+                        if (now - begin > runtime) {
+                            logger->info("Elapsed enough time");
+                            cancel(); // Do it explicitly
+                            txp->close(nullptr);
+                            cb(NoError());
                             return;
                         }
-                            cancel(); // Do it explicitly
-                            logger->info("Ending upload (%d)", (int)err);
-                            // TODO: we can avoid setting the callback
-                            txp->close([=]() {
-                                logger->info("Connection to %s:%d closed",
-                                             address.c_str(), port);
-                                cb(err);
-                            });
-                        });
-                        // Write the first data block immediately without
-                        // waiting (little) for socket being writable
                         txp->write(str.data(), str.size());
+                        snap->total += str.size();
+                        return;
+                    }
+                    cancel(); // Do it explicitly
+                    logger->info("Ending upload (%d)", (int)err);
+                    // TODO: we can avoid setting the callback
+                    txp->close([=]() {
+                        logger->info("Connection to %s:%d closed",
+                                     address.c_str(), port);
+                        cb(err);
                     });
-                },
-                settings, reactor, logger);
+                });
+                // Write the first data block immediately without
+                // waiting (little) for socket being writable
+                txp->write(str.data(), str.size());
+            });
+        },
+        settings, reactor, logger);
 }
 
 template <MK_MOCK_AS(messages::read_msg, messages_read_msg_first),

--- a/include/private/ndt/test_c2s_impl.hpp
+++ b/include/private/ndt/test_c2s_impl.hpp
@@ -194,13 +194,13 @@ void run_impl(Var<Context> ctx, Callback<Error> callback) {
 
                                     // The C2S phase is now finished
                                     callback(NoError());
-                                }, ctx->reactor);
-                        }, ctx->reactor);
+                                });
+                        });
                     });
-                }, ctx->reactor);
+                });
             },
             ctx->timeout, ctx->settings, ctx->reactor, ctx->logger);
-    }, ctx->reactor);
+    });
 }
 
 } // namespace test_c2s

--- a/include/private/ndt/test_meta_impl.hpp
+++ b/include/private/ndt/test_meta_impl.hpp
@@ -114,10 +114,10 @@ void run_impl(Var<Context> ctx, Callback<Error> cb) {
 
                             // We're done
                             callback(NoError());
-                        }, ctx->reactor);
+                        });
                 });
-            }, ctx->reactor);
-    }, ctx->reactor);
+            });
+    });
 }
 
 } // namespace test_meta

--- a/include/private/ndt/test_s2c_impl.hpp
+++ b/include/private/ndt/test_s2c_impl.hpp
@@ -58,50 +58,51 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, Params params,
                     net::continue_reading(
                         txp, [=](Error err, Buffer data,
                                  std::function<void()> & /*canceller*/) {
-                        // TODO: reindent this code block; I did not touch
-                        // it so to simplify reading the diff.
-                        if (err == NoError()) {
-                        average->total += data.length();
-                        snaps->total += data.length();
-                        double ct = time_now();
-                        // Note: we stop printing the speed when at least
-                        // one connection has terminated the test
-                        if (*num_completed == 0) {
-                            snaps->maybe_speed(ct, [&](double el, double x) {
-                                log_speed(logger, "download-speed",
-                                          params.num_streams, el, x);
-                                (*report_entry)["receiver_data"].push_back({el, x});
-                            });
-                        }
-                        // TODO: force close the connection after a given
-                        // large amount of time has passed. When we do that
-                        // we can use the `canceller` variable ^-).
-                        return;
-                        }
-                        if (err == EofError()) {
-                            err = NoError();
-                        }
-                        if (err) {
-                            logger->info("Ending download (%d)", err.code);
-                        }
-                        txp->close([=]() {
-                            ++(*num_completed);
-                            // Note: in this callback we cannot reference
-                            // txp_list or txp because that would keep
-                            // alive txp indefinitely, so we use the num_flows
-                            // variable instead (note that this means that
-                            // the `=` only copies what you use, a thing that
-                            // I was totally unaware of!)
-                            if (*num_completed < num_flows) {
+                            if (err == NoError()) {
+                                average->total += data.length();
+                                snaps->total += data.length();
+                                double ct = time_now();
+                                // Note: we stop printing the speed when at
+                                // least one connection has terminated the test
+                                if (*num_completed == 0) {
+                                    snaps->maybe_speed(ct, [&](double el,
+                                                               double x) {
+                                        log_speed(logger, "download-speed",
+                                                  params.num_streams, el, x);
+                                        (*report_entry)["receiver_data"]
+                                            .push_back({el, x});
+                                    });
+                                }
+                                // TODO: force close the connection after a
+                                // given large amount of time has passed. When
+                                // we do that we can use the `canceller`
+                                // variable ^-).
                                 return;
                             }
-                            double speed = average->speed();
-                            logger->debug("S2C speed %lf kbit/s", speed);
-                            // XXX We need to define what we consider
-                            // error when we have parallel flows
-                            cb((num_flows == 1) ? err : NoError(), speed);
+                            if (err == EofError()) {
+                                err = NoError();
+                            }
+                            if (err) {
+                                logger->info("Ending download (%d)", err.code);
+                            }
+                            txp->close([=]() {
+                                ++(*num_completed);
+                                // Note: in this callback we cannot reference
+                                // txp_list or txp because that would keep
+                                // alive txp indefinitely, so we use the
+                                // num_flows variable instead (note that this
+                                // means that the `=` only copies what you use,
+                                // a thing that I was totally unaware of!)
+                                if (*num_completed < num_flows) {
+                                    return;
+                                }
+                                double speed = average->speed();
+                                logger->debug("S2C speed %lf kbit/s", speed);
+                                // XXX We need to define what we consider
+                                // error when we have parallel flows
+                                cb((num_flows == 1) ? err : NoError(), speed);
+                            });
                         });
-                    });
                 }
             });
         },

--- a/include/private/ndt/test_s2c_impl.hpp
+++ b/include/private/ndt/test_s2c_impl.hpp
@@ -4,11 +4,8 @@
 #ifndef PRIVATE_NDT_TEST_S2C_IMPL_HPP
 #define PRIVATE_NDT_TEST_S2C_IMPL_HPP
 
-#include "private/common/mock.hpp"
-
-#include "private/common/mock.hpp"
-
 #include "../ndt/internal.hpp"
+#include "private/common/mock.hpp"
 
 namespace mk {
 namespace ndt {
@@ -58,7 +55,12 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, Params params,
                 for (auto txp : txp_list) {
                     txp->set_timeout(timeout);
 
-                    txp->on_data([=](Buffer data) {
+                    net::continue_reading(
+                        txp, [=](Error err, Buffer data,
+                                 std::function<void()> & /*canceller*/) {
+                        // TODO: reindent this code block; I did not touch
+                        // it so to simplify reading the diff.
+                        if (err == NoError()) {
                         average->total += data.length();
                         snaps->total += data.length();
                         double ct = time_now();
@@ -72,10 +74,10 @@ void coroutine_impl(Var<Entry> report_entry, std::string address, Params params,
                             });
                         }
                         // TODO: force close the connection after a given
-                        // large amount of time has passed
-                    });
-
-                    txp->on_error([=](Error err) {
+                        // large amount of time has passed. When we do that
+                        // we can use the `canceller` variable ^-).
+                        return;
+                        }
                         if (err == EofError()) {
                             err = NoError();
                         }

--- a/include/private/ndt/test_s2c_impl.hpp
+++ b/include/private/ndt/test_s2c_impl.hpp
@@ -139,7 +139,7 @@ void finalizing_test_impl(Var<Context> ctx, Var<Entry> cur_entry,
         }
         // XXX: Here we can loop forever
         finalizing_test_impl<messages_read_msg>(ctx, cur_entry, callback);
-    }, ctx->reactor);
+    });
 }
 
 template <MK_MOCK_AS(messages::read_msg, messages_read_msg_first),
@@ -287,12 +287,12 @@ void run_impl(Var<Context> ctx, Callback<Error> callback) {
                                 // We enter into the final state of this test
                                 finalizing_test(ctx, cur_entry, callback);
                             });
-                        }, ctx->reactor);
+                        });
                     });
-                }, ctx->reactor);
+                });
             },
             ctx->timeout, ctx->settings, ctx->reactor, ctx->logger);
-    }, ctx->reactor);
+    });
 }
 
 } // namespace test_s2c

--- a/include/private/net/emitter.hpp
+++ b/include/private/net/emitter.hpp
@@ -102,6 +102,15 @@ class EmitterBase : public Transport {
     void on_flush(std::function<void()> fn) override {
         logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'flush' handler",
                     (fn != nullptr) ? "" : "un");
+        if (close_pending) {
+            logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
+            return;
+        }
+        if (fn) {
+            start_writing();
+        } else {
+            stop_writing();
+        }
         do_flush = fn;
     }
 
@@ -259,6 +268,7 @@ class Emitter : public EmitterBase {
     void start_reading() override {}
     void stop_reading() override {}
     void start_writing() override {}
+    void stop_writing() override {}
 };
 
 } // namespace net

--- a/include/private/net/emitter.hpp
+++ b/include/private/net/emitter.hpp
@@ -113,6 +113,8 @@ class EmitterBase : public Transport {
 
     void close(Callback<> cb) override;
 
+    Var<Reactor> get_reactor() override { return reactor; }
+
     /*
      * TransportRecorder
      */

--- a/include/private/net/emitter.hpp
+++ b/include/private/net/emitter.hpp
@@ -21,8 +21,9 @@ class EmitterBase : public Transport {
      * TransportEmitter
      */
 
-    void emit_connect() override {
-        logger->log(MK_LOG_DEBUG2, "emitter: emit 'connect' event");
+    void emit_connect(Error err) override {
+        logger->log(MK_LOG_DEBUG2, "emitter: emit 'connect' event (error: %d)",
+                    err.code);
         if (close_pending) {
             logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
             return;
@@ -31,12 +32,12 @@ class EmitterBase : public Transport {
             logger->log(MK_LOG_DEBUG2, "emitter: no handler set; ignoring");
             return;
         }
-        do_connect();
+        do_connect(err);
     }
 
-    void emit_data(Buffer data) override {
-        logger->log(MK_LOG_DEBUG2, "emitter: emit 'data' event "
-                    "(num_bytes = %zu)", data.length());
+    void emit_data(Error err, Buffer data) override {
+        logger->log(MK_LOG_DEBUG2, "emitter: emit 'data' event (error: %d)"
+                    "(num_bytes = %zu)", err.code, data.length());
         if (close_pending) {
             logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
             return;
@@ -48,11 +49,12 @@ class EmitterBase : public Transport {
             logger->log(MK_LOG_DEBUG2, "emitter: no handler set; ignoring");
             return;
         }
-        do_data(data);
+        do_data(err, data);
     }
 
-    void emit_flush() override {
-        logger->log(MK_LOG_DEBUG2, "emitter: emit 'flush' event");
+    void emit_flush(Error err) override {
+        logger->log(MK_LOG_DEBUG2, "emitter: emit 'flush' event (error: %d)",
+                    err.code);
         if (close_pending) {
             logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
             return;
@@ -61,30 +63,20 @@ class EmitterBase : public Transport {
             logger->log(MK_LOG_DEBUG2, "emitter: no handler set; ignoring");
             return;
         }
-        do_flush();
+        do_flush(err);
     }
 
-    void emit_error(Error err) override {
-        logger->log(MK_LOG_DEBUG2, "emitter: emit 'error' event "
-                    "(error = '%s')", err.explain().c_str());
+    void on_connect(Callback<Error> fn) override {
+        logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'connect' handler",
+                    (fn != nullptr) ? "" : "un");
         if (close_pending) {
             logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
             return;
         }
-        if (!do_error) {
-            logger->log(MK_LOG_DEBUG2, "emitter: no handler set; ignoring");
-            return;
-        }
-        do_error(err);
-    }
-
-    void on_connect(std::function<void()> fn) override {
-        logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'connect' handler",
-                    (fn != nullptr) ? "" : "un");
         do_connect = fn;
     }
 
-    void on_data(std::function<void(Buffer)> fn) override {
+    void on_data(Callback<Error, Buffer> fn) override {
         logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'data' handler",
                     (fn != nullptr) ? "" : "un");
         if (close_pending) {
@@ -99,7 +91,7 @@ class EmitterBase : public Transport {
         do_data = fn;
     }
 
-    void on_flush(std::function<void()> fn) override {
+    void on_flush(Callback<Error> fn) override {
         logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'flush' handler",
                     (fn != nullptr) ? "" : "un");
         if (close_pending) {
@@ -112,12 +104,6 @@ class EmitterBase : public Transport {
             stop_writing();
         }
         do_flush = fn;
-    }
-
-    void on_error(std::function<void(Error)> fn) override {
-        logger->log(MK_LOG_DEBUG2, "emitter: %sregister 'error' handler",
-                    (fn != nullptr) ? "" : "un");
-        do_error = fn;
     }
 
     void close(Callback<> cb) override;
@@ -236,10 +222,9 @@ class EmitterBase : public Transport {
     Buffer output_buff;
 
   private:
-    Delegate<> do_connect;
-    Delegate<Buffer> do_data;
-    Delegate<> do_flush;
-    Delegate<Error> do_error;
+    Delegate<Error> do_connect;
+    Delegate<Error, Buffer> do_data;
+    Delegate<Error> do_flush;
     bool do_record_received_data = false;
     Buffer received_data_record;
     bool do_record_sent_data = false;

--- a/src/libmeasurement_kit/http/request.cpp
+++ b/src/libmeasurement_kit/http/request.cpp
@@ -129,12 +129,8 @@ void request_recv_response(Var<Transport> txp,
                            Var<Reactor> reactor, Var<Logger> logger) {
     Var<ResponseParserNg> parser{new ResponseParserNg{logger}};
     Var<Response> response(new Response);
-    Var<bool> prevent_emit(new bool(false));
+    Var<bool> reached_end(new bool(false));
     Var<bool> valid_response(new bool(false));
-
-    // Note: any parser error at this point is an exception catched by the
-    // connection code and routed to the error handler function below
-    txp->on_data([=](Buffer data) { parser->feed(data); });
 
     parser->on_response([=](Response r) {
         *response = r;
@@ -144,28 +140,32 @@ void request_recv_response(Var<Transport> txp,
     // TODO: here we should honour the `ignore_body` setting
     parser->on_body([=](std::string s) { response->body += s; });
 
-    // TODO: we should improve the parser such that the transport forwards the
-    // "error" event to it and then the parser does the right thing, so that the
-    // code becomes less "twisted" here.
-    //
-    // XXX actually trying to do that could make things worse as we have
-    // seen in #690; we should refactor this code with care.
-
     parser->on_end([=]() {
-        if (*prevent_emit == true) {
-            return;
-        }
+        *reached_end = true;
         if (response->body.size() > 0) {
             logger->log(MK_LOG_DEBUG2, "%s", response->body.c_str());
         }
-        txp->emit_error(NoError());
     });
-    txp->on_error([=](Error err) {
+
+    net::continue_reading(txp, [=](Error err, Buffer data,
+                                   std::function<void()> &cancel) {
+
         logger->debug("http: received error %d on connection", err.code);
+
+        if (data.length() > 0) {
+            try {
+                parser->feed(data);
+            } catch (const Error &second_error) {
+                logger->warn("Parsing error: %d", second_error.code);
+                err = (!!err) ? err : second_error;
+                // FALLTHRU
+            }
+        }
+        if (err == NoError() && *reached_end == false) {
+            return; // basically: continue reading
+        }
+
         if (err == EofError() && *valid_response == true) {
-            // Calling parser->on_eof() could trigger parser->on_end() and
-            // we don't want this function to call ->emit_error()
-            *prevent_emit = true;
             // Assume there was no error. The parser will tell us if that
             // is true (it was in final state) or false.
             err = NoError();
@@ -178,8 +178,9 @@ void request_recv_response(Var<Transport> txp,
                 // FALLTHRU
             }
         }
-        txp->on_error(nullptr);
-        txp->on_data(nullptr);
+
+        cancel();
+
         reactor->call_soon([=]() {
             logger->log(MK_LOG_DEBUG2, "http: end of closure");
             cb(err, response);

--- a/src/libmeasurement_kit/ndt/messages.cpp
+++ b/src/libmeasurement_kit/ndt/messages.cpp
@@ -9,19 +9,16 @@ namespace ndt {
 namespace messages {
 
 void read_ll(Var<Context> ctx,
-             mk::Callback<Error, uint8_t, std::string> callback,
-             Var<Reactor> reactor) {
-    read_ll_impl(ctx, callback, reactor);
+             mk::Callback<Error, uint8_t, std::string> callback) {
+    read_ll_impl(ctx, callback);
 }
 
-void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback,
-               Var<Reactor> reactor) {
-    read_json_impl(ctx, callback, reactor);
+void read_json(Var<Context> ctx, Callback<Error, uint8_t, json> callback) {
+    read_json_impl(ctx, callback);
 }
 
-void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> cb,
-              Var<Reactor> reactor) {
-    read_msg_impl(ctx, cb, reactor);
+void read_msg(Var<Context> ctx, Callback<Error, uint8_t, std::string> cb) {
+    read_msg_impl(ctx, cb);
 }
 
 ErrorOr<Buffer> format_msg_extended_login(unsigned char tests) {

--- a/src/libmeasurement_kit/net/emitter.cpp
+++ b/src/libmeasurement_kit/net/emitter.cpp
@@ -24,14 +24,13 @@ void EmitterBase::close(Callback<> cb) {
          * to inform the caller that there is a problem with the code
          * because `close()` has been called more than once.
          */
-        throw std::runtime_error("close already pending");
+        throw std::runtime_error("close already pending"); // FIXME
     }
     close_pending = true;
     shutdown();
     on_connect(nullptr);
     on_data(nullptr);
     on_flush(nullptr);
-    on_error(nullptr);
     close_cb = cb;
 }
 

--- a/src/libmeasurement_kit/net/transport.cpp
+++ b/src/libmeasurement_kit/net/transport.cpp
@@ -34,12 +34,11 @@ void write(Var<Transport> txp, Buffer buf, Callback<Error> cb) {
     txp->write(buf);
 }
 
-void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
-           Var<Reactor> reactor) {
+void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb) {
     if (buff->length() >= n) {
         // Shortcut that simplifies coding a great deal - yet, do not callback
         // immediately to avoid O(N) stack consumption
-        reactor->call_soon([=]() {
+        txp->get_reactor()->call_soon([=]() {
             cb(NoError());
         });
         return;
@@ -60,9 +59,8 @@ void readn(Var<Transport> txp, Var<Buffer> buff, size_t n, Callback<Error> cb,
     });
 }
 
-void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback,
-          Var<Reactor> reactor) {
-    readn(t, buff, 1, callback, reactor);
+void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback) {
+    readn(t, buff, 1, callback);
 }
 
 void continue_reading(

--- a/src/libmeasurement_kit/net/transport.cpp
+++ b/src/libmeasurement_kit/net/transport.cpp
@@ -65,5 +65,23 @@ void read(Var<Transport> t, Var<Buffer> buff, Callback<Error> callback,
     readn(t, buff, 1, callback, reactor);
 }
 
+void continue_reading(
+    Var<Transport> txp,
+    Callback<Error, Buffer, std::function<void()> &> callback) {
+    txp->on_data([=](Buffer data) {
+        std::function<void()> canceller{[=]() {
+            txp->on_data(nullptr);
+            txp->on_error(nullptr);
+        }};
+        callback(NoError(), data, canceller);
+    });
+    txp->on_error([=](Error error) {
+        txp->on_data(nullptr);
+        txp->on_error(nullptr);
+        std::function<void()> canceller{[=]() {}};
+        callback(error, Buffer{}, canceller);
+    });
+}
+
 } // namespace net
 } // namespace mk

--- a/src/libmeasurement_kit/ooni/http_invalid_request_line.cpp
+++ b/src/libmeasurement_kit/ooni/http_invalid_request_line.cpp
@@ -32,7 +32,10 @@ static void send_receive_invalid_request_line(net::Endpoint endpoint,
             return;
         }
         Var<std::string> received_data(new std::string);
-        txp->on_data([=](net::Buffer data) {
+        net::continue_reading(txp, [=](Error /*err*/, net::Buffer data,
+                                       std::function<void()> &/*cancel*/) {
+            // XXX The original code did not check for network errors
+            // and I did not change this during refactoring.
             logger->debug("http_invalid_request_line: on_data: %s",
                           data.peek().c_str());
             *received_data += data.read();


### PR DESCRIPTION
This branch contains ongoing work for refactoring net. My (tentative) objectives are:

- simplify the code and make it easier to read
- allow to interact with a `Transport` using a full proactor pattern (i.e. similar to asio's `async_read` and `async_write` and to `libuv`)
- refactor all code related to connecting using libevent into a single file
- fix the bug that we cannot do socks5 over ssl
- allow to measure precisely the amount of bytes sent and received (at ssl level)
- refactor socks5 to be a simple factory
- rationalize usage of errors and be able to measure more ssl errors
- allow to capture the content of the initial ssl handshake
- refactor more code (including algorithms on transports) to be public templates using mocks for testability
- use a single bufferevent for ssl code when possible (should improve performance)
- improve performance of sending by using `evbuffer` reference rather than copying a string

I am structuring this branch as a set of simple, self-contained patches that ideally can cherry-picked and applied to master when they're ready. Probably, at the end, this branch will not even be merged but all of its content will be cherry-picked and merged into master.