### PR TITLE
Update Vagrantfile to use zesty instead of yakkety

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/mk"
-  config.vm.define "yakkety" do |yakkety|
-    yakkety.vm.box = "ubuntu/yakkety64"
-    yakkety.vm.provider "virtualbox" do |v|
+  config.vm.define "zesty" do |zesty|
+    zesty.vm.box = "ubuntu/zesty64"
+    zesty.vm.provider "virtualbox" do |v|
       v.memory = 2048
     end
   end


### PR DESCRIPTION
The current Vagrantfile uses yakkety, but trying to pull the image gives a 404. This PR replaces yakkety with zesty, which does not 404.