### PR TITLE
Release v0.7.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# MeasurementKit 0.7.3 [2017-09-21]
+
+- fix(`tcp_connect1 template): never pass null transport to callback  (#1372)
+
 # MeasurementKit 0.7.2 [2017-09-13]
 
 - fix(`async_runner`): prevent MT race

--- a/build/ios/archive-library
+++ b/build/ios/archive-library
@@ -3,7 +3,7 @@ set -e
 ROOTDIR=$(cd $(dirname $0)/../.. && pwd -P)
 cd $ROOTDIR
 D=build/ios
-V=0.7.2
+V=0.7.3
 
 # Do not ship *.la files that would break the build and, while there, also
 # remove directories that we don't need for cross compiling MK

--- a/build/ios/library
+++ b/build/ios/library
@@ -2,7 +2,7 @@
 set -e
 ROOTDIR=$(cd `dirname "$0"` && pwd -P)
 
-RELEASE_URL=https://github.com/measurement-kit/measurement-kit/releases/download/v0.7.2/ios_binaries-0.7.2.tgz
+RELEASE_URL=https://github.com/measurement-kit/measurement-kit/releases/download/v0.7.3/ios_binaries-0.7.3.tgz
 RELEASE_FILE=$(basename $RELEASE_URL)
 if wget $RELEASE_URL; then
     wget $RELEASE_URL.asc

--- a/build/spec/mk
+++ b/build/spec/mk
@@ -1,5 +1,5 @@
 pkg_name=measurement-kit
-pkg_branch_or_tag=v0.7.2
+pkg_branch_or_tag=v0.7.3
 _dd=${pkg_prefix}/${pkg_cross}/${pkg_cross_arch}
 pkg_configure_flags="--disable-examples --disable-shared --disable-binaries --with-openssl=${_dd} --with-libevent=${_dd} --with-geoip=${_dd} $pkg_configure_flags"
 pkg_make_install_rule=install-strip

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # information on the copying conditions.
 
 # Autoconf requirements
-AC_INIT(measurement_kit, 0.7.2, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.7.3, bassosimone@gmail.com)
 
 # information on the package
 AC_CONFIG_SRCDIR([Makefile.am])

--- a/doc/api/common/version.md
+++ b/doc/api/common/version.md
@@ -8,8 +8,8 @@ MeasurementKit (libmeasurement_kit, -lmeasurement_kit).
 ```C++
 #include <measurement_kit/common/version.h>
 
-#define MK_VERSION "0.7.2"
-#define MK_VERSION_FULL "v0.7.2-6-abcdef"
+#define MK_VERSION "0.7.3"
+#define MK_VERSION_FULL "v0.7.3-6-abcdef"
 
 #define MEASUREMENT_KIT_VERSION MK_VERSION /* Backward compat. */
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,4 +1,4 @@
-Welcome to Measurement Kit **v0.7.2** documentation!
+Welcome to Measurement Kit **v0.7.3** documentation!
 
 # How to generate documentation
 

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -8,7 +8,7 @@
 #include <measurement_kit/common/git_version.hpp>
 
 // Note: we use semantic versioning (see: http://semver.org/)
-#define MK_VERSION "0.7.2"
+#define MK_VERSION "0.7.3"
 #define MEASUREMENT_KIT_VERSION MK_VERSION /* Backward compatibility */
 
 #ifdef __cplusplus

--- a/measurement_kit.podspec
+++ b/measurement_kit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "measurement_kit"
-  s.version = "0.7.2"
+  s.version = "0.7.3"
   s.summary = "Portable network measurement library"
   s.author = "Simone Basso",
              "Arturo Filastò",

--- a/src/libmeasurement_kit/ooni/templates.cpp
+++ b/src/libmeasurement_kit/ooni/templates.cpp
@@ -6,6 +6,7 @@
 
 #include <event2/dns.h>
 
+#include "private/net/emitter.hpp"
 #include "private/ooni/utils.hpp"
 
 namespace mk {
@@ -187,11 +188,15 @@ void tcp_connect(Settings options, Callback<Error, Var<net::Transport>> cb,
                  Var<Reactor> reactor, Var<Logger> logger) {
     ErrorOr<int> port = options["port"].as_noexcept<int>();
     if (!port) {
-        cb(port.as_error(), nullptr);
+        cb(port.as_error(),
+                Var<net::Transport>{
+                        std::make_shared<net::Emitter>(reactor, logger)});
         return;
     }
     if (options["host"] == "") {
-        cb(MissingRequiredHostError(), nullptr);
+        cb(MissingRequiredHostError(),
+                Var<net::Transport>{
+                        std::make_shared<net::Emitter>(reactor, logger)});
         return;
     }
     net::connect(options["host"], *port, cb, options, reactor, logger);

--- a/test/ooni/templates.cpp
+++ b/test/ooni/templates.cpp
@@ -68,7 +68,7 @@ TEST_CASE("tcp connect returns error if port is missing") {
     loop_with_initial_event([]() {
         templates::tcp_connect({}, [](Error err, Var<net::Transport> txp) {
             REQUIRE(err);
-            REQUIRE(txp == nullptr);
+            REQUIRE(!!txp);
             break_loop();
         });
     });
@@ -81,7 +81,7 @@ TEST_CASE("tcp connect returns error if port is invalid") {
         templates::tcp_connect(settings,
                                [](Error err, Var<net::Transport> txp) {
                                    REQUIRE(err);
-                                   REQUIRE(txp == nullptr);
+                                   REQUIRE(!!txp);
                                    break_loop();
                                });
     });


### PR DESCRIPTION
This fix should _also_ be backported to the integration branch for
`v0.8.0` and to the stable branch, cutting `v0.7.3`.

Note: this is a cherry-pick of aaf1781b18a99c440da1c65d5a71ebf86e3a4321
from master that has been backported to stable.

Conflicts:
	src/libmeasurement_kit/ooni/templates.cpp
	test/ooni/templates.cpp