### PR TITLE
feature(raw_ptr): smart pointer for raw C pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@
 /test/common/maybe
 /test/common/parallel
 /test/common/range
+/test/common/raw_ptr
 /test/common/settings
 /test/common/shared_ptr
 /test/common/utils

--- a/include/measurement_kit/common/raw_ptr.hpp
+++ b/include/measurement_kit/common/raw_ptr.hpp
@@ -13,8 +13,9 @@ namespace mk {
 // # RawPtr
 //
 // RawPtr is a template class depending on a Type and on a TypeDeleter that
-// is used to provide RAII semantics for raw pointers. We will only invoke the
-// type deleter when the underlying pointer is not null.
+// is used to provide RAII semantics for raw pointers. By default the deleter
+// is `std::default_delete<Type>`, hence note that the deleter must be able
+// to delete a `nullptr` pointer without crashing.
 //
 // In designing this class, we have used the same method names of existing
 // libc++ smart pointers to provide the least surprise. However:

--- a/include/measurement_kit/common/raw_ptr.hpp
+++ b/include/measurement_kit/common/raw_ptr.hpp
@@ -1,0 +1,78 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+#ifndef MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
+#define MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
+
+#include <measurement_kit/common/non_copyable.hpp>
+#include <measurement_kit/common/non_movable.hpp>
+#include <stdexcept>
+#include <type_traits>
+
+namespace mk {
+
+// # RawPtr
+//
+// RawPtr is a template class depending on a Type and on a TypeDeleter that
+// is used to provide RAII semantics for raw pointers. We will only invoke the
+// type deleter when the underlying pointer is not null.
+//
+// In designing this class, we have used the same method names of existing
+// libc++ smart pointers to provide the least surprise. However:
+//
+// 1. We have added a method to automatically cast the content of this class
+//    to the underlying pointer to make the code easier to migrate.
+//
+// This class is NonCopyable and NonMovable because it manages a C pointer. It
+// should be wrapped in some other class that is movable or copyable through the
+// usage of smart pointers.
+template <typename Type, typename TypeDeleter>
+class RawPtr : public NonCopyable, public NonMovable {
+  public:
+    // The get() method returns the underlying pointer, if that is not null, or
+    // throws an exception otherwise. This provides the guarantee that we are
+    // not going to access a null pointer after some bad refactoring.
+    typename std::add_pointer<Type>::type get() const {
+        if (ptr_ == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
+        return ptr_;
+    }
+
+    // The cast-to-pointer-type operator is syntactic sugar for get().
+    operator typename std::add_pointer<Type>::type() const { return get(); }
+
+    // The release() method returns the underlying pointer and replaces the
+    // underlying pointer with nullptr. This is the way to extract the pointer
+    // from this wrapper without having the TypeDeleter invoked.
+    typename std::add_pointer<Type>::type release() {
+        typename std::add_pointer<Type>::type p = nullptr;
+        std::swap(ptr_, p);
+        return p;
+    }
+
+    // The reset() method will call the type deleter for the underlying pointer
+    // if such pointer is not null, and then will replace the underlying
+    // pointer with the provided parameter.
+    void reset(typename std::add_pointer<Type>::type p = nullptr) {
+        if (ptr_ != nullptr) {
+            TypeDeleter{}(ptr_);
+        }
+        ptr_ = p;
+    }
+
+    // The constructor with pointer takes ownership of the pointer argument.
+    RawPtr(typename std::add_pointer<Type>::type p) { ptr_ = p; }
+
+    // The default constructor constructs an empty pointer.
+    RawPtr() {}
+
+    // The destructor calls reset(nullptr) to invoke the TypeDeleter.
+    ~RawPtr() { reset(nullptr); }
+
+  private:
+    typename std::add_pointer<Type>::type ptr_ = nullptr;
+};
+
+} // namespace mk
+#endif

--- a/include/measurement_kit/common/raw_ptr.hpp
+++ b/include/measurement_kit/common/raw_ptr.hpp
@@ -4,10 +4,9 @@
 #ifndef MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
 #define MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
 
-#include <measurement_kit/common/non_copyable.hpp>
-#include <measurement_kit/common/non_movable.hpp>
-#include <stdexcept>
-#include <type_traits>
+#include <memory>      // for std::unique_ptr
+#include <stdexcept>   // for std::runtime_error
+#include <type_traits> // for std::add_pointer_type
 
 namespace mk {
 
@@ -23,20 +22,21 @@ namespace mk {
 // 1. We have added a method to automatically cast the content of this class
 //    to the underlying pointer to make the code easier to migrate.
 //
-// This class is NonCopyable and NonMovable because it manages a C pointer. It
-// should be wrapped in some other class that is movable or copyable through the
-// usage of smart pointers.
-template <typename Type, typename TypeDeleter>
-class RawPtr : public NonCopyable, public NonMovable {
+// This class is implemented using std::unique_ptr as the underlying smart
+// pointer type. This is becaused such smart pointer was the more similar one
+// to the interface we wanted to implement. As a result, this makes code
+// using this template class non-copyable but movable.
+template <typename Type, typename TypeDeleter = std::default_delete<Type>>
+class RawPtr {
   public:
     // The get() method returns the underlying pointer, if that is not null, or
     // throws an exception otherwise. This provides the guarantee that we are
     // not going to access a null pointer after some bad refactoring.
     typename std::add_pointer<Type>::type get() const {
-        if (ptr_ == nullptr) {
+        if (ptr_.get() == nullptr) {
             throw std::runtime_error("null pointer");
         }
-        return ptr_;
+        return ptr_.get();
     }
 
     // The cast-to-pointer-type operator is syntactic sugar for get().
@@ -45,33 +45,23 @@ class RawPtr : public NonCopyable, public NonMovable {
     // The release() method returns the underlying pointer and replaces the
     // underlying pointer with nullptr. This is the way to extract the pointer
     // from this wrapper without having the TypeDeleter invoked.
-    typename std::add_pointer<Type>::type release() {
-        typename std::add_pointer<Type>::type p = nullptr;
-        std::swap(ptr_, p);
-        return p;
-    }
+    typename std::add_pointer<Type>::type release() { return ptr_.release(); }
 
     // The reset() method will call the type deleter for the underlying pointer
     // if such pointer is not null, and then will replace the underlying
-    // pointer with the provided parameter.
+    // pointer with the `p` pointer parameter.
     void reset(typename std::add_pointer<Type>::type p = nullptr) {
-        if (ptr_ != nullptr) {
-            TypeDeleter{}(ptr_);
-        }
-        ptr_ = p;
+        ptr_.reset(p);
     }
 
     // The constructor with pointer takes ownership of the pointer argument.
-    RawPtr(typename std::add_pointer<Type>::type p) { ptr_ = p; }
+    RawPtr(typename std::add_pointer<Type>::type p) : ptr_{p} {}
 
     // The default constructor constructs an empty pointer.
     RawPtr() {}
 
-    // The destructor calls reset(nullptr) to invoke the TypeDeleter.
-    ~RawPtr() { reset(nullptr); }
-
   private:
-    typename std::add_pointer<Type>::type ptr_ = nullptr;
+    std::unique_ptr<Type, TypeDeleter> ptr_;
 };
 
 } // namespace mk

--- a/include/private/common/libevent_reactor.hpp
+++ b/include/private/common/libevent_reactor.hpp
@@ -17,6 +17,8 @@
 #include <measurement_kit/common/callback.hpp>     // for mk::Callback
 #include <measurement_kit/common/error.hpp>        // for mk::Error
 #include <measurement_kit/common/logger.hpp>       // for mk::warn
+#include <measurement_kit/common/non_copyable.hpp> // for mk::NonCopyable
+#include <measurement_kit/common/non_movable.hpp>  // for mk::NonMovable
 #include <measurement_kit/common/raw_ptr.hpp>      // for mk::RawPtr
 #include <measurement_kit/common/reactor.hpp>      // for mk::Reactor
 #include <measurement_kit/common/socket.hpp>       // for mk::socket_t

--- a/include/private/common/libevent_reactor.hpp
+++ b/include/private/common/libevent_reactor.hpp
@@ -40,10 +40,16 @@ class EventBaseDeleter {
     }
 };
 
-// mk::Reactor implementation using libevent.
+// LibeventReactor is an mk::Reactor implementation using libevent.
+//
+// The current implementation as of 2017-11-01 does not need to be explicitly
+// non-copyable and non-movable. But, given that in the future we will need
+// probably to pass `this` to some libevent functions, and that anyway it is
+// always used as mk::SharedPtr<mk::Reactor>, it seems more robust to keep it
+// explicitly non-copyable and non-movable.
 template <MK_MOCK(event_base_new), MK_MOCK(event_base_once),
         MK_MOCK(event_base_dispatch), MK_MOCK(event_base_loopbreak)>
-class LibeventReactor : public Reactor {
+class LibeventReactor : public Reactor, public NonCopyable, public NonMovable {
   public:
     // ## Initialization
 

--- a/test/common/libevent_reactor.cpp
+++ b/test/common/libevent_reactor.cpp
@@ -48,29 +48,26 @@ static int event_base_loopbreak_fail(event_base *) { return -1; }
 TEST_CASE("Reactor: basic functionality") {
     SECTION("We deal with event_base_new() failure") {
         REQUIRE_THROWS((LibeventReactor<event_base_new_fail, event_base_once,
-                event_base_dispatch, event_base_loopbreak, event_new,
-                event_add>{}));
+                event_base_dispatch, event_base_loopbreak>{}));
     }
 
     SECTION("We deal with event_base_dispatch() failure") {
         LibeventReactor<event_base_new, event_base_once,
-                event_base_dispatch_fail, event_base_loopbreak, event_new,
-                event_add>
+                event_base_dispatch_fail, event_base_loopbreak>
                 reactor;
         REQUIRE_THROWS(reactor.run());
     }
 
     SECTION("We deal with event_base_dispatch() running out of events") {
         LibeventReactor<event_base_new, event_base_once,
-                event_base_dispatch_no_events, event_base_loopbreak, event_new,
-                event_add>
+                event_base_dispatch_no_events, event_base_loopbreak>
                 reactor;
         reactor.run();
     }
 
     SECTION("We deal with event_base_loopbreak() failure") {
         LibeventReactor<event_base_new, event_base_once, event_base_dispatch,
-                event_base_loopbreak_fail, event_new, event_add>
+                event_base_loopbreak_fail>
                 reactor;
         REQUIRE_THROWS(reactor.stop());
     }

--- a/test/common/raw_ptr.cpp
+++ b/test/common/raw_ptr.cpp
@@ -1,0 +1,37 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#define CATCH_CONFIG_MAIN
+#include "private/ext/catch.hpp"
+
+#include <measurement_kit/common.hpp>
+
+using namespace mk;
+
+struct Foobar {
+    int foo = 17;
+    double bar = 3.14;
+};
+
+TEST_CASE("The get() method throws if the underlying pointer is null") {
+    RawPtr<Foobar> ptr;
+    REQUIRE_THROWS(ptr.get());
+}
+
+TEST_CASE("The cast operator throws if the underlying pointer is null") {
+    RawPtr<Foobar> ptr;
+    REQUIRE_THROWS((Foobar *)ptr);
+}
+
+TEST_CASE("The release method does not call the destructor") {
+    RawPtr<Foobar> ptr{new Foobar};
+    delete ptr.release();
+    // Valgrind will tell us if we double free
+}
+
+TEST_CASE("The reset method does call the destructor") {
+    RawPtr<Foobar> ptr{new Foobar};
+    ptr.reset(new Foobar);
+    // Valgrind will tell us if we leak
+}


### PR DESCRIPTION
Makes the management of the lifecycle of raw C pointers much
more structured than it's currently.

The plan is to use it to make more easy and yet robust to
change the underlying bufferevent used by Transport.