### PR TITLE
[ci skip] fix(.clang-format): set continuation indent to zero

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
 BasedOnStyle: LLVM
 IndentWidth: 4
-ContinuationIndentWidth: 6
 ---


### PR DESCRIPTION
It is very annoying that functions are not aligned to 4 spaces
because of the continuation indent.