### PR TITLE
HTTP Host and TLS SNI fragmentation/stuttering/fuzzing test

### DIFF
--- a/include/measurement_kit/nettests/nettests.hpp
+++ b/include/measurement_kit/nettests/nettests.hpp
@@ -90,6 +90,7 @@ class BaseTest {
     }
 
 MK_DECLARE_TEST(DashTest);
+MK_DECLARE_TEST(DpiFragmentTest);
 MK_DECLARE_TEST(CaptivePortalTest);
 MK_DECLARE_TEST(DnsInjectionTest);
 MK_DECLARE_TEST(FacebookMessengerTest);

--- a/include/measurement_kit/ooni/nettests.hpp
+++ b/include/measurement_kit/ooni/nettests.hpp
@@ -13,6 +13,10 @@ void captiveportal(std::string, Settings, Callback<SharedPtr<report::Entry>>,
                     SharedPtr<Reactor> = Reactor::global(),
                     SharedPtr<Logger> = Logger::global());
 
+void dpi_fragment(Settings, Callback<SharedPtr<report::Entry>>,
+                  SharedPtr<Reactor> = Reactor::global(),
+                  SharedPtr<Logger> = Logger::global());
+
 void dns_injection(std::string, Settings, Callback<SharedPtr<report::Entry>>,
                    SharedPtr<Reactor> = Reactor::global(),
                    SharedPtr<Logger> = Logger::global());

--- a/src/libmeasurement_kit/nettests/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/nettests/dpi_fragment.cpp
@@ -1,0 +1,26 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#include <private/nettests/runnable.hpp>
+
+#include <measurement_kit/nettests.hpp>
+#include <measurement_kit/ooni.hpp>
+
+namespace mk {
+namespace nettests {
+
+DpiFragmentTest::DpiFragmentTest() : BaseTest() {
+    runnable.reset(new DpiFragmentRunnable);
+    runnable->test_name = "dpi_fragment";
+    runnable->test_version = "0.0.2";
+    runnable->needs_input = false;
+}
+
+void DpiFragmentRunnable::main(std::string /*input*/, Settings options,
+                            Callback<SharedPtr<report::Entry>> cb) {
+    ooni::dpi_fragment(options, cb, reactor, logger);
+}
+
+} // namespace nettests
+} // namespace mk

--- a/src/libmeasurement_kit/nettests/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/nettests/dpi_fragment.cpp
@@ -2,7 +2,7 @@
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
 
-#include <private/nettests/runnable.hpp>
+#include "src/libmeasurement_kit/nettests/runnable.hpp"
 
 #include <measurement_kit/nettests.hpp>
 #include <measurement_kit/ooni.hpp>

--- a/src/libmeasurement_kit/nettests/runnable.hpp
+++ b/src/libmeasurement_kit/nettests/runnable.hpp
@@ -76,6 +76,7 @@ class Runnable : public NonCopyable, public NonMovable {
     }
 
 MK_DECLARE_RUNNABLE(DashRunnable);
+MK_DECLARE_RUNNABLE(DpiFragmentRunnable);
 MK_DECLARE_RUNNABLE(CaptivePortalRunnable);
 MK_DECLARE_RUNNABLE(DnsInjectionRunnable);
 MK_DECLARE_RUNNABLE(FacebookMessengerRunnable);

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -1,0 +1,373 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#include "private/ooni/constants.hpp"
+#include "private/ooni/utils.hpp"
+#include "private/common/fcompose.hpp"
+#include "private/common/utils.hpp"
+#include <measurement_kit/ooni.hpp>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+
+#include <stdexcept>
+
+#include <iostream>
+
+#include <string>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <arpa/inet.h> 
+#include <sys/time.h>
+
+
+
+
+namespace mk {
+namespace ooni {
+
+using namespace mk::report;
+
+
+
+class SSLFilter {
+    public:
+        SSLFilter(SSL_CTX* ctxt,
+                  std::shared_ptr<std::string> nread,
+                  std::shared_ptr<std::string> nwrite,
+                  std::shared_ptr<std::string> aread,
+                  std::shared_ptr<std::string> awrite,
+                  std::string hostname);
+        virtual ~SSLFilter();
+
+        void update();
+
+    private:
+        bool continue_ssl_(int function_return);
+
+        SSL * ssl;
+        BIO * rbio;
+        BIO * wbio;
+
+        std::shared_ptr<std::string> nread;
+        std::shared_ptr<std::string> nwrite;
+        std::shared_ptr<std::string> aread;
+        std::shared_ptr<std::string> awrite;
+};
+
+SSLFilter::SSLFilter(SSL_CTX* ctxt,
+                     std::shared_ptr<std::string> nread,
+                     std::shared_ptr<std::string> nwrite,
+                     std::shared_ptr<std::string> aread,
+                     std::shared_ptr<std::string> awrite,
+                     std::string hostname)
+                      :
+                     nread(nread),
+                     nwrite(nwrite),
+                     aread(aread),
+                     awrite(awrite) {
+
+    rbio = BIO_new(BIO_s_mem());
+    wbio = BIO_new(BIO_s_mem());
+
+    ssl = SSL_new(ctxt);
+    if (ssl == NULL) {
+        exit(-1); //XXX
+    }
+
+    //XXX for now, we're only doing client-side,
+	// but maybe make it configurable?
+    //SSL_set_accept_state(ssl);
+    SSL_set_connect_state(ssl);
+    SSL_set_bio(ssl, rbio, wbio);
+    int success = SSL_set_tlsext_host_name(ssl, hostname.c_str()); //XXX error code
+}
+
+SSLFilter::~SSLFilter() {
+    SSL_free(ssl);
+}
+
+// XXX ought we to specify FilterDirection?
+//void SSLFilter::update(Filter::FilterDirection) {
+void SSLFilter::update() {
+    // If we have data from the network to process, put it the memory BIO for OpenSSL
+    if (!nread->empty()) {
+        int written = BIO_write(rbio, nread->c_str(), nread->length());
+        if (written > 0) {
+            nread->erase(0, written);
+        }
+    }
+
+    // If the application wants to write data out to the network, process it with SSL_write
+    if (!awrite->empty()) {
+        int written = SSL_write(ssl, awrite->c_str(), awrite->length());
+
+        if (!continue_ssl_(written)) {
+            throw std::runtime_error("An SSL error occured.");
+        }
+
+        if (written > 0) {
+            awrite->erase(0, written);
+        }
+    }
+
+    // Read data for the application from the encrypted connection and place it in the string for the app to read
+    while (1) {
+        char *readto = new char[1024];
+        int read = SSL_read(ssl, readto, 1024);
+
+        if (!continue_ssl_(read)) {
+            delete readto;
+            throw std::runtime_error("An SSL error occured.");
+        }
+
+        if (read > 0) {
+            size_t cur_size = aread->length();
+            aread->resize(cur_size + read);
+            std::copy(readto, readto + read, aread->begin() + cur_size);
+        }
+
+        delete readto;
+
+        if (static_cast<size_t>(read) != 1024 || read == 0) break;
+    }
+
+    // Read any data to be written to the network from the memory BIO and copy it to nwrite
+    while (1) {
+        char *readto = new char[1024];
+        int read = BIO_read(wbio, readto, 1024);
+
+        if (read > 0) {
+            size_t cur_size = nwrite->length();
+            nwrite->resize(cur_size + read);
+            std::copy(readto, readto + read, nwrite->begin() + cur_size);
+        }
+
+        delete readto;
+
+        if (static_cast<size_t>(read) != 1024 || read == 0) break;
+    }
+}
+bool SSLFilter::continue_ssl_(int function_return) {
+    int err = SSL_get_error(ssl, function_return);
+    char desc[120];
+
+    if (err != SSL_ERROR_NONE) {
+        ERR_error_string(err, desc);
+        ERR_print_errors_fp(stdout);
+    }
+
+    if (err == SSL_ERROR_NONE || err == SSL_ERROR_WANT_READ) {
+        return true;
+    }
+
+    if (err == SSL_ERROR_SYSCALL) {
+        ERR_print_errors_fp(stderr);
+        perror("syscall error: ");
+        return false;
+    }
+
+    if (err == SSL_ERROR_SSL) {
+        ERR_print_errors_fp(stderr);
+        return false;
+    }
+    return true;
+}
+
+std::string fragmented_https_request(bool do_fragment, bool do_ssl,
+                        SharedPtr<Logger> logger) {
+    std::string hostname { "example.com" };
+    std::string ip { "93.184.216.34" };
+
+    auto nread = std::make_shared<std::string>();
+    auto nwrite = std::make_shared<std::string>();
+    auto aread = std::make_shared<std::string>();
+    auto awrite = std::make_shared<std::string>();
+
+    SSL_CTX* ctx = SSL_CTX_new(SSLv23_method()); //XXX don't ignore errors
+    if (ctx == NULL) {
+        logger->info("failed to make context\n");
+        exit(1);
+    }   
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL); //XXX probably want to verify eventually
+
+    SSLFilter ssl_filter = SSLFilter(ctx, nread, nwrite, aread, awrite, hostname);
+    if (!do_ssl) { //XXX v. hacky; make passthrough class
+        awrite = nwrite;
+        aread = nread;
+    }
+
+    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0)
+    {
+        logger->info("socket() failed");
+        return *aread; //XXX probably raise exception
+    }
+
+    struct sockaddr_in serv_addr;
+    serv_addr.sin_family = AF_INET;
+    if (do_ssl) {
+        serv_addr.sin_port = htons(443);
+    } else {
+        serv_addr.sin_port = htons(80);
+    }
+
+    if (inet_pton(AF_INET, ip.c_str(), &serv_addr.sin_addr) <= 0) {
+        logger->info("inet_pton() failed");
+        return *aread; //XXX probably raise exception
+    }
+
+    if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+        logger->info("connect() failed");
+        return *aread; //XXX probably raise exception
+    }
+
+    *awrite = "GET /index.html HTTP/1.1\r\nHost: ";
+    *awrite += hostname;
+    *awrite += "\r\n\r\n";
+    if (do_ssl) { //XXX hacky; make a proper passthrough class
+        ssl_filter.update();
+    }
+
+    char readbuf[1024]; //XXX put on heap
+
+    struct timeval tv;
+    int sel_ret;
+    int n;
+    bool stop_reading = false;
+    bool stop_writing = false;
+    fd_set rfds, wfds;
+
+    while(1) {
+        logger->info("TOP OF WHILE LOOP\n");
+        FD_ZERO(&rfds);
+        FD_ZERO(&wfds);
+        if (!stop_reading) {
+            FD_SET(sockfd, &rfds);
+            logger->info("we want to read");
+        }
+        if (!nwrite->empty() && !stop_writing) {
+            FD_SET(sockfd, &wfds);
+            logger->info("we want to write");
+        }
+
+        tv.tv_sec = 4;
+        tv.tv_usec = 0;
+
+        logger->info("BLOCKING ON SELECT\n");
+        sel_ret = select(sockfd+1, &rfds, &wfds, NULL, &tv);
+        if (sel_ret < 0) {
+            logger->info("select() failed");
+            break;
+        }
+        if (sel_ret == 0) {
+            logger->info("select() timed out.\n");
+            if (do_ssl) {
+                ssl_filter.update(); //XXX shouldn't need to sprinkle these around so much if i do more thinking
+            }
+            break;
+        }
+        if (FD_ISSET(sockfd, &wfds)) {
+            logger->info("WRITABLE\n");
+
+            //XXX clean this up
+            if (do_fragment) {
+                std::size_t found = nwrite->find(hostname);
+                if (found!=std::string::npos) {
+                    logger->info("$$$$$$ found plaintext hostname; hacking planet $$$$$$$$$");
+                    n = write(sockfd, nwrite->c_str(), found+3);
+                    if (n > 0) {
+                        nwrite->erase(0, n);
+                    }
+                    sleep(0.5);
+                }
+            }
+
+            n = write(sockfd, nwrite->c_str(), nwrite->length());
+            if (n > 0) {
+                nwrite->erase(0, n);
+            }
+        }
+
+        if (FD_ISSET(sockfd, &rfds)) {
+            logger->info("READABLE\n");
+            while(1) {
+                n = read(sockfd, &readbuf, sizeof(readbuf));
+                logger->info("read from sockfd: %d", n);
+                if (read > 0) {
+                    size_t cur_size = nread->length();
+                    nread->resize(cur_size + n);
+                    std::copy(readbuf, readbuf + n, nread->begin() + cur_size);
+                }
+                if (n == 0) {
+                    stop_reading = true;
+                    break;
+                }
+                if (static_cast<size_t>(n) != sizeof(readbuf)) {
+                    break;
+                }
+                if(n < 0) {
+                    break;
+                }
+            }
+        }
+
+        if (do_ssl) {
+            ssl_filter.update();
+        }
+        if (awrite->size() == 0 && nwrite->size() == 0) {
+            stop_writing = true;
+        }
+        if (stop_reading && stop_writing) {
+            break;
+        }
+
+    }
+
+    return *aread;
+}
+
+
+
+
+void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
+                        SharedPtr<Reactor> reactor, SharedPtr<Logger> logger) {
+    reactor->call_in_thread(logger, [=]() {
+        logger->info("starting dpi_fragment");
+        SharedPtr<Entry> entry(new Entry);
+
+        std::string fragmented_https = fragmented_https_request(true, true, logger);
+        std::string unfragmented_https = fragmented_https_request(false, true, logger);
+        std::string fragmented_http = fragmented_https_request(true, false, logger);
+        std::string unfragmented_http = fragmented_https_request(false, false, logger);
+
+        logger->info("fragmented https response: %s", fragmented_https.c_str());
+        logger->info("unfragmented https response: %s", unfragmented_https.c_str());
+        logger->info("fragmented http response: %s", fragmented_http.c_str());
+        logger->info("unfragmented http response: %s", unfragmented_http.c_str());
+
+        logger->info("fragmented https response length: %d", fragmented_https.length());
+        logger->info("unfragmented https response length: %d", unfragmented_https.length());
+        logger->info("fragmented http response length: %d", fragmented_http.length());
+        logger->info("unfragmented http response length: %d", unfragmented_http.length());
+        callback(entry);
+    });
+}
+
+} // namespace ooni
+} // namespace mk

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -11,17 +11,12 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
-
 #include <stdexcept>
-
 #include <iostream>
-
 #include <string>
-
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bio.h>
-
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -35,15 +30,10 @@
 #include <arpa/inet.h> 
 #include <sys/time.h>
 
-
-
-
 namespace mk {
 namespace ooni {
 
 using namespace mk::report;
-
-
 
 class SSLFilter {
     public:
@@ -341,9 +331,6 @@ std::string fragmented_https_request(bool do_fragment, bool do_ssl,
 
     return *aread;
 }
-
-
-
 
 void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
                         SharedPtr<Reactor> reactor, SharedPtr<Logger> logger) {

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -2,10 +2,10 @@
 // Measurement-kit is free software under the BSD license. See AUTHORS
 // and LICENSE for more information on the copying conditions.
 
-#include "private/ooni/constants.hpp"
-#include "private/ooni/utils.hpp"
-#include "private/common/fcompose.hpp"
-#include "private/common/utils.hpp"
+#include "src/libmeasurement_kit/ooni/constants.hpp"
+#include "src/libmeasurement_kit/ooni/utils.hpp"
+#include "src/libmeasurement_kit/common/fcompose.hpp"
+#include "src/libmeasurement_kit/common/utils.hpp"
 #include <measurement_kit/ooni.hpp>
 
 #include <openssl/ssl.h>

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -348,7 +348,8 @@ std::string fragmented_https_request(bool do_fragment, bool do_ssl,
 void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
                         SharedPtr<Reactor> reactor, SharedPtr<Logger> logger) {
     reactor->call_in_thread(logger, [callback = std::move(callback),
-                                     logger = std::move(logger)]() {
+                                     logger = std::move(logger),
+                                     reactor = std::move(reactor)]() {
         logger->info("starting dpi_fragment");
         SharedPtr<Entry> entry(new Entry);
 
@@ -366,7 +367,10 @@ void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
         logger->info("unfragmented https response length: %d", unfragmented_https.length());
         logger->info("fragmented http response length: %d", fragmented_http.length());
         logger->info("unfragmented http response length: %d", unfragmented_http.length());
-        callback(entry);
+        reactor->call_soon([entry = std::move(entry),
+                            callback = std::move(callback)]() {
+            callback(entry);
+        });
     });
 }
 

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -164,7 +164,7 @@ void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
         logger->info("starting dpi_fragment");
         SharedPtr<Entry> entry(new Entry);
 
-        std::string hostname = "example.com";
+        std::string hostname = options.get("url", std::string{"example.com"});
 
         // copied from getaddrinfo_async.hpp
         addrinfo *rp = nullptr;

--- a/src/libmeasurement_kit/ooni/dpi_fragment.cpp
+++ b/src/libmeasurement_kit/ooni/dpi_fragment.cpp
@@ -347,7 +347,8 @@ std::string fragmented_https_request(bool do_fragment, bool do_ssl,
 
 void dpi_fragment(Settings options, Callback<SharedPtr<report::Entry>> callback,
                         SharedPtr<Reactor> reactor, SharedPtr<Logger> logger) {
-    reactor->call_in_thread(logger, [=]() {
+    reactor->call_in_thread(logger, [callback = std::move(callback),
+                                     logger = std::move(logger)]() {
         logger->info("starting dpi_fragment");
         SharedPtr<Entry> entry(new Entry);
 

--- a/src/libmeasurement_kit/ooni/ssl_filter.cpp
+++ b/src/libmeasurement_kit/ooni/ssl_filter.cpp
@@ -1,0 +1,147 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#include "src/libmeasurement_kit/ooni/ssl_filter.hpp"
+
+#include <stdexcept>
+#include <iostream>
+#include <string>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <arpa/inet.h> 
+#include <sys/time.h>
+
+namespace mk {
+namespace ooni {
+
+SSLFilter::SSLFilter(SSL_CTX* ctxt,
+                     SharedPtr<std::string> nread,
+                     SharedPtr<std::string> nwrite,
+                     SharedPtr<std::string> aread,
+                     SharedPtr<std::string> awrite,
+                     std::string hostname)
+                      :
+                     nread(nread),
+                     nwrite(nwrite),
+                     aread(aread),
+                     awrite(awrite) {
+
+    rbio = BIO_new(BIO_s_mem());
+    wbio = BIO_new(BIO_s_mem());
+
+    ssl = SSL_new(ctxt);
+    if (ssl == NULL) {
+        exit(-1); //XXX
+    }
+
+    //XXX for now, we're only doing client-side,
+	// but maybe make it configurable?
+    //SSL_set_accept_state(ssl);
+    SSL_set_connect_state(ssl);
+    SSL_set_bio(ssl, rbio, wbio);
+    int success = SSL_set_tlsext_host_name(ssl, hostname.c_str()); //XXX error code
+}
+
+SSLFilter::~SSLFilter() {
+    SSL_free(ssl);
+}
+
+// XXX ought we to specify FilterDirection?
+//void SSLFilter::update(Filter::FilterDirection) {
+void SSLFilter::update() {
+    // If we have data from the network to process, put it the memory BIO for OpenSSL
+    if (!nread->empty()) {
+        int written = BIO_write(rbio, nread->c_str(), nread->length());
+        if (written > 0) {
+            nread->erase(0, written);
+        }
+    }
+
+    // If the application wants to write data out to the network, process it with SSL_write
+    if (!awrite->empty()) {
+        int written = SSL_write(ssl, awrite->c_str(), awrite->length());
+
+        if (!continue_ssl_(written)) {
+            throw std::runtime_error("An SSL error occured.");
+        }
+
+        if (written > 0) {
+            awrite->erase(0, written);
+        }
+    }
+
+    // Read data for the application from the encrypted connection and place it in the string for the app to read
+    while (1) {
+        char *readto = new char[1024];
+        int read = SSL_read(ssl, readto, 1024);
+
+        if (!continue_ssl_(read)) {
+            delete readto;
+            throw std::runtime_error("An SSL error occured.");
+        }
+
+        if (read > 0) {
+            size_t cur_size = aread->length();
+            aread->resize(cur_size + read);
+            std::copy(readto, readto + read, aread->begin() + cur_size);
+        }
+
+        delete readto;
+
+        if (static_cast<size_t>(read) != 1024 || read == 0) break;
+    }
+
+    // Read any data to be written to the network from the memory BIO and copy it to nwrite
+    while (1) {
+        char *readto = new char[1024];
+        int read = BIO_read(wbio, readto, 1024);
+
+        if (read > 0) {
+            size_t cur_size = nwrite->length();
+            nwrite->resize(cur_size + read);
+            std::copy(readto, readto + read, nwrite->begin() + cur_size);
+        }
+
+        delete readto;
+
+        if (static_cast<size_t>(read) != 1024 || read == 0) break;
+    }
+}
+bool SSLFilter::continue_ssl_(int function_return) {
+    int err = SSL_get_error(ssl, function_return);
+    char desc[120];
+
+    if (err != SSL_ERROR_NONE) {
+        ERR_error_string(err, desc);
+        ERR_print_errors_fp(stdout);
+    }
+
+    if (err == SSL_ERROR_NONE || err == SSL_ERROR_WANT_READ) {
+        return true;
+    }
+
+    if (err == SSL_ERROR_SYSCALL) {
+        ERR_print_errors_fp(stderr);
+        perror("syscall error: ");
+        return false;
+    }
+
+    if (err == SSL_ERROR_SSL) {
+        ERR_print_errors_fp(stderr);
+        return false;
+    }
+    return true;
+}
+
+}
+}

--- a/src/libmeasurement_kit/ooni/ssl_filter.hpp
+++ b/src/libmeasurement_kit/ooni/ssl_filter.hpp
@@ -1,0 +1,42 @@
+// Part of Measurement Kit <https://measurement-kit.github.io/>.
+// Measurement Kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+#ifndef SRC_LIBMEASUREMENT_KIT_OONI_SSL_FILTER_HPP
+#define SRC_LIBMEASUREMENT_KIT_OONI_SSL_FILTER_HPP
+
+#include "src/libmeasurement_kit/ooni/utils.hpp"
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+
+namespace mk {
+namespace ooni {
+
+class SSLFilter {
+    public:
+        SSLFilter(SSL_CTX* ctxt,
+                  SharedPtr<std::string> nread,
+                  SharedPtr<std::string> nwrite,
+                  SharedPtr<std::string> aread,
+                  SharedPtr<std::string> awrite,
+                  std::string hostname);
+        virtual ~SSLFilter();
+
+        void update();
+
+    private:
+        bool continue_ssl_(int function_return);
+
+        SSL * ssl;
+        BIO * rbio;
+        BIO * wbio;
+
+        SharedPtr<std::string> nread;
+        SharedPtr<std::string> nwrite;
+        SharedPtr<std::string> aread;
+        SharedPtr<std::string> awrite;
+};
+
+}
+}
+#endif

--- a/src/measurement_kit/cmd/dpi_fragment.cpp
+++ b/src/measurement_kit/cmd/dpi_fragment.cpp
@@ -1,0 +1,33 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#include "../cmdline.hpp"
+
+namespace dpi_fragment {
+
+#define USAGE                                                 \
+    "usage: measurement_kit [options] dpi_fragment\n"   \
+
+int main(std::list<Callback<BaseTest &>> &initializers, int argc, char **argv) {
+    mk::nettests::DpiFragmentTest test;
+    int ch;
+    while ((ch = getopt(argc, argv, "B:f:")) != -1) {
+        switch (ch) {
+        default:
+            fprintf(stderr, "%s\n", USAGE);
+            exit(1);
+        }
+    }
+    argc -= optind, argv += optind;
+    if (argc != 0) {
+        fprintf(stderr, "%s\n", USAGE);
+        exit(1);
+        /* NOTREACHED */
+    }
+
+    common_init(initializers, test).run();
+    return 0;
+}
+
+} // namespace dpi_fragment

--- a/src/measurement_kit/cmd/dpi_fragment.cpp
+++ b/src/measurement_kit/cmd/dpi_fragment.cpp
@@ -12,8 +12,11 @@ namespace dpi_fragment {
 int main(std::list<Callback<BaseTest &>> &initializers, int argc, char **argv) {
     mk::nettests::DpiFragmentTest test;
     int ch;
-    while ((ch = getopt(argc, argv, "B:f:")) != -1) {
+    while ((ch = getopt(argc, argv, "B:u:")) != -1) {
         switch (ch) {
+        case 'u':
+            test.set_option("url", optarg);
+            break;
         default:
             fprintf(stderr, "%s\n", USAGE);
             exit(1);

--- a/src/measurement_kit/cmdline.hpp
+++ b/src/measurement_kit/cmdline.hpp
@@ -19,6 +19,7 @@ using namespace mk::nettests;
     XX(dash)                                                                   \
     XX(captiveportal)                                                         \
     XX(dns_injection)                                                          \
+    XX(dpi_fragment)                                                          \
     XX(facebook_messenger)                                                     \
     XX(http_header_field_manipulation)                                         \
     XX(http_invalid_request_line)                                              \

--- a/test/nettests/dpi_fragment.cpp
+++ b/test/nettests/dpi_fragment.cpp
@@ -1,0 +1,20 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#ifdef ENABLE_INTEGRATION_TESTS
+#define CATCH_CONFIG_MAIN
+#include "private/ext/catch.hpp"
+
+#include "../nettests/utils.hpp"
+
+using namespace mk::nettests;
+using namespace mk;
+
+TEST_CASE("Synchronous dpi_fragment test") {
+    test::nettests::with_test<DpiFragmentTest>(test::nettests::run_test);
+}
+
+#else
+int main() {}
+#endif


### PR DESCRIPTION
[Link to spec PR](https://github.com/TheTorProject/ooni-spec/pull/103)

```
l@nl2 ~/code/measurement-kit [sni_stutter] $ ./measurement_kit -n dpi_fragment -u wikipedia.org                                                                                                            
Contacting bouncer: https://bouncer.ooni.io
Using discovered collector: https://c.collector.ooni.io:443
Your public IP address: 185.52.0.143
Your country: NL
Your ISP identifier: AS198203
5%: geoip lookup
10%: open report
starting dpi_fragment
resolved wikipedia.org to 91.198.174.192, now doing 4 http(s) requests...
fragmented https response length: 1174
unfragmented https response length: 1174
fragmented http response length: 500
unfragmented http response length: 500
95%: ending the test
Overall data usage (bytes): 1286 down - 413 up
100%: test complete
```

So instead of trying to hook things at the libevent level, which even Simone says is Hard To Do (:)), I'm doing a good ol' blocking `socket(); connect(); select(); read(); write();` loop in my own thread. I'm telling OpenSSL to talk to some buffers instead of the socket directly, and I'm taking care of read/writing them to the socket (with the `sleep()` trick around the plaintext hostname).
