### PR TITLE
Rename raw_ptr as unique_ptr

### DIFF
--- a/include/measurement_kit/common/unique_ptr.hpp
+++ b/include/measurement_kit/common/unique_ptr.hpp
@@ -1,8 +1,8 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
-#ifndef MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
-#define MEASUREMENT_KIT_COMMON_RAW_PTR_HPP
+#ifndef MEASUREMENT_KIT_COMMON_UNIQUE_PTR_HPP
+#define MEASUREMENT_KIT_COMMON_UNIQUE_PTR_HPP
 
 #include <memory>      // for std::unique_ptr
 #include <stdexcept>   // for std::runtime_error
@@ -10,25 +10,12 @@
 
 namespace mk {
 
-// # RawPtr
+// # UniquePtr
 //
-// RawPtr is a template class depending on a Type and on a TypeDeleter that
-// is used to provide RAII semantics for raw pointers. By default the deleter
-// is `std::default_delete<Type>`, hence note that the deleter must be able
-// to delete a `nullptr` pointer without crashing.
-//
-// In designing this class, we have used the same method names of existing
-// libc++ smart pointers to provide the least surprise. However:
-//
-// 1. We have added a method to automatically cast the content of this class
-//    to the underlying pointer to make the code easier to migrate.
-//
-// This class is implemented using std::unique_ptr as the underlying smart
-// pointer type. This is becaused such smart pointer was the more similar one
-// to the interface we wanted to implement. As a result, this makes code
-// using this template class non-copyable but movable.
+// UniquePtr is a wrapper for `std::unique_ptr` where accessing a null
+// pointer will throw a `std::runtime_error` exception.
 template <typename Type, typename TypeDeleter = std::default_delete<Type>>
-class RawPtr {
+class UniquePtr {
   public:
     // The get() method returns the underlying pointer, if that is not null, or
     // throws an exception otherwise. This provides the guarantee that we are
@@ -39,9 +26,6 @@ class RawPtr {
         }
         return ptr_.get();
     }
-
-    // The cast-to-pointer-type operator is syntactic sugar for get().
-    operator typename std::add_pointer<Type>::type() const { return get(); }
 
     // The release() method returns the underlying pointer and replaces the
     // underlying pointer with nullptr. This is the way to extract the pointer
@@ -56,10 +40,10 @@ class RawPtr {
     }
 
     // The constructor with pointer takes ownership of the pointer argument.
-    RawPtr(typename std::add_pointer<Type>::type p) : ptr_{p} {}
+    UniquePtr(typename std::add_pointer<Type>::type p) : ptr_{p} {}
 
     // The default constructor constructs an empty pointer.
-    RawPtr() {}
+    UniquePtr() {}
 
   private:
     std::unique_ptr<Type, TypeDeleter> ptr_;

--- a/test/common/unique_ptr.cpp
+++ b/test/common/unique_ptr.cpp
@@ -15,23 +15,18 @@ struct Foobar {
 };
 
 TEST_CASE("The get() method throws if the underlying pointer is null") {
-    RawPtr<Foobar> ptr;
+    UniquePtr<Foobar> ptr;
     REQUIRE_THROWS(ptr.get());
 }
 
-TEST_CASE("The cast operator throws if the underlying pointer is null") {
-    RawPtr<Foobar> ptr;
-    REQUIRE_THROWS((Foobar *)ptr);
-}
-
 TEST_CASE("The release method does not call the destructor") {
-    RawPtr<Foobar> ptr{new Foobar};
+    UniquePtr<Foobar> ptr{new Foobar};
     delete ptr.release();
     // Valgrind will tell us if we double free
 }
 
 TEST_CASE("The reset method does call the destructor") {
-    RawPtr<Foobar> ptr{new Foobar};
+    UniquePtr<Foobar> ptr{new Foobar};
     ptr.reset(new Foobar);
     // Valgrind will tell us if we leak
 }


### PR DESCRIPTION
After reading excerpts of book on C++ recommended by @hellais, I did
convince myself that it's better not to implicitly cast a smart pointer
to its underlying pointer type, but it's better to have an explicit
method, as `get()` for doing that.

After this change, RawPtr now really looks like a wrapper for a unique
pointer, hence just rename it for clarity and propagate changes.