### PR TITLE
nettests: prepare for API v1.0.0

### DIFF
--- a/include/measurement_kit/nettests/nettests.hpp
+++ b/include/measurement_kit/nettests/nettests.hpp
@@ -4,57 +4,68 @@
 #ifndef MEASUREMENT_KIT_NETTESTS_NETTESTS_HPP
 #define MEASUREMENT_KIT_NETTESTS_NETTESTS_HPP
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <functional>
+#include <measurement_kit/common/settings.hpp>
+#include <measurement_kit/common/lexical_cast.hpp>
+#include <measurement_kit/common/shared_ptr.hpp>
 #include <string>
 
-#include <measurement_kit/common/callback.hpp>
-#include <measurement_kit/common/lexical_cast.hpp>
-#include <measurement_kit/common/settings.hpp>
-#include <measurement_kit/common/shared_ptr.hpp>
-
 namespace mk {
-
 namespace nettests {
 class Runnable;
 
 class BaseTest {
   public:
-    BaseTest &on_logger_eof(Callback<>);
-    BaseTest &on_log(Callback<uint32_t, const char *>);
-    BaseTest &on_event(Callback<const char *>);
-    BaseTest &on_progress(Callback<double, const char *>);
-    BaseTest &set_verbosity(uint32_t);
-    BaseTest &increase_verbosity();
-
     BaseTest();
+
     virtual ~BaseTest();
 
     BaseTest &add_input(std::string);
+
     BaseTest &add_input_filepath(std::string);
+
     BaseTest &set_input_filepath(std::string);
+
     BaseTest &set_output_filepath(std::string);
+
     BaseTest &set_error_filepath(std::string);
+
+    BaseTest &on_logger_eof(std::function<void()> &&);
+
+    BaseTest &on_log(std::function<void(uint32_t, const char *)> &&);
+
+    BaseTest &on_event(std::function<void(const char *)> &&);
+
+    BaseTest &on_progress(std::function<void(double, const char *)> &&);
+
+    BaseTest &set_verbosity(uint32_t);
+
+    BaseTest &increase_verbosity();
 
     template <typename T,
               typename = typename std::enable_if<
                     !std::is_same<std::string, T>::value>::type>
     BaseTest &set_options(std::string key, T value) {
-        return set_options(key, lexical_cast<std::string>(value));
+        return set_options(key, mk::lexical_cast<std::string>(value));
     }
 
     BaseTest &set_options(std::string key, std::string value);
 
-    BaseTest &on_entry(Callback<std::string>);
-    BaseTest &on_begin(Callback<>);
-    BaseTest &on_end(Callback<> cb);
-    BaseTest &on_destroy(Callback<> cb);
+    BaseTest &on_entry(std::function<void(std::string)> &&);
+
+    BaseTest &on_begin(std::function<void()> &&);
+
+    BaseTest &on_end(std::function<void()> &&);
+
+    BaseTest &on_destroy(std::function<void()> &&);
 
     void run();
-    void start(Callback<> func);
+
+    void start(std::function<void()> &&);
 
     SharedPtr<Runnable> runnable;
+
     Settings settings;
 };
 

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -13,22 +13,22 @@
 namespace mk {
 namespace nettests {
 
-BaseTest &BaseTest::on_logger_eof(Callback<> func) {
+BaseTest &BaseTest::on_logger_eof(Callback<> &&func) {
     runnable->logger->on_eof(std::move(func));
     return *this;
 }
 
-BaseTest &BaseTest::on_log(Callback<uint32_t, const char *> func) {
+BaseTest &BaseTest::on_log(Callback<uint32_t, const char *> &&func) {
     runnable->logger->on_log(std::move(func));
     return *this;
 }
 
-BaseTest &BaseTest::on_event(Callback<const char *> func) {
+BaseTest &BaseTest::on_event(Callback<const char *> &&func) {
     runnable->logger->on_event(std::move(func));
     return *this;
 }
 
-BaseTest &BaseTest::on_progress(Callback<double, const char *> func) {
+BaseTest &BaseTest::on_progress(Callback<double, const char *> &&func) {
     runnable->logger->on_progress(std::move(func));
     return *this;
 }
@@ -79,22 +79,22 @@ BaseTest &BaseTest::set_options(std::string key, std::string value) {
     return *this;
 }
 
-BaseTest &BaseTest::on_entry(Callback<std::string> cb) {
+BaseTest &BaseTest::on_entry(Callback<std::string> &&cb) {
     runnable->entry_cb = cb;
     return *this;
 }
 
-BaseTest &BaseTest::on_begin(Callback<> cb) {
+BaseTest &BaseTest::on_begin(Callback<> &&cb) {
     runnable->begin_cb = cb;
     return *this;
 }
 
-BaseTest &BaseTest::on_end(Callback<> cb) {
+BaseTest &BaseTest::on_end(Callback<> &&cb) {
     runnable->end_cbs.push_back(cb);
     return *this;
 }
 
-BaseTest &BaseTest::on_destroy(Callback<> cb) {
+BaseTest &BaseTest::on_destroy(Callback<> &&cb) {
     runnable->destroy_cbs.push_back(cb);
     return *this;
 }
@@ -148,7 +148,7 @@ void BaseTest::run() {
 
 }
 
-void BaseTest::start(Callback<> callback) {
+void BaseTest::start(Callback<> &&callback) {
     // Note: using `std::move` to invalidate the `runnable` such that it is
     // not possible to start another test from the same object.
     start_internal_(std::move(runnable), nullptr, std::move(callback));


### PR DESCRIPTION
- make sure we move in all callbacks

- use std::function and not mk::Callback (more standard components
  hence less cognitive overhead)

- reorder the methods a bit

- trim includes