### PR TITLE
Fix for systems that don't support thread_local

### DIFF
--- a/build/ios/cross
+++ b/build/ios/cross
@@ -16,6 +16,9 @@ MINIOSVERSION="9.0"
 if [ "$PLATFORM" = "iphoneos" ]; then
     EXTRA_CONFIG="--host=arm-apple-darwin --target=arm-apple-darwin --disable-shared"
     MINVERSION="-miphoneos-version-min=$MINIOSVERSION"
+    if [ "$ARCH" = "armv7" -o "$ARCH" = "armv7s" ]; then
+        CPPFLAGS="-DMK_NO_THREAD_LOCAL"
+    fi
 elif [ "$ARCH" = "i386" ]; then
     EXTRA_CONFIG="--host=i386-apple-darwin --target=i386-apple-darwin --disable-shared"
     MINVERSION="-mios-simulator-version-min=$MINIOSVERSION"
@@ -36,7 +39,7 @@ DESTDIR="$ROOTDIR/tmp"
 
 export CC="$(xcrun -find -sdk ${PLATFORM} cc)"
 export CXX="$(xcrun -find -sdk ${PLATFORM} g++)"
-export CPPFLAGS="-arch ${ARCH} -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
+export CPPFLAGS="-arch ${ARCH} -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path) $CPPFLAGS"
 export CFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 export CXXFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 export LDFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"

--- a/include/private/net/libssl.hpp
+++ b/include/private/net/libssl.hpp
@@ -219,8 +219,17 @@ template <size_t max_cache_size = 64> class Cache {
     */
 
     /// Return thread local instance of the cache.
-    static Cache &thread_local_instance() {
-        static thread_local Cache instance;
+    static Var<Cache> thread_local_instance() {
+        // We have experimentally found that iOS armv7 does not support well
+        // thread_local. In such case, we allocate a new cache every time rather
+        // than using a thread local cache. We will be able to drop this fix
+        // in the moment in which support for 32-bit iOS will be dropped.
+        //
+        // See <https://github.com/measurement-kit/measurement-kit/issues/1397>.
+#ifndef MK_NO_THREAD_LOCAL
+        static thread_local
+#endif
+        Var<Cache> instance{new Cache};
         return instance;
     }
 

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -220,7 +220,7 @@ void connect(std::string address, int port,
                 }
                 logger->debug("ca_bundle_path: '%s'", cbp.c_str());
                 ErrorOr<SSL *> cssl = libssl::Cache<>::thread_local_instance()
-                    .get_client_ssl(cbp, address, logger);
+                    ->get_client_ssl(cbp, address, logger);
                 if (!cssl) {
                     Error err = cssl.as_error();
                     bufferevent_free(r->connected_bev);

--- a/src/libmeasurement_kit/ooni/utils.cpp
+++ b/src/libmeasurement_kit/ooni/utils.cpp
@@ -19,7 +19,16 @@ void resolver_lookup(Callback<Error, std::string> callback, Settings settings,
 }
 
 /* static */ Var<GeoipCache> GeoipCache::thread_local_instance() {
-    static thread_local Var<GeoipCache> singleton(new GeoipCache);
+    // We have experimentally found that iOS armv7 does not support well
+    // thread_local. In such case, we allocate a new cache every time rather
+    // than using a thread local cache. We will be able to drop this fix
+    // in the moment in which support for 32-bit iOS will be dropped.
+    //
+    // See <https://github.com/measurement-kit/measurement-kit/issues/1397>.
+#ifndef MK_NO_THREAD_LOCAL
+    static thread_local
+#endif
+    Var<GeoipCache> singleton{new GeoipCache};
     return singleton;
 }
 

--- a/test/net/libssl.cpp
+++ b/test/net/libssl.cpp
@@ -94,12 +94,12 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache is evicted when too many SSL_CTX are created") {
         auto cache = Cache<1>{};
         REQUIRE(cache.size() == 0);
-        auto ssl = cache->get_client_ssl(default_cert, "www.google.com",
+        auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
                                         Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
-        ssl = cache->get_client_ssl("./test/fixtures/saved_ca_bundle.pem",
+        ssl = cache.get_client_ssl("./test/fixtures/saved_ca_bundle.pem",
                                    "www.google.com", Logger::global());
         REQUIRE(*ssl != nullptr);
         // Note: we expect this to be equal to one, meaning that the first
@@ -111,12 +111,12 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache works in the common case") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
-        auto ssl = cache->get_client_ssl(default_cert, "www.google.com",
+        auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
                                         Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
-        ssl = cache->get_client_ssl("./test/fixtures/basic_ca.pem",
+        ssl = cache.get_client_ssl("./test/fixtures/basic_ca.pem",
                                    "www.google.com", Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 2);
@@ -126,10 +126,10 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache uses same SSL_CTX for equal certificate path") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
-        auto first = cache->get_client_ssl(default_cert, "www.google.com",
+        auto first = cache.get_client_ssl(default_cert, "www.google.com",
                                           Logger::global());
         REQUIRE(!!first);
-        auto second = cache->get_client_ssl(default_cert, "www.kernel.org",
+        auto second = cache.get_client_ssl(default_cert, "www.kernel.org",
                                            Logger::global());
         REQUIRE(!!second);
         REQUIRE(SSL_get_SSL_CTX(*first) == SSL_get_SSL_CTX(*second));
@@ -139,7 +139,7 @@ TEST_CASE("Cache works as expected") {
 
     SECTION("cache behaves when Context::make fails") {
         auto cache = Cache<>{};
-        auto r = cache->get_client_ssl<context_make_fail>(
+        auto r = cache.get_client_ssl<context_make_fail>(
               default_cert, "www.google.com", Logger::global());
         REQUIRE(!r);
         REQUIRE(r.as_error() == MockedError());
@@ -175,14 +175,14 @@ TEST_CASE("verify_peer works as expected") {
     Cache<> c;
 
     SECTION("when SSL_get_verify_result fails") {
-        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE(verify_peer<ssl_get_verify_result_fail>(
                       "", ssl, Logger::global()) != NoError());
         SSL_free(ssl);
     }
 
     SECTION("when SSL_get_peer_certificate fails") {
-        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_fail>(
                       "", ssl, Logger::global())) != NoError());
@@ -190,7 +190,7 @@ TEST_CASE("verify_peer works as expected") {
     }
 
     SECTION("when tls_check_name fails") {
-        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
                              tls_check_name_fail>("", ssl, Logger::global())) !=
@@ -199,7 +199,7 @@ TEST_CASE("verify_peer works as expected") {
     }
 
     SECTION("when tls_check_name does not match") {
-        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
                              tls_check_name_nomatch>(

--- a/test/net/libssl.cpp
+++ b/test/net/libssl.cpp
@@ -81,7 +81,7 @@ static ErrorOr<Var<Context>> context_make_fail(std::string, Var<Logger>) {
 TEST_CASE("Cache works as expected") {
     SECTION("different threads get different SSL_CTX") {
         auto make = []() {
-            return Cache<>::thread_local_instance().get_client_ssl(
+            return Cache<>::thread_local_instance()->get_client_ssl(
                   default_cert, "www.google.com", Logger::global());
         };
         auto first = std::async(std::launch::async, make).get();
@@ -94,12 +94,12 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache is evicted when too many SSL_CTX are created") {
         auto cache = Cache<1>{};
         REQUIRE(cache.size() == 0);
-        auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
+        auto ssl = cache->get_client_ssl(default_cert, "www.google.com",
                                         Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
-        ssl = cache.get_client_ssl("./test/fixtures/saved_ca_bundle.pem",
+        ssl = cache->get_client_ssl("./test/fixtures/saved_ca_bundle.pem",
                                    "www.google.com", Logger::global());
         REQUIRE(*ssl != nullptr);
         // Note: we expect this to be equal to one, meaning that the first
@@ -111,12 +111,12 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache works in the common case") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
-        auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
+        auto ssl = cache->get_client_ssl(default_cert, "www.google.com",
                                         Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
-        ssl = cache.get_client_ssl("./test/fixtures/basic_ca.pem",
+        ssl = cache->get_client_ssl("./test/fixtures/basic_ca.pem",
                                    "www.google.com", Logger::global());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 2);
@@ -126,10 +126,10 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache uses same SSL_CTX for equal certificate path") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
-        auto first = cache.get_client_ssl(default_cert, "www.google.com",
+        auto first = cache->get_client_ssl(default_cert, "www.google.com",
                                           Logger::global());
         REQUIRE(!!first);
-        auto second = cache.get_client_ssl(default_cert, "www.kernel.org",
+        auto second = cache->get_client_ssl(default_cert, "www.kernel.org",
                                            Logger::global());
         REQUIRE(!!second);
         REQUIRE(SSL_get_SSL_CTX(*first) == SSL_get_SSL_CTX(*second));
@@ -139,7 +139,7 @@ TEST_CASE("Cache works as expected") {
 
     SECTION("cache behaves when Context::make fails") {
         auto cache = Cache<>{};
-        auto r = cache.get_client_ssl<context_make_fail>(
+        auto r = cache->get_client_ssl<context_make_fail>(
               default_cert, "www.google.com", Logger::global());
         REQUIRE(!r);
         REQUIRE(r.as_error() == MockedError());
@@ -175,14 +175,14 @@ TEST_CASE("verify_peer works as expected") {
     Cache<> c;
 
     SECTION("when SSL_get_verify_result fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE(verify_peer<ssl_get_verify_result_fail>(
                       "", ssl, Logger::global()) != NoError());
         SSL_free(ssl);
     }
 
     SECTION("when SSL_get_peer_certificate fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_fail>(
                       "", ssl, Logger::global())) != NoError());
@@ -190,7 +190,7 @@ TEST_CASE("verify_peer works as expected") {
     }
 
     SECTION("when tls_check_name fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
                              tls_check_name_fail>("", ssl, Logger::global())) !=
@@ -199,7 +199,7 @@ TEST_CASE("verify_peer works as expected") {
     }
 
     SECTION("when tls_check_name does not match") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c->get_client_ssl(default_cert, "x.org", Logger::global());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
                              tls_check_name_nomatch>(


### PR DESCRIPTION
There is empirical evidence that MK v0.7.5 crashes on 32 bit iOS systems
because thread_local isn't working properly.

See #1397.

This diff is an attempt to fix the issue in a very light way. Basically,
retain the thread local semantic, but allocate a cache very time if
thread_local is known to misbehave.

This fix makes the code less efficient for those devices where thread_local
is not working, of course. In fact, basically, for those devices any kind of
caching is disabled.

Yet, given that this seems to affect a minority of our users, I've decided
to go for an as-simple-as-possible fix that prevents the crash.

(Also, `armv7` and `armv7s` are going to disappear anyway in the near future,
because Apple is now mostly focusing on `arm64`.)

While there I've refactored `libssl.hpp`'s cache factory to return a shared
pointer rather than a reference, in the hope that, if the shared pointer
is not initialized, this will lead to an exception and not a crash.