### PR TITLE
reactor: correctly deal with exception in child thread

### DIFF
--- a/include/measurement_kit/common/reactor.hpp
+++ b/include/measurement_kit/common/reactor.hpp
@@ -6,6 +6,7 @@
 
 #include <measurement_kit/common/callback.hpp>
 #include <measurement_kit/common/error.hpp>
+#include <measurement_kit/common/logger.hpp>
 #include <measurement_kit/common/shared_ptr.hpp>
 #include <measurement_kit/common/socket.hpp>
 
@@ -54,12 +55,13 @@ class Reactor {
     /// serve them. When there are no further callbacks to execute,
     /// background threads will exit, to save resources.
     ///
+    /// The \p logger parameter is the logger to be used.
+    ///
     /// \throw std::exception (or a derived class) if it is not
     /// possible to create a background thread or schedule the callback.
     ///
-    /// If \p cb throws an exception of type std::exception (or
-    /// derived from it), such exception is swallowed.
-    virtual void call_in_thread(Callback<> &&cb) = 0;
+    /// If \p cb throws an exception, this exception propagates.
+    virtual void call_in_thread(SharedPtr<Logger> logger, Callback<> &&cb) = 0;
 
     /// \brief `call_soon() schedules the execution of \p cb in the
     /// I/O thread as soon as possible.

--- a/include/private/common/libevent_reactor.hpp
+++ b/include/private/common/libevent_reactor.hpp
@@ -109,8 +109,8 @@ class LibeventReactor : public Reactor, public NonCopyable, public NonMovable {
 
     // ## Call later
 
-    void call_in_thread(Callback<> &&cb) override {
-        worker.call_in_thread(std::move(cb));
+    void call_in_thread(SharedPtr<Logger> logger, Callback<> &&cb) override {
+        worker.call_in_thread(logger, std::move(cb));
     }
 
     void call_soon(Callback<> &&cb) override { call_later(0.0, std::move(cb)); }

--- a/include/private/common/worker.hpp
+++ b/include/private/common/worker.hpp
@@ -31,7 +31,7 @@ class Worker {
         std::list<Callback<>> queue;
     };
 
-    void call_in_thread(Callback<> &&func);
+    void call_in_thread(SharedPtr<Logger> logger, Callback<> &&func);
 
     unsigned short parallelism() const;
 

--- a/include/private/dns/getaddrinfo_async.hpp
+++ b/include/private/dns/getaddrinfo_async.hpp
@@ -93,8 +93,7 @@ void getaddrinfo_async(std::string name, addrinfo hints, SharedPtr<Reactor> reac
      */
     reactor->call_in_thread(logger, [
         name = std::move(name), hints = std::move(hints),
-        reactor = std::move(reactor), logger = std::move(logger),
-        cb = std::move(cb)
+        reactor, logger, cb = std::move(cb)
     ]() {
         addrinfo *rp = nullptr;
         Error error = getaddrinfo_async_map_error(

--- a/include/private/dns/getaddrinfo_async.hpp
+++ b/include/private/dns/getaddrinfo_async.hpp
@@ -91,7 +91,7 @@ void getaddrinfo_async(std::string name, addrinfo hints, SharedPtr<Reactor> reac
      * Move everything down such that there is always just one function in
      * one specific thread having ownership of the state
      */
-    reactor->call_in_thread([
+    reactor->call_in_thread(logger, [
         name = std::move(name), hints = std::move(hints),
         reactor = std::move(reactor), logger = std::move(logger),
         cb = std::move(cb)

--- a/src/libmeasurement_kit/common/worker.cpp
+++ b/src/libmeasurement_kit/common/worker.cpp
@@ -20,7 +20,7 @@
 
 namespace mk {
 
-void Worker::call_in_thread(Callback<> &&func) {
+void Worker::call_in_thread(SharedPtr<Logger> logger, Callback<> &&func) {
     std::unique_lock<std::mutex> _{state->mutex};
 
     // Move function such that the running-in-background thread
@@ -33,7 +33,7 @@ void Worker::call_in_thread(Callback<> &&func) {
 
     // Note: pass only the internal state, so that the thread can possibly
     // continue to work even when the external object is gone.
-    auto task = [S = state]() {
+    auto task = [S = state, logger]() {
         for (;;) {
             Callback<> func = [&]() {
                 std::unique_lock<std::mutex> _{S->mutex};
@@ -50,10 +50,17 @@ void Worker::call_in_thread(Callback<> &&func) {
             if (!func) {
                 break;
             }
+            // Exceptions are fatal in measurement-kit. If we get an unhandled
+            // one here is a bug that must be fixed. Make sure it is logged
+            // using the current logger and bail.
             try {
                 func();
+            } catch (const std::exception &exc) {
+                logger->warn("worker: unhandled exception: %s", exc.what());
+                std::rethrow_exception(std::current_exception());
             } catch (...) {
-                mk::warn("worker thread: unhandled exception");
+                logger->warn("worker: unhandled unknown exception");
+                std::rethrow_exception(std::current_exception());
             }
         }
     };

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -120,7 +120,7 @@ static void start_internal_(SharedPtr<Runnable> &&r, std::promise<void> *promise
     //    while the callback allows to make it asynchronous.
     assert(!r->reactor);
     Worker::default_tasks_queue()->call_in_thread(r->logger,
-          [ r = std::move(r), promise, callback = std::move(callback) ] {
+          [ r, promise, callback = std::move(callback) ] {
               r->reactor = Reactor::make();
               r->reactor->run_with_initial_event([&]() {
                   r->begin([&](Error) {

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -119,7 +119,7 @@ static void start_internal_(SharedPtr<Runnable> &&r, std::promise<void> *promise
     // 5. the `promise`, if present, allows to make the test synchronous,
     //    while the callback allows to make it asynchronous.
     assert(!r->reactor);
-    Worker::default_tasks_queue()->call_in_thread(
+    Worker::default_tasks_queue()->call_in_thread(r->logger,
           [ r = std::move(r), promise, callback = std::move(callback) ] {
               r->reactor = Reactor::make();
               r->reactor->run_with_initial_event([&]() {

--- a/src/libmeasurement_kit/ooni/orchestrate.cpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.cpp
@@ -161,7 +161,7 @@ void Client::register_probe(std::string &&password,
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread([
+    Worker::default_tasks_queue()->call_in_thread(Logger::global(), [
         password = std::move(password), meta = *this, cb = std::move(cb)
     ]() mutable {
         SharedPtr<Reactor> reactor = Reactor::make();
@@ -182,7 +182,7 @@ void Client::find_location(
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread(
+    Worker::default_tasks_queue()->call_in_thread(Logger::global(),
           [ meta = *this, cb = std::move(cb) ]() {
               SharedPtr<Reactor> reactor = Reactor::make();
               reactor->run_with_initial_event([&]() {
@@ -203,7 +203,7 @@ void Client::update(Auth &&auth, Callback<Error &&, Auth &&> &&cb) const {
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread([
+    Worker::default_tasks_queue()->call_in_thread(Logger::global(), [
         meta = *this, cb = std::move(cb), auth = std::move(auth)
     ]() mutable {
         SharedPtr<Reactor> reactor = Reactor::make();

--- a/test/common/worker.cpp
+++ b/test/common/worker.cpp
@@ -17,7 +17,7 @@
 TEST_CASE("The worker is robust to submitting many tasks in a row") {
     auto worker = mk::SharedPtr<mk::Worker>::make();
     for (auto _: mk::range<int>(128)) {
-        worker->call_in_thread([]() {
+        worker->call_in_thread(mk::Logger::global(), []() {
             using namespace std::chrono_literals;
             std::this_thread::sleep_for(2s);
         });


### PR DESCRIPTION
<strike>Depends on #1446.</strike>

Closes #1387.

Required for v0.8.0-beta.