### PR TITLE
Fix for systems that don't support thread_local

### DIFF
--- a/build/ios/cross
+++ b/build/ios/cross
@@ -16,6 +16,9 @@ MINIOSVERSION="9.0"
 if [ "$PLATFORM" = "iphoneos" ]; then
     EXTRA_CONFIG="--host=arm-apple-darwin --target=arm-apple-darwin --disable-shared"
     MINVERSION="-miphoneos-version-min=$MINIOSVERSION"
+    if [ "$ARCH" = "armv7" -o "$ARCH" = "armv7s" ]; then
+        CPPFLAGS="-DMK_NO_THREAD_LOCAL"
+    fi
 elif [ "$ARCH" = "i386" ]; then
     EXTRA_CONFIG="--host=i386-apple-darwin --target=i386-apple-darwin --disable-shared"
     MINVERSION="-mios-simulator-version-min=$MINIOSVERSION"
@@ -36,7 +39,7 @@ DESTDIR="$ROOTDIR/tmp"
 
 export CC="$(xcrun -find -sdk ${PLATFORM} cc)"
 export CXX="$(xcrun -find -sdk ${PLATFORM} g++)"
-export CPPFLAGS="-arch ${ARCH} -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
+export CPPFLAGS="-arch ${ARCH} -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path) $CPPFLAGS"
 export CFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 export CXXFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"
 export LDFLAGS="-arch ${ARCH} $MINVERSION -isysroot $(xcrun -sdk ${PLATFORM} --show-sdk-path)"

--- a/include/private/net/libssl.hpp
+++ b/include/private/net/libssl.hpp
@@ -219,8 +219,17 @@ template <size_t max_cache_size = 64> class Cache {
     */
 
     /// Return thread local instance of the cache.
-    static Cache &thread_local_instance() {
-        static thread_local Cache instance;
+    static SharedPtr<Cache> thread_local_instance() {
+        // We have experimentally found that iOS armv7 does not support well
+        // thread_local. In such case, we allocate a new cache every time rather
+        // than using a thread local cache. We will be able to drop this fix
+        // in the moment in which support for 32-bit iOS will be dropped.
+        //
+        // See <https://github.com/measurement-kit/measurement-kit/issues/1397>.
+#ifndef MK_NO_THREAD_LOCAL
+        static thread_local
+#endif
+        SharedPtr<Cache> instance{new Cache};
         return instance;
     }
 

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -218,7 +218,7 @@ void connect(std::string address, int port,
                     cbp = settings.at("net/ca_bundle_path");
                 }
                 ErrorOr<SSL *> cssl = libssl::Cache<>::thread_local_instance()
-                    .get_client_ssl(cbp, address, logger);
+                    ->get_client_ssl(cbp, address, logger);
                 if (!cssl) {
                     Error err = cssl.as_error();
                     bufferevent_free(r->connected_bev);

--- a/src/libmeasurement_kit/ooni/utils.cpp
+++ b/src/libmeasurement_kit/ooni/utils.cpp
@@ -19,7 +19,16 @@ void resolver_lookup(Callback<Error, std::string> callback, Settings settings,
 }
 
 /* static */ SharedPtr<GeoipCache> GeoipCache::thread_local_instance() {
-    static thread_local SharedPtr<GeoipCache> singleton(new GeoipCache);
+    // We have experimentally found that iOS armv7 does not support well
+    // thread_local. In such case, we allocate a new cache every time rather
+    // than using a thread local cache. We will be able to drop this fix
+    // in the moment in which support for 32-bit iOS will be dropped.
+    //
+    // See <https://github.com/measurement-kit/measurement-kit/issues/1397>.
+#ifndef MK_NO_THREAD_LOCAL
+    static thread_local
+#endif
+    SharedPtr<GeoipCache> singleton{new GeoipCache};
     return singleton;
 }
 

--- a/test/net/libssl.cpp
+++ b/test/net/libssl.cpp
@@ -81,7 +81,7 @@ static ErrorOr<SharedPtr<Context>> context_make_fail(std::string, SharedPtr<Logg
 TEST_CASE("Cache works as expected") {
     SECTION("different threads get different SSL_CTX") {
         auto make = []() {
-            return Cache<>::thread_local_instance().get_client_ssl(
+            return Cache<>::thread_local_instance()->get_client_ssl(
                   default_cert, "www.google.com", Logger::global());
         };
         auto first = std::async(std::launch::async, make).get();


### PR DESCRIPTION
[Cherry-pick of #1402 from `stable`.]

There is empirical evidence that MK v0.7.5 crashes on 32 bit iOS systems
because thread_local isn't working properly.

See #1397.

This diff is an attempt to fix the issue in a very light way. Basically,
retain the thread local semantic, but allocate a cache very time if
thread_local is known to misbehave.

This fix makes the code less efficient for those devices where thread_local
is not working, of course. In fact, basically, for those devices any kind of
caching is disabled.

Yet, given that this seems to affect a minority of our users, I've decided
to go for an as-simple-as-possible fix that prevents the crash.

(Also, `armv7` and `armv7s` are going to disappear anyway in the near future,
because Apple is now mostly focusing on `arm64`.)

While there I've refactored `libssl.hpp`'s cache factory to return a shared
pointer rather than a reference, in the hope that, if the shared pointer
is not initialized, this will lead to an exception and not a crash.

Conflicts:
	src/libmeasurement_kit/ooni/utils.cpp