### PR TITLE
cleanup(error): make error simpler to use

### DIFF
--- a/doc/api/report/report.md
+++ b/doc/api/report/report.md
@@ -110,7 +110,7 @@ errors of the returned error:
                     debug("- %d succeeded", idx);
                     continue;
                 }
-                debug("- %d failed: %s", idx, child_err->explain().c_str());
+                debug("- %d failed: %s", idx, child_err->what());
                 idx += 1;
             }
             // Note: given that `open` is idempotent, here you can

--- a/example/dns/ping.cpp
+++ b/example/dns/ping.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
                              [=](Error err, SharedPtr<dns::Message> m) {
                                  std::cout << query_class << " " << query_type;
                                  if (err) {
-                                     std::cout << " " << err.explain() << "\n";
+                                     std::cout << " " << err << "\n";
                                      return;
                                  }
                                  std::cout << " " << m->rtt;

--- a/example/http/request.cpp
+++ b/example/http/request.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
             body,
             [=](Error error, SharedPtr<http::Response> response) {
                 if (error) {
-                    std::cout << "Error: " << error.explain() << "\n";
+                    std::cout << "Error: " << error << "\n";
                     reactor->stop();
                     return;
                 }

--- a/example/net/connect.cpp
+++ b/example/net/connect.cpp
@@ -48,23 +48,23 @@ int main(int argc, char **argv) {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
         connect(domain, port, [=](Error err, SharedPtr<Transport> txp) {
-            std::cout << "Overall connect result: " << err.as_ooni_error() << "\n";
+            std::cout << "Overall connect result: " << err << "\n";
             auto resolve_result = txp->dns_result();
             std::cout << "input was valid ipv4: " <<
                     resolve_result.inet_pton_ipv4 << "\n";
             std::cout << "input was valid ipv6: " <<
                     resolve_result.inet_pton_ipv6 << "\n";
             std::cout << "ipv4 resolve error: " <<
-                    resolve_result.ipv4_err.as_ooni_error() << "\n";
+                    resolve_result.ipv4_err << "\n";
             std::cout << "ipv6 resolve error: " <<
-                    resolve_result.ipv6_err.as_ooni_error() << "\n";
+                    resolve_result.ipv6_err << "\n";
             std::cout << "list of addresses returned:\n";
             for (auto addr : resolve_result.addresses) {
                 std::cout << "    - " << addr << "\n";
             }
             std::cout << "errors returned by the various connects:\n";
             for (auto e : txp->connect_errors()) {
-                std::cout << "    - " << e.as_ooni_error() << "\n";
+                std::cout << "    - " << e << "\n";
             }
             txp->close([=]() { reactor->stop(); });
         }, settings);

--- a/example/ooni/ooniresources.cpp
+++ b/example/ooni/ooniresources.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
         mk::ooni::resources::get_latest_release(
             [=](Error error, std::string latest) {
                 if (error) {
-                    fprintf(stderr, "error: %s\n", error.explain().c_str());
+                    fprintf(stderr, "error: %s\n", error.what());
                     reactor->stop();
                     return;
                 }
@@ -43,8 +43,7 @@ int main(int argc, char **argv) {
                     latest, "ALL",
                     [=](Error error) {
                         if (error) {
-                            fprintf(stderr, "error: %s\n",
-                                    error.explain().c_str());
+                            fprintf(stderr, "error: %s\n", error.what());
                             /* FALLTHROUGH */
                         }
                         reactor->stop();

--- a/include/measurement_kit/common/detail/parallel.hpp
+++ b/include/measurement_kit/common/detail/parallel.hpp
@@ -6,6 +6,7 @@
 
 #include <measurement_kit/common/continuation.hpp>
 #include <measurement_kit/common/error.hpp>
+#include <measurement_kit/common/shared_ptr.hpp>
 
 namespace mk {
 
@@ -22,7 +23,7 @@ static inline void run(size_t idx, std::vector<Continuation<Error>> input,
                 overall->reason = template_error.reason;
                 // FALLTHROUGH
             }
-            overall->child_errors[idx] = SharedPtr<Error>(new Error(error));
+            overall->child_errors[idx] = error;
             *completed += 1;
             if (*completed == input.size()) {
                 cb(*overall);
@@ -45,7 +46,7 @@ static inline void parallel(std::vector<Continuation<Error>> input,
         cb(*overall);
         return;
     }
-    overall->child_errors.resize(input.size(), nullptr);
+    overall->child_errors.resize(input.size(), NoError());
     SharedPtr<size_t> completed(new size_t(0));
     if (parallelism <= 0) {
         parallelism = input.size();

--- a/include/private/dns/getaddrinfo_async.hpp
+++ b/include/private/dns/getaddrinfo_async.hpp
@@ -100,7 +100,7 @@ void getaddrinfo_async(std::string name, addrinfo hints, SharedPtr<Reactor> reac
         Error error = getaddrinfo_async_map_error(
             getaddrinfo(name.c_str(), nullptr, &hints, &rp));
         logger->debug("getaddrinfo('%s') => error: code=%d, reason='%s'",
-                      name.c_str(), error.code, error.as_ooni_error().c_str());
+                      name.c_str(), error.code, error.what());
         std::vector<Answer> answers;
         if (!error && rp != nullptr) {
             try {

--- a/include/private/libevent/connection.hpp
+++ b/include/private/libevent/connection.hpp
@@ -189,7 +189,7 @@ class Connection : public EmitterBase, public NonMovable, public NonCopyable {
             }
         }
 
-        logger->warn("Got error: %s", sys_error.as_ooni_error().c_str());
+        logger->warn("Got error: %s", sys_error.what());
         emit_error(sys_error);
     }
 

--- a/include/private/mlabns/mlabns_impl.hpp
+++ b/include/private/mlabns/mlabns_impl.hpp
@@ -83,7 +83,7 @@ void query_impl(std::string tool, Callback<Error, Reply> callback,
         [callback, logger](Error error, SharedPtr<http::Response> /*response*/,
                            nlohmann::json json_response) {
             if (error) {
-                logger->warn("mlabns: HTTP error: %s", error.explain().c_str());
+                logger->warn("mlabns: HTTP error: %s", error.what());
                 callback(error, Reply());
                 return;
             }
@@ -99,8 +99,7 @@ void query_impl(std::string tool, Callback<Error, Reply> callback,
                 reply.country = node.at("country");
             });
             if (err) {
-                logger->warn("mlabns: cannot parse json: %s",
-                             err.explain().c_str());
+                logger->warn("mlabns: cannot parse json: %s", err.what());
             } else {
                 logger->info("Discovered mlab test server: %s",
                              reply.fqdn.c_str());

--- a/include/private/ndt/protocol_impl.hpp
+++ b/include/private/ndt/protocol_impl.hpp
@@ -218,8 +218,8 @@ void run_tests_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     ctx->logger->debug("Run test with id %d ...", *num);
     func(ctx, [=](Error err) {
         ctx->logger->debug("Run test with id %d ... complete (%s)", *num,
-                           err.explain().c_str());
-        (*ctx->entry)["phase_result"][id_to_name(*num)] = err.as_ooni_error();
+                           err.what());
+        (*ctx->entry)["phase_result"][id_to_name(*num)] = err.reason;
         run_tests_impl<test_c2s_run, test_meta_run, test_s2c_run>(ctx,
                                                                   callback);
     });

--- a/include/private/net/connect_impl.hpp
+++ b/include/private/net/connect_impl.hpp
@@ -97,8 +97,7 @@ void connect_base(std::string address, int port,
         if (sys_error == NoError()) {
             sys_error = GenericError(); /* We must report an error */
         }
-        logger->warn("reason why connect() has failed: %s",
-                     sys_error.as_ooni_error().c_str());
+        logger->warn("reason why connect() has failed: %s", sys_error.what());
         cb(sys_error, nullptr, 0.0);
         return;
     }
@@ -114,8 +113,7 @@ void connect_base(std::string address, int port,
                 logger->warn("connect() for %s failed in its callback",
                              endpoint.c_str());
                 bufferevent_free(bev);
-                logger->warn("reason why connect() has failed: %s",
-                             err.as_ooni_error().c_str());
+                logger->warn("reason why connect() has failed: %s", err.what());
                 cb(err, nullptr, 0.0);
                 return;
             }

--- a/include/private/net/emitter.hpp
+++ b/include/private/net/emitter.hpp
@@ -66,7 +66,7 @@ class EmitterBase : public Transport {
 
     void emit_error(Error err) override {
         logger->log(MK_LOG_DEBUG2, "emitter: emit 'error' event "
-                    "(error = '%s')", err.explain().c_str());
+                    "(error = '%s')", err.what());
         if (close_pending) {
             logger->log(MK_LOG_DEBUG2, "emitter: already closed; ignoring");
             return;

--- a/include/private/neubot/dash_impl.hpp
+++ b/include/private/neubot/dash_impl.hpp
@@ -237,8 +237,7 @@ void run_loop_(SharedPtr<DashLoopCtx> ctx) {
           },
           "", ctx->logger, [=](Error error, SharedPtr<http::Request> req) {
               if (error) {
-                  ctx->logger->warn("dash: request failed: %s",
-                                    error.explain().c_str());
+                  ctx->logger->warn("dash: request failed: %s", error.what());
                   ctx->cb(error);
                   return;
               }
@@ -249,14 +248,14 @@ void run_loop_(SharedPtr<DashLoopCtx> ctx) {
                         if (error) {
                             ctx->logger->warn(
                                   "dash: cannot receive response: %s",
-                                  error.explain().c_str());
+                                  error.what());
                             ctx->cb(error);
                             return;
                         }
                         assert(!!res);
                         if (res->status_code != 200) {
                             ctx->logger->warn("dash: invalid response code: %s",
-                                              error.explain().c_str());
+                                              error.what());
                             ctx->cb(http::HttpRequestFailedError());
                             return;
                         }
@@ -362,7 +361,7 @@ void run_impl(std::string url, std::string auth_token, std::string real_address,
           [=](Error error, SharedPtr<net::Transport> txp) {
               if (error) {
                   logger->warn("dash: cannot connect to server: %s",
-                               error.explain().c_str());
+                               error.what());
                   cb(error);
                   return;
               }
@@ -410,8 +409,7 @@ void negotiate_loop_(SharedPtr<report::Entry> entry, SharedPtr<net::Transport> t
           body,
           [=](Error error, SharedPtr<http::Response> res) {
               if (error) {
-                  logger->warn("neubot: negotiate failed: %s",
-                               error.explain().c_str());
+                  logger->warn("neubot: negotiate failed: %s", error.what());
                   callback(error, "", "");
                   return;
               }
@@ -434,7 +432,7 @@ void negotiate_loop_(SharedPtr<report::Entry> entry, SharedPtr<net::Transport> t
                     });
               if (error) {
                   logger->warn("neubot: cannot parse negotiate response: %s",
-                               error.as_ooni_error().c_str());
+                               error.what());
                   callback(error, "", "");
                   return;
               }
@@ -466,8 +464,7 @@ void collect_(SharedPtr<net::Transport> txp, SharedPtr<report::Entry> entry,
           body,
           [=](Error error, SharedPtr<http::Response> res) {
               if (error) {
-                  logger->warn("neubot: collect failed: %s",
-                               error.as_ooni_error().c_str());
+                  logger->warn("neubot: collect failed: %s", error.what());
                   cb(error);
                   return;
               }
@@ -505,7 +502,7 @@ void negotiate_with_(std::string hostname, SharedPtr<report::Entry> entry,
                   // Note: in this case we don't need to close the transport
                   // because we get passed a dumb transport on error
                   logger->warn("neubot: cannot connect to negotiate server: %s",
-                               error.explain().c_str());
+                               error.what());
                   cb(error);
                   return;
               }
@@ -517,7 +514,7 @@ void negotiate_with_(std::string hostname, SharedPtr<report::Entry> entry,
                         std::string real_address) {
                         if (error) {
                             logger->warn("neubot: negotiate failed: %s",
-                                         error.explain().c_str());
+                                         error.what());
                             txp->close([=]() { cb(error); });
                             return;
                         }
@@ -526,7 +523,7 @@ void negotiate_with_(std::string hostname, SharedPtr<report::Entry> entry,
                                  reactor, logger, [=](Error error) {
                                      if (error) {
                                          logger->warn("neubot: test failed: %s",
-                                                      error.explain().c_str());
+                                                      error.what());
                                          /* FALLTHROUGH */
                                      }
                                      logger->info("Collecting results");
@@ -556,7 +553,7 @@ void negotiate_impl(SharedPtr<report::Entry> entry, Settings settings,
                  [=](Error error, mlabns::Reply reply) {
                      if (error) {
                          logger->warn("neubot: mlabns error: %s",
-                                      error.explain().c_str());
+                                      error.what());
                          cb(error);
                          return;
                      }

--- a/include/private/ooni/bouncer_impl.hpp
+++ b/include/private/ooni/bouncer_impl.hpp
@@ -41,7 +41,7 @@ ErrorOr<SharedPtr<BouncerReply>> create_impl(std::string data, SharedPtr<Logger>
         }
     });
     if (err) {
-        logger->warn("bouncer parsing error: %s", err.explain().c_str());
+        logger->warn("bouncer parsing error: %s", err.what());
         return err;
     }
     return reply;
@@ -72,8 +72,7 @@ void post_net_tests_impl(std::string base_bouncer_url, std::string test_name,
                  request.dump(),
                  [=](Error error, SharedPtr<http::Response> resp) {
                      if (error) {
-                         logger->warn("Bouncer error: %s",
-                                      error.explain().c_str());
+                         logger->warn("Bouncer error: %s", error.what());
                          cb(error, nullptr);
                          return;
                      }

--- a/include/private/ooni/orchestrate_impl.hpp
+++ b/include/private/ooni/orchestrate_impl.hpp
@@ -42,7 +42,7 @@ void login(Auth &&auth, std::string registry_url, Settings settings,
                      nlohmann::json json_response) mutable {
               if (error) {
                   logger->warn("orchestrator: JSON API error: %s",
-                               error.explain().c_str());
+                               error.what());
                   cb(std::move(error), std::move(auth));
                   return;
               }
@@ -69,7 +69,7 @@ void login(Auth &&auth, std::string registry_url, Settings settings,
                     });
               if (error) {
                   logger->warn("orchestrator: json processing error: %s",
-                               error.explain().c_str());
+                               error.what());
               }
               cb(std::move(error), std::move(auth));
           },
@@ -116,7 +116,7 @@ void register_probe_(const ClientMetadata &m, std::string password,
                                      nlohmann::json json_response) mutable {
               if (error) {
                   logger->warn("orchestrator: JSON API error: %s",
-                               error.as_ooni_error().c_str());
+                               error.what());
                   cb(std::move(error), std::move(auth));
                   return;
               }
@@ -136,7 +136,7 @@ void register_probe_(const ClientMetadata &m, std::string password,
                     });
               if (error) {
                   logger->warn("orchestrator: JSON processing error: %s",
-                               error.explain().c_str());
+                               error.what());
               } else {
                   logger->info("Registered probe with orchestrator as: '%s'",
                                auth.username.c_str());
@@ -222,7 +222,7 @@ void do_find_location(const ClientMetadata &m, SharedPtr<Reactor> reactor,
                   ErrorOr<std::string> x = callable(db, ip, logger);
                   if (!x) {
                       logger->warn("geoip failed for '%s': %s", ip.c_str(),
-                                   x.as_error().as_ooni_error().c_str());
+                                   x.as_error().what());
                       dest = fallback;
                       return;
                   }

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -163,8 +163,7 @@ void connect_ssl(bufferevent *orig_bev, ssl_st *ssl, std::string hostname,
                 ssl_st *ssl = bufferevent_openssl_get_ssl(bev);
 
                 if (err) {
-                    std::string s = err.explain();
-                    logger->debug("ssl: handshake error: %s", s.c_str());
+                    logger->debug("ssl: handshake error: %s", err.what());
                     bufferevent_free(bev);
                     cb(err, nullptr);
                     return;

--- a/src/libmeasurement_kit/nettests/dash.cpp
+++ b/src/libmeasurement_kit/nettests/dash.cpp
@@ -21,7 +21,7 @@ void DashRunnable::main(std::string /*input*/, Settings options,
     auto entry = SharedPtr<report::Entry>::make();
     neubot::dash::negotiate(entry, options, reactor, logger, [=](Error error) {
         if (error) {
-            (*entry)["failure"] = error.as_ooni_error();
+            (*entry)["failure"] = error.reason;
         } else {
             (*entry)["failure"] = nullptr;
         }

--- a/src/libmeasurement_kit/nettests/ndt.cpp
+++ b/src/libmeasurement_kit/nettests/ndt.cpp
@@ -26,7 +26,7 @@ void NdtRunnable::main(std::string, Settings settings,
     // possibly modified copy of the `options` object
     ndt::run(entry, [=](Error error) {
         if (error) {
-            (*entry)["failure"] = error.as_ooni_error();
+            (*entry)["failure"] = error.reason;
         }
         try {
             (*entry)["simple"] = mk::ndt::utils::compute_simple_stats(*entry, logger);

--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -208,8 +208,7 @@ void Runnable::geoip_lookup(Callback<> cb) {
                     probe_cc = *GeoipCache::thread_local_instance()
                        ->resolve_country_code(country_path, ip, logger);
                 } catch (const Error &err) {
-                    logger->warn("cannot lookup country code: %s",
-                                 err.explain().c_str());
+                    logger->warn("cannot lookup country code: %s", err.what());
                 }
                 if (probe_cc != "ZZ") {
                     logger->info("Your country: %s", probe_cc.c_str());
@@ -224,8 +223,7 @@ void Runnable::geoip_lookup(Callback<> cb) {
                     probe_asn = *GeoipCache::thread_local_instance()
                         ->resolve_asn(asn_path, ip, logger);
                 } catch (const Error &err) {
-                    logger->warn("cannot lookup asn: %s",
-                                 err.explain().c_str());
+                    logger->warn("cannot lookup asn: %s", err.what());
                 }
                 if (probe_asn != "AS0") {
                     logger->info("Your ISP identifier: %s", probe_asn.c_str());
@@ -367,7 +365,7 @@ void Runnable::begin(Callback<Error> cb) {
                     open_report([=](Error error) {
                         if (error) {
                             logger->warn("Cannot open report: %s",
-                                         error.explain().c_str());
+                                         error.what());
                             // FALLTHROUGH
                         }
                         logger->progress(0.1, "open report");

--- a/src/libmeasurement_kit/ooni/http_header_field_manipulation.cpp
+++ b/src/libmeasurement_kit/ooni/http_header_field_manipulation.cpp
@@ -99,8 +99,8 @@ void http_header_field_manipulation(std::string /*input*/, Settings options,
             if (err) {
                 logger->debug(
                     "http_header_field_manipulation: http-request error: %s",
-                    err.explain().c_str());
-                (*entry)["failure"] = err.as_ooni_error();
+                    err.what());
+                (*entry)["failure"] = err.reason;
             }
 
             if (!response) {
@@ -109,9 +109,8 @@ void http_header_field_manipulation(std::string /*input*/, Settings options,
                 try {
                     compare_headers_response(headers, response, entry, logger);
                 } catch (const std::exception &exc) {
-                    (*entry)["failure"] = exc.what();
-                    logger->warn("exception in "
-                                 "compare_headers_response(): %s",
+                    (*entry)["failure"] = exc.what(); // XXX
+                    logger->warn("exception in compare_headers_response(): %s",
                                  exc.what());
                 }
             }

--- a/src/libmeasurement_kit/ooni/http_invalid_request_line.cpp
+++ b/src/libmeasurement_kit/ooni/http_invalid_request_line.cpp
@@ -27,7 +27,7 @@ static void send_receive_invalid_request_line(net::Endpoint endpoint,
     templates::tcp_connect(settings, [=](Error err, SharedPtr<net::Transport> txp) {
         if (err) {
             logger->warn("http_invalid_request_line: error connecting");
-            (*entry)["failure"] = err.as_ooni_error();
+            (*entry)["failure"] = err.reason;
             cb(entry);
             return;
         }
@@ -74,9 +74,9 @@ void http_invalid_request_line(Settings options,
 
     if (!endpoint) {
         logger->warn("Invalid helper endpoint: %s (backend = '%s')",
-                     endpoint.as_error().explain().c_str(),
+                     endpoint.as_error().what(),
                      options["backend"].c_str());
-        (*entry)["failure"] = endpoint.as_error().as_ooni_error();
+        (*entry)["failure"] = endpoint.as_error().reason;
         cb(entry);
         return;
     }
@@ -93,7 +93,7 @@ void http_invalid_request_line(Settings options,
             for (auto &x : (*entry)["failure_list"]) {
                 if (x != nullptr) {
                     (*entry)["failure"]
-                        = ParallelOperationError().as_ooni_error();
+                        = ParallelOperationError().reason;
                     break;
                 }
             }

--- a/src/libmeasurement_kit/ooni/meek_fronted_requests.cpp
+++ b/src/libmeasurement_kit/ooni/meek_fronted_requests.cpp
@@ -27,7 +27,7 @@ void meek_fronted_requests(std::string input, Settings options,
     std::list<std::string> outer_inner = split(input, ":");
     if (outer_inner.size() != 2) {
         logger->warn("Couldn't split input: %s", input.c_str());
-        (*entry)["failure"] = ValueError().as_ooni_error();
+        (*entry)["failure"] = ValueError().reason;
         callback(entry);
         return;
     }
@@ -45,7 +45,7 @@ void meek_fronted_requests(std::string input, Settings options,
     if (!outer_url || !inner_url) {
         logger->warn("Invalid url: %s or %s", outer_host.c_str(),
                      inner_host.c_str());
-        (*entry)["failure"] = ValueError().as_ooni_error();
+        (*entry)["failure"] = ValueError().reason;
         callback(entry);
         return;
     }
@@ -63,10 +63,10 @@ void meek_fronted_requests(std::string input, Settings options,
                                 if (err) {
                                     logger->debug(
                                         "meek_fronted_requests: http-request error: %s",
-                                        err.explain().c_str());
+                                        err.what());
 
                                     (*entry)["failure"] =
-                                        err.as_ooni_error();
+                                        err.reason;
                                 }
 
                                 if (!!response) {

--- a/src/libmeasurement_kit/ooni/tcp_connect.cpp
+++ b/src/libmeasurement_kit/ooni/tcp_connect.cpp
@@ -18,7 +18,7 @@ void tcp_connect(std::string input, Settings options,
     // is not specified, defaulting to 80 in such case.
     ErrorOr<net::Endpoint> maybe_epnt = net::parse_endpoint(input, 80);
     if (!maybe_epnt) {
-        (*entry)["connection"] = maybe_epnt.as_error().as_ooni_error();
+        (*entry)["connection"] = maybe_epnt.as_error().reason;
         callback(entry);
         return;
     }
@@ -27,7 +27,7 @@ void tcp_connect(std::string input, Settings options,
     templates::tcp_connect(options, [=](Error err, SharedPtr<net::Transport> txp) {
         logger->debug("tcp_connect: Got response to TCP connect test");
         if (err) {
-            (*entry)["connection"] = err.as_ooni_error();
+            (*entry)["connection"] = err.reason;
             callback(entry);
             return;
         }

--- a/src/libmeasurement_kit/ooni/telegram.cpp
+++ b/src/libmeasurement_kit/ooni/telegram.cpp
@@ -29,7 +29,7 @@ static void tcp_many(const std::vector<std::string> ip_ports, SharedPtr<Entry> e
                 logger->info("telegram: failure TCP connecting to %s:%d",
                     ip.c_str(), port);
                 result["status"]["success"] = false;
-                result["status"]["failure"] = connect_error.as_ooni_error();
+                result["status"]["failure"] = connect_error.reason;
             } else {
                 logger->info("telegram: success TCP connecting to %s:%d",
                     ip.c_str(), port);
@@ -47,7 +47,7 @@ static void tcp_many(const std::vector<std::string> ip_ports, SharedPtr<Entry> e
         std::list<std::string> ip_port_l = split(ip_port, ":");
         if (ip_port_l.size() != 2) {
             logger->warn("Couldn't split ip_port: %s", ip_port.c_str());
-            (*entry)["failure"] = ValueError().as_ooni_error();
+            (*entry)["failure"] = ValueError().reason;
             all_done_cb(ValueError());
             return;
         }
@@ -82,7 +82,7 @@ static void http_many(const std::vector<std::string> urls, std::string type,
                     "telegram: failure HTTP connecting to %s", url.c_str());
                 if (type == "web") {
                     (*entry)["telegram_web_status"] = "blocked";
-                    (*entry)["telegram_web_failure"] = err.as_ooni_error();
+                    (*entry)["telegram_web_failure"] = err.reason;
                 }
             } else {
                 logger->info(

--- a/src/libmeasurement_kit/ooni/templates.cpp
+++ b/src/libmeasurement_kit/ooni/templates.cpp
@@ -80,7 +80,7 @@ void dns_query(SharedPtr<Entry> entry, dns::QueryType query_type,
                            }
                        }
                    } else {
-                       (*query_entry)["failure"] = error.as_ooni_error();
+                       (*query_entry)["failure"] = error.reason;
                    }
                    // TODO add support for bytes received
                    // (*query_entry)["bytes"] = response.get_bytes();
@@ -129,7 +129,7 @@ void http_request(SharedPtr<Entry> entry, Settings settings, http::Headers heade
                 Entry rr;
 
                 if (!!error) {
-                    rr["failure"] = error.as_ooni_error();
+                    rr["failure"] = error.reason;
                 } else {
                     rr["failure"] = nullptr;
                 }

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -395,7 +395,7 @@ static void control_request(http::Headers headers_to_pass_along,
                               return;
                           }
                       }
-                      (*entry)["control_failure"] = error.as_ooni_error();
+                      (*entry)["control_failure"] = error.reason;
                       callback(error);
                       return;
                   },
@@ -428,7 +428,7 @@ static void experiment_http_request(
                             [=](Error err, SharedPtr<http::Response> response) {
                                 if (err) {
                                     (*entry)["http_experiment_failure"] =
-                                        err.as_ooni_error();
+                                        err.reason;
                                     cb(err, headers, response);
                                     return;
                                 }
@@ -466,7 +466,7 @@ static void experiment_tcp_connect(SharedPtr<Entry> entry, SocketList sockets,
                 logger->info("web_connectivity: failed to connect to %s:%d",
                              ip.c_str(), port);
                 result["status"]["success"] = false;
-                result["status"]["failure"] = err.as_ooni_error();
+                result["status"]["failure"] = err.reason;
                 close_txp = false;
             } else {
                 logger->info("web_connectivity: success to connect to %s:%d",
@@ -572,7 +572,7 @@ void web_connectivity(std::string input, Settings options,
 
     if (!url) {
         logger->warn("Invalid test url.");
-        (*entry)["failure"] = url.as_error().as_ooni_error();
+        (*entry)["failure"] = url.as_error().reason;
         callback(entry);
         return;
     }
@@ -595,7 +595,7 @@ void web_connectivity(std::string input, Settings options,
 
             if (err) {
                 logger->warn("web_connectivity: dns-query error: %s",
-                             err.explain().c_str());
+                             err.what());
             }
             logger->info("web_connectivity: starting tcp_connect");
 
@@ -610,7 +610,7 @@ void web_connectivity(std::string input, Settings options,
 
                     if (err) {
                         logger->warn("web_connectivity: tcp-connect error: %s",
-                                     err.explain().c_str());
+                                     err.what());
                     }
 
                     logger->info(
@@ -624,7 +624,7 @@ void web_connectivity(std::string input, Settings options,
                             if (err) {
                                 logger->warn(
                                     "web_connectivity: http-request error: %s",
-                                    err.explain().c_str());
+                                    err.what());
                             }
 
                             logger->info(
@@ -638,7 +638,7 @@ void web_connectivity(std::string input, Settings options,
                                         logger->warn("web_connectivity: "
                                                      "control-request error: "
                                                      "%s",
-                                                     err.explain().c_str());
+                                                     err.what());
                                     }
 
                                     logger->info("web_connectivity: comparing "

--- a/test/common/error.cpp
+++ b/test/common/error.cpp
@@ -13,7 +13,7 @@ TEST_CASE("The default constructed error is true-ish") {
     Error err;
     REQUIRE(!err);
     REQUIRE((err.child_errors.size() <= 0));
-    REQUIRE(err.code == 0);
+    REQUIRE(err == 0);
     REQUIRE(err.reason == "");
 }
 
@@ -21,7 +21,7 @@ TEST_CASE("Error constructed with error code is correctly initialized") {
     Error err{17};
     REQUIRE(!!err);
     REQUIRE((err.child_errors.size() <= 0));
-    REQUIRE(err.code == 17);
+    REQUIRE(err == 17);
     REQUIRE(err.reason == "unknown_failure 17");
 }
 
@@ -29,15 +29,15 @@ TEST_CASE("Error constructed with error and message is correctly initialized") {
     Error err{17, "antani"};
     REQUIRE(!!err);
     REQUIRE((err.child_errors.size() <= 0));
-    REQUIRE(err.code == 17);
+    REQUIRE(err == 17);
     REQUIRE(err.reason == "antani");
 }
 
 TEST_CASE("Constructor with underlying error works correctly") {
     Error err{17, "antani", MockedError()};
     REQUIRE(!!err);
-    REQUIRE(*err.child_errors[0] == MockedError());
-    REQUIRE(err.code == 17);
+    REQUIRE(err.child_errors[0] == MockedError());
+    REQUIRE(err == 17);
     REQUIRE(err.reason == "antani");
 }
 
@@ -56,9 +56,9 @@ MK_DEFINE_ERR(17, ExampleError, "example error")
 TEST_CASE("The defined-error constructor with string works") {
     ExampleError ex{"antani"};
     REQUIRE(!!ex);
-    REQUIRE(ex.code == 17);
-    REQUIRE(ex.as_ooni_error() == "example error: antani");
+    REQUIRE(ex == 17);
     REQUIRE(ex.reason == "example error: antani");
+    REQUIRE(strcmp(ex.what(), "example error: antani") == 0);
 }
 
 TEST_CASE("The add_child_error() method works") {
@@ -68,8 +68,8 @@ TEST_CASE("The add_child_error() method works") {
     err.add_child_error(ex);
     err.add_child_error(merr);
     REQUIRE((err.child_errors.size() == 2));
-    REQUIRE((err.child_errors[0]->code == ExampleError().code));
-    REQUIRE((err.child_errors[0]->reason == "example error: antani"));
-    REQUIRE((err.child_errors[1]->code == MockedError().code));
-    REQUIRE((err.child_errors[1]->reason == "mocked_error"));
+    REQUIRE((err.child_errors[0] == ExampleError()));
+    REQUIRE((err.child_errors[0].reason == "example error: antani"));
+    REQUIRE((err.child_errors[1] == MockedError()));
+    REQUIRE((err.child_errors[1].reason == "mocked_error"));
 }

--- a/test/common/parallel.cpp
+++ b/test/common/parallel.cpp
@@ -30,7 +30,7 @@ TEST_CASE("mk::parallel() works as expected with all successes") {
         mk::parallel(input, [=](Error error) {
             REQUIRE((error == NoError()));
             for (auto &sub_error: error.child_errors) {
-                REQUIRE((*sub_error == NoError()));
+                REQUIRE((sub_error == NoError()));
             }
             reactor->stop();
         });
@@ -57,9 +57,9 @@ TEST_CASE("mk::parallel() works as expected with some failures") {
             REQUIRE((error.child_errors.size() == 16));
             for (size_t i = 0; i < error.child_errors.size(); ++i) {
                 if ((i % 2) == 0) {
-                    REQUIRE((*error.child_errors[i] == MockedError()));
+                    REQUIRE((error.child_errors[i] == MockedError()));
                 } else {
-                    REQUIRE((*error.child_errors[i] == NoError()));
+                    REQUIRE((error.child_errors[i] == NoError()));
                 }
             }
             reactor->stop();
@@ -81,7 +81,7 @@ TEST_CASE("mk::parallel() works as expected with all failures") {
         mk::parallel(input, [=](Error error) {
             REQUIRE((error == ParallelOperationError()));
             for (auto &sub_error: error.child_errors) {
-                REQUIRE((*sub_error == MockedError()));
+                REQUIRE((sub_error == MockedError()));
             }
             reactor->stop();
         });

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -169,14 +169,14 @@ TEST_CASE("slurpv() works as expected") {
         auto maybe_res = mk::slurpv_impl<char, fopen_fail>(
             "./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("If first fseek() fails") {
         auto maybe_res = mk::slurpv_impl<char, std::fopen, fseek_fail>(
             "./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("If ftell() fails") {
@@ -184,7 +184,7 @@ TEST_CASE("slurpv() works as expected") {
             mk::slurpv_impl<char, std::fopen, std::fseek, ftell_fail>(
                 "./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("If second fseek() fails") {
@@ -192,7 +192,7 @@ TEST_CASE("slurpv() works as expected") {
             mk::slurpv_impl<char, std::fopen, std::fseek, std::ftell,
                             fseek_fail>("./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("If fread() fails") {
@@ -200,7 +200,7 @@ TEST_CASE("slurpv() works as expected") {
                                          std::ftell, std::fseek, fread_fail>(
             "./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("If fclose() fails") {
@@ -209,7 +209,7 @@ TEST_CASE("slurpv() works as expected") {
                             std::fseek, std::fread, fclose_fail>(
                 "./test/fixtures/text-with-utf8.txt");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("For a file containing UTF-8") {
@@ -284,7 +284,7 @@ TEST_CASE("slurp() works as expected") {
     SECTION("In case of nonexistent file") {
         auto maybe_res = mk::slurp("/nonexistent");
         REQUIRE(!maybe_res);
-        REQUIRE(maybe_res.as_error().code == mk::FileIoError().code);
+        REQUIRE(maybe_res.as_error() == mk::FileIoError());
     }
 
     SECTION("In case of existent file") {

--- a/test/dns/ping.cpp
+++ b/test/dns/ping.cpp
@@ -31,7 +31,7 @@ TEST_CASE("The dns::ping() template works") {
                              Maybe<double>{10.0}, settings, reactor,
                              Logger::global(),
                              [](Error err, SharedPtr<dns::Message> message) {
-                                 std::cout << err.explain();
+                                 std::cout << err;
                                  if (message) {
                                      std::cout << " " << message->error_code;
                                      for (auto &a : message->answers) {

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -841,7 +841,7 @@ TEST_CASE("request_json_string() works as expected") {
             request_json_string_impl<non_200_response>(
               "GET", "http://www.google.com", "", {},
               [=](Error error, SharedPtr<Response> resp, nlohmann::json) {
-                  REQUIRE(error.code == NoError().code);
+                  REQUIRE(error == NoError());
                   REQUIRE(resp->status_code != 200);
                   reactor->stop();
               },

--- a/test/libevent/dns_error.cpp
+++ b/test/libevent/dns_error.cpp
@@ -15,37 +15,37 @@ using namespace mk::libevent;
 
 TEST_CASE("Evdns errors are correctly mapped to OONI failures") {
 
-    REQUIRE(dns_error(DNS_ERR_NONE).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_NONE).reason ==
             "");
-    REQUIRE(dns_error(DNS_ERR_FORMAT).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_FORMAT).reason ==
             "dns_lookup_error");
     REQUIRE(dns_error(DNS_ERR_SERVERFAILED)
-                .as_ooni_error() == "dns_lookup_error");
-    REQUIRE(dns_error(DNS_ERR_NOTEXIST).as_ooni_error() ==
+                .reason == "dns_lookup_error");
+    REQUIRE(dns_error(DNS_ERR_NOTEXIST).reason ==
             "dns_lookup_error");
-    REQUIRE(dns_error(DNS_ERR_NOTIMPL).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_NOTIMPL).reason ==
             "dns_lookup_error");
-    REQUIRE(dns_error(DNS_ERR_REFUSED).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_REFUSED).reason ==
             "dns_lookup_error");
 
     REQUIRE(dns_error(DNS_ERR_TRUNCATED)
-                .as_ooni_error() == "dns_lookup_error");
-    REQUIRE(dns_error(DNS_ERR_UNKNOWN).as_ooni_error() ==
+                .reason == "dns_lookup_error");
+    REQUIRE(dns_error(DNS_ERR_UNKNOWN).reason ==
             "dns_unknown_error");
-    REQUIRE(dns_error(DNS_ERR_TIMEOUT).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_TIMEOUT).reason ==
             "generic_timeout_error");
-    REQUIRE(dns_error(DNS_ERR_SHUTDOWN).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_SHUTDOWN).reason ==
             "dns_shutdown");
-    REQUIRE(dns_error(DNS_ERR_CANCEL).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_CANCEL).reason ==
             "dns_cancel");
-    REQUIRE(dns_error(DNS_ERR_NODATA).as_ooni_error() ==
+    REQUIRE(dns_error(DNS_ERR_NODATA).reason ==
             "dns_lookup_error");
 
     // Just three random numbers to increase confidence...
-    REQUIRE(dns_error(1024).as_ooni_error() ==
+    REQUIRE(dns_error(1024).reason ==
             "generic_error");
-    REQUIRE(dns_error(1025).as_ooni_error() ==
+    REQUIRE(dns_error(1025).reason ==
             "generic_error");
-    REQUIRE(dns_error(1026).as_ooni_error() ==
+    REQUIRE(dns_error(1026).reason ==
             "generic_error");
 }

--- a/test/ooni/resources.cpp
+++ b/test/ooni/resources.cpp
@@ -32,7 +32,7 @@ TEST_CASE("get_latest_release() works as expected") {
     SECTION("When http::get() fails") {
         ooni::resources::get_latest_release_impl<get_fail>(
             [=](Error e, std::string s) {
-                REQUIRE(e.code == MockedError().code);
+                REQUIRE(e == MockedError());
                 REQUIRE(s == "");
             },
             {}, Reactor::global(), Logger::global());
@@ -41,7 +41,7 @@ TEST_CASE("get_latest_release() works as expected") {
     SECTION("When response is not a redirection") {
         ooni::resources::get_latest_release_impl<get_500>(
             [=](Error e, std::string s) {
-                REQUIRE(e.code == ooni::CannotGetResourcesVersionError().code);
+                REQUIRE(e == ooni::CannotGetResourcesVersionError());
                 REQUIRE(s == "");
             },
             {}, Reactor::global(), Logger::global());
@@ -53,7 +53,7 @@ TEST_CASE("get_latest_release() works as expected") {
         reactor->run_with_initial_event([=]() {
             ooni::resources::get_latest_release(
                 [=](Error e, std::string s) {
-                    REQUIRE(e.code == NoError().code);
+                    REQUIRE(e == NoError());
                     REQUIRE(s != "");
                     reactor->stop();
                 },
@@ -77,7 +77,7 @@ TEST_CASE("get_manifest_as_json() works as expected") {
     SECTION("When http::get() fails") {
         ooni::resources::get_manifest_as_json_impl<get_fail>(
             "2", [=](Error e, nlohmann::json s) {
-                REQUIRE(e.code == MockedError().code);
+                REQUIRE(e == MockedError());
                 REQUIRE(s == nullptr);
             },
             {}, Reactor::global(), Logger::global());
@@ -86,7 +86,7 @@ TEST_CASE("get_manifest_as_json() works as expected") {
     SECTION("When response is not okay") {
         ooni::resources::get_manifest_as_json_impl<get_500>(
             "2", [=](Error e, nlohmann::json s) {
-                REQUIRE(e.code == ooni::CannotGetResourcesManifestError().code);
+                REQUIRE(e == ooni::CannotGetResourcesManifestError());
                 REQUIRE(s == nullptr);
             },
             {}, Reactor::global(), Logger::global());
@@ -95,7 +95,7 @@ TEST_CASE("get_manifest_as_json() works as expected") {
     SECTION("When the body is not a valid JSON") {
         ooni::resources::get_manifest_as_json_impl<get_invalid_json>(
             "2", [=](Error e, nlohmann::json s) {
-                REQUIRE(e.code == JsonParseError().code);
+                REQUIRE(e == JsonParseError());
                 REQUIRE(s == nullptr);
             },
             {}, Reactor::global(), Logger::global());
@@ -142,7 +142,7 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl(
                 "6", nullptr, "IT",
                 [=](Error err) {
-                    REQUIRE(err.code == JsonDomainError().code);
+                    REQUIRE(err == JsonDomainError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -155,7 +155,7 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl(
                 "6", nlohmann::json::object(), "IT",
                 [=](Error err) {
-                    REQUIRE(err.code == JsonKeyError().code);
+                    REQUIRE(err == JsonKeyError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -172,10 +172,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl(
                 "6", root, "IT",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                JsonDomainError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                JsonDomainError());
                     }
                     reactor->stop();
                 },
@@ -193,10 +193,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl(
                 "6", root, "IT",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                JsonKeyError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                JsonKeyError());
                     }
                     reactor->stop();
                 },
@@ -219,13 +219,13 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country(
                 "6", root, "IT",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     /*
                      * JsonKeyError because `path` is missing.
                      */
-                    REQUIRE(err.child_errors[0]->code == JsonKeyError().code);
-                    REQUIRE(err.child_errors[1]->code == NoError().code);
-                    REQUIRE(err.child_errors[2]->code == NoError().code);
+                    REQUIRE(err.child_errors[0] == JsonKeyError());
+                    REQUIRE(err.child_errors[1] == NoError());
+                    REQUIRE(err.child_errors[2] == NoError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -247,13 +247,13 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     /*
                      * JsonKeyError because `path` is missing.
                      */
-                    REQUIRE(err.child_errors[0]->code == JsonKeyError().code);
-                    REQUIRE(err.child_errors[1]->code == JsonKeyError().code);
-                    REQUIRE(err.child_errors[2]->code == JsonKeyError().code);
+                    REQUIRE(err.child_errors[0] == JsonKeyError());
+                    REQUIRE(err.child_errors[1] == JsonKeyError());
+                    REQUIRE(err.child_errors[2] == JsonKeyError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -278,10 +278,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl<get_fail>(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
-                    REQUIRE(err.child_errors[0]->code == MockedError().code);
-                    REQUIRE(err.child_errors[1]->code == MockedError().code);
-                    REQUIRE(err.child_errors[2]->code == MockedError().code);
+                    REQUIRE(err == ParallelOperationError());
+                    REQUIRE(err.child_errors[0] == MockedError());
+                    REQUIRE(err.child_errors[1] == MockedError());
+                    REQUIRE(err.child_errors[2] == MockedError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -306,10 +306,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl<get_500>(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                ooni::CannotGetResourceError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                ooni::CannotGetResourceError());
                     }
                     reactor->stop();
                 },
@@ -335,10 +335,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl<get_antani_body>(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                JsonKeyError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                JsonKeyError());
                     }
                     reactor->stop();
                 },
@@ -367,10 +367,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
             ooni::resources::get_resources_for_country_impl<get_antani_body>(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                ooni::ResourceIntegrityError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                ooni::ResourceIntegrityError());
                     }
                     reactor->stop();
                 },
@@ -400,10 +400,10 @@ TEST_CASE("get_resources_for_country() works as expected") {
                                                             io_error>(
                 "6", root, "ALL",
                 [=](Error err) {
-                    REQUIRE(err.code == ParallelOperationError().code);
+                    REQUIRE(err == ParallelOperationError());
                     for (size_t i = 0; i < err.child_errors.size(); ++i) {
-                        REQUIRE(err.child_errors[i]->code ==
-                                FileIoError().code);
+                        REQUIRE(err.child_errors[i] ==
+                                FileIoError());
                     }
                     reactor->stop();
                 },
@@ -439,7 +439,7 @@ TEST_CASE("get_resources() works as expected") {
             ooni::resources::get_resources_impl<get_manifest_as_json_fail>(
                 "6", "IT",
                 [=](Error error) {
-                    REQUIRE(error.code == MockedError().code);
+                    REQUIRE(error == MockedError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -453,7 +453,7 @@ TEST_CASE("get_resources() works as expected") {
                                                 get_resources_for_country_fail>(
                 "6", "IT",
                 [=](Error error) {
-                    REQUIRE(error.code == MockedError().code);
+                    REQUIRE(error == MockedError());
                     reactor->stop();
                 },
                 {}, reactor, Logger::global());
@@ -468,8 +468,8 @@ TEST_CASE("get_resources() works as expected") {
         reactor->run_with_initial_event([=]() {
             ooni::resources::get_resources("6", "ALL",
                                            [=](Error error) {
-                                               REQUIRE(error.code ==
-                                                       NoError().code);
+                                               REQUIRE(error ==
+                                                       NoError());
                                                reactor->stop();
                                            },
                                            {}, reactor, logger);

--- a/test/report/report.cpp
+++ b/test/report/report.cpp
@@ -101,12 +101,12 @@ TEST_CASE("The open() method works correctly") {
     report.open([&](Error err) {
         REQUIRE(!err);
         report.open([&](Error err) {
-            REQUIRE(err.code == NoError().code);
+            REQUIRE(err == NoError());
             REQUIRE(err.child_errors.size() == 1);
-            REQUIRE(err.child_errors[0]->code == NoError().code);
-            REQUIRE(err.child_errors[0]->child_errors.size() == 1);
-            REQUIRE(err.child_errors[0]->child_errors[0]->code ==
-                    ReportAlreadyOpenError().code);
+            REQUIRE(err.child_errors[0] == NoError());
+            REQUIRE(err.child_errors[0].child_errors.size() == 1);
+            REQUIRE(err.child_errors[0].child_errors[0] ==
+                    ReportAlreadyOpenError());
         });
     });
 }
@@ -118,18 +118,18 @@ TEST_CASE("We can retry a partially successful open") {
     report.add_reporter(counted_reporter.as<BaseReporter>());
     report.add_reporter(failing_reporter.as<BaseReporter>());
     report.open([&](Error err) {
-        REQUIRE(err.code == ParallelOperationError().code);
+        REQUIRE(err == ParallelOperationError());
         REQUIRE(err.child_errors.size() == 2);
-        REQUIRE(err.child_errors[0]->code == NoError().code);
-        REQUIRE(err.child_errors[1]->code == MockedError().code);
+        REQUIRE(err.child_errors[0] == NoError());
+        REQUIRE(err.child_errors[1] == MockedError());
         report.open([&](Error err) {
-            REQUIRE(err.code == NoError().code);
+            REQUIRE(err == NoError());
             REQUIRE(err.child_errors.size() == 2);
-            REQUIRE(err.child_errors[0]->code == NoError().code);
-            REQUIRE(err.child_errors[0]->child_errors.size() == 1);
-            REQUIRE(err.child_errors[0]->child_errors[0]->code ==
-                    ReportAlreadyOpenError().code);
-            REQUIRE(err.child_errors[1]->code == NoError().code);
+            REQUIRE(err.child_errors[0] == NoError());
+            REQUIRE(err.child_errors[0].child_errors.size() == 1);
+            REQUIRE(err.child_errors[0].child_errors[0] ==
+                    ReportAlreadyOpenError());
+            REQUIRE(err.child_errors[1] == NoError());
         });
     });
     REQUIRE(counted_reporter->open_count == 1);
@@ -141,23 +141,23 @@ TEST_CASE("The write_entry() method works correctly") {
     report.add_reporter(BaseReporter::make());
     Entry entry;
     report.write_entry(entry, [&](Error err) {
-        REQUIRE(err.code == ParallelOperationError().code);
+        REQUIRE(err == ParallelOperationError());
         REQUIRE(err.child_errors.size() == 1);
-        REQUIRE(err.child_errors[0]->code == ReportNotOpenError().code);
+        REQUIRE(err.child_errors[0] == ReportNotOpenError());
         report.open([&](Error err) {
             REQUIRE(!err);
             entry["foobar"] = 1;
             report.write_entry(entry, [&](Error err) {
                 REQUIRE(!err);
                 REQUIRE(err.child_errors.size() == 1);
-                REQUIRE(err.child_errors[0]->code == NoError().code);
-                REQUIRE(err.child_errors[0]->child_errors.size() == 0);
+                REQUIRE(err.child_errors[0] == NoError());
+                REQUIRE(err.child_errors[0].child_errors.size() == 0);
                 entry["foobar"] = 2;
                 report.write_entry(entry, [&](Error err) {
                     REQUIRE(!err);
                     REQUIRE(err.child_errors.size() == 1);
-                    REQUIRE(err.child_errors[0]->code == NoError().code);
-                    REQUIRE(err.child_errors[0]->child_errors.size() == 0);
+                    REQUIRE(err.child_errors[0] == NoError());
+                    REQUIRE(err.child_errors[0].child_errors.size() == 0);
                     entry["foobar"] = 3;
                     report.write_entry(entry, [&](Error err) {
                         REQUIRE(!err);
@@ -165,16 +165,16 @@ TEST_CASE("The write_entry() method works correctly") {
                             REQUIRE(!err);
                             REQUIRE(err.child_errors.size() == 1);
                             REQUIRE(
-                                err.child_errors[0]->code == NoError().code);
+                                err.child_errors[0] == NoError());
                             REQUIRE(
-                                err.child_errors[0]->child_errors.size() == 0);
+                                err.child_errors[0].child_errors.size() == 0);
                             entry["foobar"] = 4;
                             report.write_entry(entry, [&](Error err) {
-                                REQUIRE(err.code ==
-                                        ParallelOperationError().code);
+                                REQUIRE(err ==
+                                        ParallelOperationError());
                                 REQUIRE(err.child_errors.size() == 1);
-                                REQUIRE(err.child_errors[0]->code ==
-                                        ReportAlreadyClosedError().code);
+                                REQUIRE(err.child_errors[0] ==
+                                        ReportAlreadyClosedError());
                             }, Logger::global());
                         });
                     }, Logger::global());
@@ -192,23 +192,23 @@ TEST_CASE("We can retry a partially successful write_entry()") {
     report.add_reporter(counted_reporter.as<BaseReporter>());
     report.add_reporter(failing_reporter.as<BaseReporter>());
     report.open([&](Error err) {
-        REQUIRE(err.code == NoError().code);
+        REQUIRE(err == NoError());
         Entry entry;
         entry["foobar"] = 17;
         entry["baz"] = "foobar";
         report.write_entry(entry, [&](Error err) {
-            REQUIRE(err.code == ParallelOperationError().code);
+            REQUIRE(err == ParallelOperationError());
             REQUIRE(err.child_errors.size() == 2);
-            REQUIRE(err.child_errors[0]->code == NoError().code);
-            REQUIRE(err.child_errors[1]->code == MockedError().code);
+            REQUIRE(err.child_errors[0] == NoError());
+            REQUIRE(err.child_errors[1] == MockedError());
             report.write_entry(entry, [&](Error err) {
-                REQUIRE(err.code == NoError().code);
+                REQUIRE(err == NoError());
                 REQUIRE(err.child_errors.size() == 2);
-                REQUIRE(err.child_errors[0]->code == NoError().code);
-                REQUIRE(err.child_errors[0]->child_errors.size() == 1);
-                REQUIRE(err.child_errors[0]->child_errors[0]->code ==
-                        DuplicateEntrySubmitError().code);
-                REQUIRE(err.child_errors[1]->code == NoError().code);
+                REQUIRE(err.child_errors[0] == NoError());
+                REQUIRE(err.child_errors[0].child_errors.size() == 1);
+                REQUIRE(err.child_errors[0].child_errors[0] ==
+                        DuplicateEntrySubmitError());
+                REQUIRE(err.child_errors[1] == NoError());
             }, Logger::global());
         }, Logger::global());
     });
@@ -224,12 +224,12 @@ TEST_CASE("The close() method works correctly") {
         report.close([&](Error err) {
             REQUIRE(!err);
             report.close([&](Error err) {
-                REQUIRE(err.code == NoError().code);
+                REQUIRE(err == NoError());
                 REQUIRE(err.child_errors.size() == 1);
-                REQUIRE(err.child_errors[0]->code == NoError().code);
-                REQUIRE(err.child_errors[0]->child_errors.size() == 1);
-                REQUIRE(err.child_errors[0]->child_errors[0]->code ==
-                        ReportAlreadyClosedError().code);
+                REQUIRE(err.child_errors[0] == NoError());
+                REQUIRE(err.child_errors[0].child_errors.size() == 1);
+                REQUIRE(err.child_errors[0].child_errors[0] ==
+                        ReportAlreadyClosedError());
             });
         });
     });
@@ -243,20 +243,20 @@ TEST_CASE("We can retry a partially successful close") {
     report.add_reporter(counted_reporter.as<BaseReporter>());
     report.add_reporter(failing_reporter.as<BaseReporter>());
     report.open([&](Error err) {
-        REQUIRE(err.code == NoError().code);
+        REQUIRE(err == NoError());
         report.close([&](Error err) {
-            REQUIRE(err.code == ParallelOperationError().code);
+            REQUIRE(err == ParallelOperationError());
             REQUIRE(err.child_errors.size() == 2);
-            REQUIRE(err.child_errors[0]->code == NoError().code);
-            REQUIRE(err.child_errors[1]->code == MockedError().code);
+            REQUIRE(err.child_errors[0] == NoError());
+            REQUIRE(err.child_errors[1] == MockedError());
             report.close([&](Error err) {
-                REQUIRE(err.code == NoError().code);
+                REQUIRE(err == NoError());
                 REQUIRE(err.child_errors.size() == 2);
-                REQUIRE(err.child_errors[0]->code == NoError().code);
-                REQUIRE(err.child_errors[0]->child_errors.size() == 1);
-                REQUIRE(err.child_errors[0]->child_errors[0]->code ==
-                        ReportAlreadyClosedError().code);
-                REQUIRE(err.child_errors[1]->code == NoError().code);
+                REQUIRE(err.child_errors[0] == NoError());
+                REQUIRE(err.child_errors[0].child_errors.size() == 1);
+                REQUIRE(err.child_errors[0].child_errors[0] ==
+                        ReportAlreadyClosedError());
+                REQUIRE(err.child_errors[1] == NoError());
             });
         });
     });
@@ -283,12 +283,12 @@ TEST_CASE(
     report.add_reporter(ReturningIdReporter::make().as<BaseReporter>());
     report.add_reporter(ReturningIdReporter::make().as<BaseReporter>());
     report.open([&](Error err) {
-        REQUIRE(err.code == NoError().code);
+        REQUIRE(err == NoError());
         Entry entry;
         entry["foobar"] = 17;
         entry["baz"] = "foobar";
         report.write_entry(entry, [&](Error err) {
-            REQUIRE(err.code == MultipleReportIdsError().code);
+            REQUIRE(err == MultipleReportIdsError());
         }, Logger::global());
     });
 }

--- a/test/traceroute/android.cpp
+++ b/test/traceroute/android.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Typical IPv4 traceroute usage") {
         });
 
         prober.on_error([&](Error err) {
-            std::cout << ttl << " error: " << err.what() << "\n";
+            std::cout << ttl << " error: " << err << "\n";
             if (ttl >= 64) {
                 reactor->stop();
                 return;
@@ -89,7 +89,7 @@ TEST_CASE("Check whether it works when destination sends reply") {
         });
 
         prober.on_error([&](Error err) {
-            std::cout << ttl << " error: " << err.what() << "\n";
+            std::cout << ttl << " error: " << err << "\n";
             if (ttl >= 64) {
                 reactor->stop();
                 return;


### PR DESCRIPTION
- do not use SharedPtr when we actually don't need it

- simplify constructors chain

- remove the explain() method: until we agree on a good OONI way
  to represent compound error is better not to expose anything

- make errors printable through `std::ostream`

- remove `as_ooni_error()` and decided that `.reason` will
  actually be the real ooni error (`#simplicity`)

- consistently use:

    - `error.reason` in string context

    - `error.what()` in printf() context

- apply changes to the whole tree