### PR TITLE
fix(collector_client): recognize build number

### DIFF
--- a/src/libmeasurement_kit/ooni/collector_client.cpp
+++ b/src/libmeasurement_kit/ooni/collector_client.cpp
@@ -30,7 +30,7 @@ using namespace mk::report;
 
 static const std::regex re_name{R"(^[A-Za-z0-9._-]+$)"};
 static const std::regex re_version{
-    R"(\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b)",
+    R"(^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?$)",
     std::regex::icase};
 
 static std::map<std::string, std::regex> mandatory_re{

--- a/src/libmeasurement_kit/ooni/collector_client.cpp
+++ b/src/libmeasurement_kit/ooni/collector_client.cpp
@@ -15,7 +15,7 @@ using namespace mk::report;
 
 static const std::regex re_name{"^[A-Za-z0-9._-]+$"};
 static const std::regex re_version{
-    "^[0-9]+.[0-9]+(.[0-9]+(-[A-Za-z0-9._-]+)?)?$"};
+    R"(^[0-9]+\.[0-9]+(\.[0-9]+(-[A-Za-z0-9._-]+)?(\+[0-9]+)?)?$)"};
 
 static std::map<std::string, std::regex> mandatory_re{
     {"software_name", re_name},

--- a/src/libmeasurement_kit/ooni/collector_client.cpp
+++ b/src/libmeasurement_kit/ooni/collector_client.cpp
@@ -13,20 +13,36 @@ using namespace mk::http;
 using namespace mk::net;
 using namespace mk::report;
 
-static const std::regex re_name{"^[A-Za-z0-9._-]+$"};
+// Regex notes
+// -----------
+//
+// 1. [the default grammar is ECMAScript](
+//      http://en.cppreference.com/w/cpp/regex/basic_regex
+//    )
+//
+// 2. the `re_version` regexp is copied from [sindresorhus/semver-regex](
+//       https://github.com/sindresorhus/semver-regex/blob/624a91ef62e593abebbf8f411449ab0d257eac4d/index.js
+//    )
+//
+// 3. R"(...)" delimits a [raw characters sequence](
+//      http://en.cppreference.com/w/cpp/language/string_literal
+//    )
+
+static const std::regex re_name{R"(^[A-Za-z0-9._-]+$)"};
 static const std::regex re_version{
-    R"(^[0-9]+\.[0-9]+(\.[0-9]+(-[A-Za-z0-9._-]+)?(\+[0-9]+)?)?$)"};
+    R"(\bv?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b)",
+    std::regex::icase};
 
 static std::map<std::string, std::regex> mandatory_re{
     {"software_name", re_name},
     {"software_version", re_version},
-    {"probe_asn", std::regex{"^AS[0-9]+$"}},
-    {"probe_cc", std::regex{"^[A-Z]{2}$"}},
+    {"probe_asn", std::regex{R"(^AS[0-9]+$)"}},
+    {"probe_cc", std::regex{R"(^[A-Z]{2}$)"}},
     {"test_name", re_name},
     {"test_version", re_version},
     {"data_format_version", re_version},
     {"test_start_time",
-     std::regex{"^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$"}},
+     std::regex{R"(^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$)"}},
 };
 
 Error valid_entry(Entry entry) {

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -196,7 +196,7 @@ static Entry ENTRY{
     {"probe_cc", "ZZ"},
     {"probe_ip", "127.0.0.1"},
     {"software_name", "measurement_kit"},
-    {"software_version", "0.2.0-alpha.1+11"},
+    {"software_version", "0.2.0-alpha.1+11.1"},
     {"test_keys", {
         {"failure", nullptr},
         {"received", Json::array()},
@@ -220,7 +220,7 @@ static Entry BAD_ENTRY{
     {"probe_cc", "ZZ"},
     {"probe_ip", "127.0.0.1"},
     {"software_name", "measurement kit"}, // This should fail
-    {"software_version", "0.2.0-alpha.1+11"},
+    {"software_version", "0.2.0-alpha.1+11.1"},
     {"test_keys", {
         {"failure", nullptr},
         {"received", Json::array()},

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -196,7 +196,7 @@ static Entry ENTRY{
     {"probe_cc", "ZZ"},
     {"probe_ip", "127.0.0.1"},
     {"software_name", "measurement_kit"},
-    {"software_version", "0.2.0-alpha.1"},
+    {"software_version", "0.2.0-alpha.1+11"},
     {"test_keys", {
         {"failure", nullptr},
         {"received", Json::array()},
@@ -220,7 +220,7 @@ static Entry BAD_ENTRY{
     {"probe_cc", "ZZ"},
     {"probe_ip", "127.0.0.1"},
     {"software_name", "measurement kit"}, // This should fail
-    {"software_version", "0.2.0-alpha.1"},
+    {"software_version", "0.2.0-alpha.1+11"},
     {"test_keys", {
         {"failure", nullptr},
         {"received", Json::array()},


### PR DESCRIPTION
Closes TheTorProject/ooniprobe-ios#131

This needs to be backported in v0.8.x and v0.7.x.