### PR TITLE
fix(aaa_base): make it a C header

### DIFF
--- a/include/measurement_kit/common/aaa_base.h
+++ b/include/measurement_kit/common/aaa_base.h
@@ -1,16 +1,19 @@
 // Part of measurement-kit <https://measurement-kit.github.io/>.
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
-#ifndef MEASUREMENT_KIT_COMMON_AAA_BASE_HPP
-#define MEASUREMENT_KIT_COMMON_AAA_BASE_HPP
+#ifndef MEASUREMENT_KIT_COMMON_AAA_BASE_H
+#define MEASUREMENT_KIT_COMMON_AAA_BASE_H
 
-/// This header file contains portability definitions and headers.
+/// This header file contains portability definitions and headers. You
+/// should not include portability headers directly, rather include this
+/// file in your portable C/C++ code.
 
 #include <measurement_kit/common/portable/sys/types.h>
 
 #include <measurement_kit/common/portable/netinet/in.h>
 #include <measurement_kit/common/portable/netinet/tcp.h>
 #include <measurement_kit/common/portable/arpa/inet.h>
+#include <measurement_kit/common/portable/arpa/nameser.h>
 #include <measurement_kit/common/portable/sys/socket.h>
 #include <measurement_kit/common/portable/sys/time.h>
 #include <measurement_kit/common/portable/netdb.h>
@@ -20,8 +23,5 @@
 // Note: standard headers with non-standard additions
 #include <measurement_kit/common/portable/stdlib.h>
 #include <measurement_kit/common/portable/time.h>
-
-// Include ciso646 to make sure we have `and`, `or`, etc
-#include <ciso646>
 
 #endif

--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -5,7 +5,7 @@
 #define MEASUREMENT_KIT_COMMON_LOGGER_HPP
 
 #include <cstdint>
-#include <measurement_kit/common/aaa_base.hpp>
+#include <measurement_kit/common/aaa_base.h>
 #include <measurement_kit/common/callback.hpp>
 #include <measurement_kit/common/shared_ptr.hpp>
 #include <stdarg.h>

--- a/include/measurement_kit/common/socket.hpp
+++ b/include/measurement_kit/common/socket.hpp
@@ -4,7 +4,7 @@
 #ifndef MEASUREMENT_KIT_COMMON_SOCKET_HPP
 #define MEASUREMENT_KIT_COMMON_SOCKET_HPP
 
-#include <measurement_kit/common/aaa_base.hpp>
+#include <measurement_kit/common/aaa_base.h>
 
 namespace mk {
 

--- a/include/private/dns/utils.hpp
+++ b/include/private/dns/utils.hpp
@@ -4,7 +4,7 @@
 #ifndef PRIVATE_DNS_UTILS_HPP
 #define PRIVATE_DNS_UTILS_HPP
 
-#include <measurement_kit/common/portable/arpa/nameser.h>
+#include <measurement_kit/common/aaa_base.h>
 #include <measurement_kit/common/data_usage.hpp>
 #include <measurement_kit/dns.hpp>
 

--- a/include/private/ext/tls_internal.h
+++ b/include/private/ext/tls_internal.h
@@ -5,7 +5,7 @@
 #ifndef PRIVATE_EXT_TLS_INTERNAL_H
 #define PRIVATE_EXT_TLS_INTERNAL_H
 
-#include <measurement_kit/common/portable/netinet/in.h>
+#include <measurement_kit/common/aaa_base.h>
 #include <openssl/x509.h>
 
 struct tls {

--- a/include/private/libevent/connection.hpp
+++ b/include/private/libevent/connection.hpp
@@ -24,7 +24,7 @@
 #include <measurement_kit/net/error.hpp>
 #include <measurement_kit/net/transport.hpp>
 #include <measurement_kit/net/utils.hpp>
-#include <measurement_kit/common/portable/sys/socket.h>
+#include <measurement_kit/common/aaa_base.h>
 #include <new>
 #include <openssl/err.h>
 #include <ostream>

--- a/src/libmeasurement_kit/common/citrus_utf8.c
+++ b/src/libmeasurement_kit/common/citrus_utf8.c
@@ -30,7 +30,7 @@
  * SUCH DAMAGE.
  */
 
-#include <measurement_kit/common/portable/sys/types.h>
+#include <measurement_kit/common/aaa_base.h>
 
 #include <errno.h>
 #include <string.h>

--- a/src/libmeasurement_kit/common/logger.cpp
+++ b/src/libmeasurement_kit/common/logger.cpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <fstream>
 #include <list>
-#include <measurement_kit/common/aaa_base.hpp>
+#include <measurement_kit/common/aaa_base.h>
 #include <measurement_kit/common/callback.hpp>
 #include "private/common/delegate.hpp"
 #include "private/common/locked.hpp"

--- a/src/libmeasurement_kit/ext/tls_verify.c
+++ b/src/libmeasurement_kit/ext/tls_verify.c
@@ -21,10 +21,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <measurement_kit/common/portable/sys/socket.h>
-
-#include <measurement_kit/common/portable/arpa/inet.h>
-#include <measurement_kit/common/portable/netinet/in.h>
+#include <measurement_kit/common/aaa_base.h>
 
 #include <string.h>
 

--- a/src/libmeasurement_kit/ooni/whatsapp.cpp
+++ b/src/libmeasurement_kit/ooni/whatsapp.cpp
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <measurement_kit/net/utils.hpp>
 #include <measurement_kit/ooni.hpp>
-#include <measurement_kit/common/portable/sys/socket.h>
 
 namespace mk {
 namespace ooni {

--- a/src/libmeasurement_kit/portable/strtonum.c
+++ b/src/libmeasurement_kit/portable/strtonum.c
@@ -20,7 +20,7 @@
 #include <errno.h>
 #include <limits.h>
 
-#include <measurement_kit/common/portable/stdlib.h>
+#include <measurement_kit/common/aaa_base.h>
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"


### PR DESCRIPTION
Avoids importing specific portable headers manually.

Allows for further simplifications.

Will deal with the ciso646 fallback on Windows.