### PR TITLE
travis: improve build flags

### DIFF
--- a/build/docker/spec/valgrind-clang
+++ b/build/docker/spec/valgrind-clang
@@ -2,9 +2,10 @@
 set -e
 
 export CPP="clang -E"
+export CPPFLAGS="$CPPFLAGS -Wdate-time -D_FORTIFY_SOURCE=2"
 export CC="clang"
 export CXX="clang++"
-export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+export CXXFLAGS="-stdlib=libc++ $CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security"
 export pkg_make_check_rule="run-valgrind-docker"
 
 debian_deps="$debian_deps autoconf"

--- a/build/docker/spec/valgrind-clang
+++ b/build/docker/spec/valgrind-clang
@@ -4,8 +4,9 @@ set -e
 export CPP="clang -E"
 export CPPFLAGS="$CPPFLAGS -Wdate-time -D_FORTIFY_SOURCE=2"
 export CC="clang"
+export CFLAGS="$CFLAGS -fstack-protector-strong -Wformat -Werror=format-security -O2"
 export CXX="clang++"
-export CXXFLAGS="-stdlib=libc++ $CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security"
+export CXXFLAGS="-stdlib=libc++ $CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security -O2"
 export pkg_make_check_rule="run-valgrind-docker"
 
 debian_deps="$debian_deps autoconf"

--- a/build/docker/spec/valgrind-gcc
+++ b/build/docker/spec/valgrind-gcc
@@ -2,8 +2,10 @@
 set -e
 
 export CPP="gcc -E"
+export CPPFLAGS="$CPPFLAGS -Wdate-time -D_FORTIFY_SOURCE=2"
 export CC="gcc"
 export CXX="g++"
+export CXXFLAGS="$CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security"
 export pkg_make_check_rule="run-valgrind-docker"
 
 debian_deps="$debian_deps autoconf"

--- a/build/docker/spec/valgrind-gcc
+++ b/build/docker/spec/valgrind-gcc
@@ -4,8 +4,9 @@ set -e
 export CPP="gcc -E"
 export CPPFLAGS="$CPPFLAGS -Wdate-time -D_FORTIFY_SOURCE=2"
 export CC="gcc"
+export CFLAGS="$CFLAGS -fstack-protector-strong -Wformat -Werror=format-security -O2"
 export CXX="g++"
-export CXXFLAGS="$CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security"
+export CXXFLAGS="$CXXFLAGS -fstack-protector-strong -Wformat -Werror=format-security -O2"
 export pkg_make_check_rule="run-valgrind-docker"
 
 debian_deps="$debian_deps autoconf"


### PR DESCRIPTION
For continuous integration, let's use flags more similar to the ones used by Debian.