### PR TITLE
dash: include congestion signals into result

### DIFF
--- a/include/private/neubot/dash_impl.hpp
+++ b/include/private/neubot/dash_impl.hpp
@@ -492,7 +492,18 @@ void collect_(SharedPtr<net::Transport> txp, SharedPtr<report::Entry> entry,
                             res->body.c_str());
               error = json_process(
                     res->body, [&](Json &json) {
+                        // Store the Web100/tcp_info data from the sender.
                         (*entry)["sender_data"] = json;
+                        // Put the number of congestion signals seen into the
+                        // simple key. This metric is useful when running with
+                        // CBR, to assess whether there was congestion.
+                        (*entry)["simple"]["congestion_signals"] = nullptr;
+                        auto sds = (*entry)["sender_data"].size();
+                        if (sds >= 1) {
+                            (*entry)["simple"]["congestion_signals"] =
+                                    (*entry)["sender_data"][sds - 1][
+                                            "web100_snap"]["CongestionSignals"];
+                        }
                     });
               cb(error);
           },

--- a/src/measurement_kit/cmd/dash.cpp
+++ b/src/measurement_kit/cmd/dash.cpp
@@ -46,9 +46,11 @@ int main(std::list<Callback<BaseTest &>> &initializers, int argc, char **argv) {
               double median_bitrate = simple["median_bitrate"];
               double min_playout_delay = simple["min_playout_delay"];
               double connect_latency = simple["connect_latency"];
+              unsigned long congestion_signals = simple["congestion_signals"];
               printf("Connect latency: %.2f ms\n", 1000.0 * connect_latency);
               printf("Median bitrate: %.2f kbit/s\n", median_bitrate);
-              printf("Min. playout delay: %.3f s\n", min_playout_delay);
+              printf("Minimum playout delay: %.3f s\n", min_playout_delay);
+              printf("Congestion signals: %ld\n", congestion_signals);
               printf("\n");
               fflush(stdout);
           })


### PR DESCRIPTION
An interesting question when doing streaming like stuff is whether we're generating congestion (i.e. whether we are pushing the envelope) or not. Interestingly, in my current location (D.C.; Comcast) I don't see any congestion.