### PR TITLE
fix(logger): force ofile flush for each entry

### DIFF
--- a/src/libmeasurement_kit/common/logger.cpp
+++ b/src/libmeasurement_kit/common/logger.cpp
@@ -105,7 +105,9 @@ class DefaultLogger : public Logger, public NonCopyable, public NonMovable {
         }
 
         if (ofile_) {
-            *ofile_ << buffer_ << "\n";
+            // FIX: use `std::endl` rather than `\n` to make sure we flush
+            // after each line. Fixes TheTorProject/ooniprobe-ios#80.
+            *ofile_ << buffer_ << std::endl;
             // TODO: suppose here write fails... what do we want to do?
         }
     }


### PR DESCRIPTION
Use `std::endl` rather than `\n` when emitting logs. Force flushing logs at end of test and fixes TheTorProject/ooniprobe-ios#80.

This is the forward port of the fix tested for `v0.7.4` to `master`.

Cc: @hellais 