### PR TITLE
worker: use parallelism 1 in default queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,9 @@
 /test/common/maybe
 /test/common/parallel
 /test/common/range
-/test/common/raw_ptr
 /test/common/settings
 /test/common/shared_ptr
+/test/common/unique_ptr
 /test/common/utils
 /test/common/version
 /test/common/worker

--- a/include/private/common/libevent_reactor.hpp
+++ b/include/private/common/libevent_reactor.hpp
@@ -113,7 +113,6 @@ class LibeventReactor : public Reactor, public NonCopyable, public NonMovable {
                 I have coded more broad checks for robustness.
             */
             if (ev_status > 0 && worker.concurrency() <= 0) {
-                mk::warn("reactor: no pending and/or active events");
                 break;
             }
             call_later(0.250, []() {});

--- a/include/private/common/worker.hpp
+++ b/include/private/common/worker.hpp
@@ -31,6 +31,10 @@ class Worker {
         std::list<Callback<>> queue;
     };
 
+    Worker();
+
+    Worker(size_t parallelism);
+
     void call_in_thread(SharedPtr<Logger> logger, Callback<> &&func);
 
     unsigned short parallelism() const;

--- a/src/libmeasurement_kit/common/worker.cpp
+++ b/src/libmeasurement_kit/common/worker.cpp
@@ -20,6 +20,10 @@
 
 namespace mk {
 
+Worker::Worker() {}
+
+Worker::Worker(size_t p) { state->parallelism = p; }
+
 void Worker::call_in_thread(SharedPtr<Logger> logger, Callback<> &&func) {
     std::unique_lock<std::mutex> _{state->mutex};
 
@@ -92,7 +96,7 @@ void Worker::wait_empty_() const {
 }
 
 /*static*/ SharedPtr<Worker> Worker::default_tasks_queue() {
-    static SharedPtr<Worker> worker = SharedPtr<Worker>::make();
+    static SharedPtr<Worker> worker = SharedPtr<Worker>::make(1);
     return worker;
 }
 


### PR DESCRIPTION
Closes #1434.

While there, make the reactor less noisy when it exits.