### PR TITLE
fix(error): define virtual destructor and simplify

### DIFF
--- a/include/measurement_kit/dns/error.hpp
+++ b/include/measurement_kit/dns/error.hpp
@@ -16,7 +16,7 @@ MK_DEFINE_ERR(MK_ERR_DNS(3), NotImplementedError, "dns_lookup_error")
 MK_DEFINE_ERR(MK_ERR_DNS(4), RefusedError, "dns_lookup_error")
 MK_DEFINE_ERR(MK_ERR_DNS(5), TruncatedError, "dns_lookup_error")
 MK_DEFINE_ERR(MK_ERR_DNS(6), UnknownError, "dns_unknown_error")
-using TimeoutError = mk::TimeoutError; /* Was: MK_ERR_DNS(7) */
+/* Was: MK_ERR_DNS(7) */
 MK_DEFINE_ERR(MK_ERR_DNS(8), ShutdownError, "dns_shutdown")
 MK_DEFINE_ERR(MK_ERR_DNS(9), CancelError, "dns_cancel")
 MK_DEFINE_ERR(MK_ERR_DNS(10), NoDataError, "dns_lookup_error")

--- a/include/measurement_kit/net/error.hpp
+++ b/include/measurement_kit/net/error.hpp
@@ -10,7 +10,7 @@ namespace mk {
 namespace net {
 
 MK_DEFINE_ERR(MK_ERR_NET(0), EofError, "eof_error")
-using TimeoutError = mk::TimeoutError; /* Was: MK_ERR_NET(1) */
+/* Was: MK_ERR_NET(1) */
 /* Unused: MK_ERR_NET(2) */
 MK_DEFINE_ERR(MK_ERR_NET(3), ConnectFailedError, "connect_error")
 MK_DEFINE_ERR(MK_ERR_NET(4), DnsGenericError, "dns_lookup_error")
@@ -21,7 +21,7 @@ MK_DEFINE_ERR(MK_ERR_NET(8), SocksGenericError, "socks_error")
 MK_DEFINE_ERR(MK_ERR_NET(9), EOLNotFoundError, "eol_not_found")
 MK_DEFINE_ERR(MK_ERR_NET(10), LineTooLongError, "line_too_long")
 MK_DEFINE_ERR(MK_ERR_NET(11), NetworkError, "generic_network_error")
-using SocketError = NetworkError; /* Alias */
+/* Removed SocketError. Now use NetworkError. */
 MK_DEFINE_ERR(MK_ERR_NET(12), NoAvailableSocksAuthenticationError, "socks_no_available_authentication")
 MK_DEFINE_ERR(MK_ERR_NET(13), SocksError, "socks_error")
 MK_DEFINE_ERR(MK_ERR_NET(14), BadSocksReservedFieldError, "socks_bad_reserved_field")

--- a/src/libmeasurement_kit/common/error.cpp
+++ b/src/libmeasurement_kit/common/error.cpp
@@ -1,0 +1,11 @@
+// Part of Measurement Kit <https://measurement-kit.github.io/>.
+// Measurement Kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+
+#include <measurement_kit/common/error.hpp>
+
+namespace mk {
+
+Error::~Error() {}
+
+} // namespace mk

--- a/src/libmeasurement_kit/ndt/messages_impl.hpp
+++ b/src/libmeasurement_kit/ndt/messages_impl.hpp
@@ -34,7 +34,7 @@ void read_ll_impl(SharedPtr<Context> ctx,
     // Receive message type (1 byte) and length (2 bytes)
     net_readn_first(ctx->txp, ctx->buff, 3, [=](Error err) {
         if (err) {
-            callback(ReadingMessageTypeLengthError(err), 0, "");
+            callback(ReadingMessageTypeLengthError(std::move(err)), 0, "");
             return;
         }
         ErrorOr<uint8_t> type = ctx->buff->read_uint8();
@@ -46,7 +46,7 @@ void read_ll_impl(SharedPtr<Context> ctx,
         // Now read the message payload (`*length` bytes in total)
         net_readn_second(ctx->txp, ctx->buff, *length, [=](Error err) {
             if (err) {
-                callback(ReadingMessagePayloadError(err), 0, "");
+                callback(ReadingMessagePayloadError(std::move(err)), 0, "");
                 return;
             }
             std::string s = ctx->buff->readn(*length);

--- a/src/libmeasurement_kit/ndt/protocol_impl.hpp
+++ b/src/libmeasurement_kit/ndt/protocol_impl.hpp
@@ -19,7 +19,7 @@ void connect_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                 [=](Error err, SharedPtr<Transport> txp) {
                     ctx->logger->debug("ndt: connect ... %d", (int)err);
                     if (err) {
-                        callback(ConnectControlConnectionError(err));
+                        callback(ConnectControlConnectionError(std::move(err)));
                         return;
                     }
                     txp->set_timeout(ctx->timeout);
@@ -45,7 +45,7 @@ void send_extended_login_impl(SharedPtr<Context> ctx, Callback<Error> callback) 
     messages_write(ctx, *out, [=](Error err) {
         ctx->logger->debug("ndt: send login ... %d", (int)err);
         if (err) {
-            callback(WriteExtendedLoginMessageError(err));
+            callback(WriteExtendedLoginMessageError(std::move(err)));
             return;
         }
         ctx->logger->debug("Sent LOGIN with test suite: %d", ctx->test_suite);
@@ -59,7 +59,7 @@ void recv_and_ignore_kickoff_impl(SharedPtr<Context> ctx, Callback<Error> callba
     net_readn(ctx->txp, ctx->buff, KICKOFF_MESSAGE_SIZE, [=](Error err) {
         ctx->logger->debug("ndt: recv and ignore kickoff ... %d", (int)err);
         if (err) {
-            callback(ReadingKickoffMessageError(err));
+            callback(ReadingKickoffMessageError(std::move(err)));
             return;
         }
         std::string s = ctx->buff->readn(KICKOFF_MESSAGE_SIZE);
@@ -86,7 +86,7 @@ void wait_in_queue_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: wait in queue ... %d", (int)err);
         if (err) {
-            callback(ReadingSrvQueueMessageError(err));
+            callback(ReadingSrvQueueMessageError(std::move(err)));
             return;
         }
         if (type != SRV_QUEUE) {
@@ -143,7 +143,7 @@ void recv_version_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv server version ... %d", (int)err);
         if (err) {
-            callback(ReadingServerVersionMessageError(err));
+            callback(ReadingServerVersionMessageError(std::move(err)));
             return;
         }
         if (type != MSG_LOGIN) {
@@ -163,7 +163,7 @@ void recv_tests_id_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv tests ID ... %d", (int)err);
         if (err) {
-            callback(ReadingTestsIdMessageError(err));
+            callback(ReadingTestsIdMessageError(std::move(err)));
             return;
         }
         if (type != MSG_LOGIN) {
@@ -232,7 +232,7 @@ void recv_results_and_logout_impl(SharedPtr<Context> ctx, Callback<Error> callba
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv RESULTS ... %d", (int)err);
         if (err) {
-            callback(ReadingResultsOrLogoutError(err));
+            callback(ReadingResultsOrLogoutError(std::move(err)));
             return;
         }
         if (type == MSG_RESULTS) {
@@ -276,7 +276,7 @@ void wait_close_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             return;
         }
         if (err) {
-            callback(WaitingCloseError(err));
+            callback(WaitingCloseError(std::move(err)));
             return;
         }
         ctx->logger->debug("ndt: got extra data: %s", buffer->read().c_str());

--- a/src/libmeasurement_kit/ndt/run_impl.hpp
+++ b/src/libmeasurement_kit/ndt/run_impl.hpp
@@ -136,7 +136,7 @@ void run_impl(SharedPtr<Entry> entry, Callback<Error> callback, Settings setting
     mlabns_query(settings.get<std::string>("mlabns_tool_name", "ndt"),
                  [=](Error err, mlabns::Reply reply) {
                      if (err) {
-                         callback(MlabnsQueryError(err));
+                         callback(MlabnsQueryError(std::move(err)));
                          return;
                      }
                      run_with_specific_server(entry, reply.fqdn, *port,

--- a/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
@@ -92,7 +92,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", (int)err);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -118,7 +118,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             [=](Error err, Continuation<Error> cc) {
                 ctx->logger->debug("ndt: start c2s coroutine ... %d", (int)err);
                 if (err) {
-                    callback(ConnectTestConnectionError(err));
+                    callback(ConnectTestConnectionError(std::move(err)));
                     return;
                 }
 
@@ -128,7 +128,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                                   std::string) {
                     ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                     if (err) {
-                        callback(ReadingTestStartError(err));
+                        callback(ReadingTestStartError(std::move(err)));
                         return;
                     }
                     if (type != TEST_START) {
@@ -156,7 +156,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                             ctx->logger->debug("ndt: recv TEST_MSG ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestMsgError(err));
+                                callback(ReadingTestMsgError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_MSG) {
@@ -182,7 +182,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                         "ndt: recv TEST_FINALIZE ... %d",
                                         (int)err);
                                     if (err) {
-                                        callback(ReadingTestFinalizeError(err));
+                                        callback(ReadingTestFinalizeError(std::move(err)));
                                         return;
                                     }
                                     if (type != TEST_FINALIZE) {

--- a/src/libmeasurement_kit/ndt/test_meta_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_meta_impl.hpp
@@ -31,7 +31,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", (int)err);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -43,7 +43,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
             ctx, [=](Error err, uint8_t type, std::string) {
                 ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                 if (err) {
-                    callback(ReadingTestStartError(err));
+                    callback(ReadingTestStartError(std::move(err)));
                     return;
                 }
                 if (type != TEST_START) {
@@ -89,7 +89,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
                     ctx->logger->debug("ndt: send final empty message ... %d",
                                        (int)err);
                     if (err) {
-                        callback(WritingMetaError(err));
+                        callback(WritingMetaError(std::move(err)));
                         return;
                     }
 
@@ -102,7 +102,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
                             ctx->logger->debug("ndt: recv TEST_FINALIZE ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestFinalizeError(err));
+                                callback(ReadingTestFinalizeError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_FINALIZE) {

--- a/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
@@ -112,7 +112,7 @@ void finalizing_test_impl(SharedPtr<Context> ctx, SharedPtr<Entry> cur_entry,
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_MSG ... %d", (int)err);
         if (err) {
-            callback(ReadingTestMsgError(err));
+            callback(ReadingTestMsgError(std::move(err)));
             return;
         }
         if (type == TEST_FINALIZE) {
@@ -151,7 +151,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", err.code);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -217,7 +217,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             [=](Error err, Continuation<Error, double> cc) {
                 ctx->logger->debug("ndt: start s2c coroutine ... %d", (int)err);
                 if (err) {
-                    callback(ConnectTestConnectionError(err));
+                    callback(ConnectTestConnectionError(std::move(err)));
                     return;
                 }
 
@@ -227,7 +227,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                                   std::string) {
                     ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                     if (err) {
-                        callback(ReadingTestStartError(err));
+                        callback(ReadingTestStartError(std::move(err)));
                         return;
                     }
                     if (type != TEST_START) {
@@ -251,7 +251,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                             ctx->logger->debug("ndt: recv TEST_MSG ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestMsgError(err));
+                                callback(ReadingTestMsgError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_MSG) {
@@ -275,7 +275,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                 ctx->logger->debug("ndt: send TEST_MSG ... %d",
                                                    (int)err);
                                 if (err) {
-                                    callback(WritingTestMsgError(err));
+                                    callback(WritingTestMsgError(std::move(err)));
                                     return;
                                 }
 

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -35,7 +35,7 @@ void mk_bufferevent_on_event(bufferevent *bev, short what, void *ptr) {
     if ((what & BEV_EVENT_CONNECTED) != 0) {
         (*cb)(mk::NoError(), bev);
     } else if ((what & BEV_EVENT_TIMEOUT) != 0) {
-        (*cb)(mk::net::TimeoutError(), bev);
+        (*cb)(mk::TimeoutError(), bev);
     } else {
         mk::Error err;
         /*
@@ -47,7 +47,7 @@ void mk_bufferevent_on_event(bufferevent *bev, short what, void *ptr) {
             err = mk::net::map_errno(errno);
         } else {
             long ssl_err = bufferevent_get_openssl_error(bev);
-            std::string s = ERR_error_string(ssl_err, nullptr);
+            const char *s = ERR_error_string(ssl_err, nullptr);
             err = mk::net::SslError(s);
         }
         (*cb)(err, bev);
@@ -118,7 +118,7 @@ void connect_logic(std::string hostname, int port,
                                      // Otherwise, report them all
                                      Error connect_error = ConnectFailedError();
                                      for (auto se: e) {
-                                         connect_error.add_child_error(se);
+                                         connect_error.add_child_error(std::move(se));
                                      }
                                      cb(connect_error, result);
                                      return;
@@ -127,7 +127,7 @@ void connect_logic(std::string hostname, int port,
                                     bufferevent_getfd(result->connected_bev)
                                  );
                                  for (auto se: e) {
-                                    nagle_error.add_child_error(se);
+                                    nagle_error.add_child_error(std::move(se));
                                  }
                                  cb(nagle_error, result);
                              },

--- a/src/libmeasurement_kit/net/utils.cpp
+++ b/src/libmeasurement_kit/net/utils.cpp
@@ -296,7 +296,7 @@ Error disable_nagle(socket_t sockfd) {
     static const int disable = 1;
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&disable,
                    sizeof (disable)) != 0) {
-        return SocketError();
+        return NetworkError();
     }
     return NoError();
 }

--- a/src/libmeasurement_kit/nettests/multi_ndt.cpp
+++ b/src/libmeasurement_kit/nettests/multi_ndt.cpp
@@ -93,7 +93,7 @@ void MultiNdtRunnable::main(std::string, Settings ndt_settings,
         logger->set_progress_offset(0.55);
         logger->set_progress_scale(0.35);
         logger->progress(0.0, "Starting multi-stream test");
-        ndt::run(neubot_entry, [=](Error neubot_error) {
+        ndt::run(neubot_entry, [=](Error neubot_error) mutable {
             logger->progress(1.0, "Test completed");
             if (neubot_error) {
                 (*neubot_entry)["failure"] = neubot_error.reason;
@@ -106,8 +106,8 @@ void MultiNdtRunnable::main(std::string, Settings ndt_settings,
             (*overall_entry)["single_stream"] = *ndt_entry;
             if (ndt_error or neubot_error) {
                 Error overall_error = SequentialOperationError();
-                overall_error.add_child_error(ndt_error);
-                overall_error.add_child_error(neubot_error);
+                overall_error.add_child_error(std::move(ndt_error));
+                overall_error.add_child_error(std::move(neubot_error));
                 (*overall_entry)["failure"] = overall_error.reason;
                 // FALLTHROUGH
             }

--- a/src/libmeasurement_kit/ooni/collector_client.cpp
+++ b/src/libmeasurement_kit/ooni/collector_client.cpp
@@ -53,7 +53,7 @@ Error valid_entry(Entry entry) {
             return MissingMandatoryKeyError(s.as_error());
         }
         if (!std::regex_match(*s, pair.second)) {
-            return InvalidMandatoryValueError(pair.first);
+            return InvalidMandatoryValueError(pair.first.c_str());
         }
     }
     return NoError();

--- a/src/libmeasurement_kit/traceroute/android.cpp
+++ b/src/libmeasurement_kit/traceroute/android.cpp
@@ -346,7 +346,7 @@ void AndroidProber::event_callback(Error err) {
 
     logger->debug("event_callback(%s)", err.what());
 
-    if (err == net::TimeoutError()) {
+    if (err == TimeoutError()) {
         on_timeout();
         timeout_cb_();
 

--- a/test/common/error.cpp
+++ b/test/common/error.cpp
@@ -33,8 +33,9 @@ TEST_CASE("Error constructed with error and message is correctly initialized") {
     REQUIRE(err.reason == "antani");
 }
 
-TEST_CASE("Constructor with underlying error works correctly") {
-    Error err{17, "antani", MockedError()};
+TEST_CASE("An error with underlying error works correctly") {
+    Error err{17, "antani"};
+    err.add_child_error(MockedError());
     REQUIRE(!!err);
     REQUIRE(err.child_errors[0] == MockedError());
     REQUIRE(err == 17);
@@ -51,25 +52,20 @@ TEST_CASE("Unequality works for errors") {
     REQUIRE(first != second);
 }
 
-MK_DEFINE_ERR(17, ExampleError, "example error")
-
 TEST_CASE("The defined-error constructor with string works") {
-    ExampleError ex{"antani"};
+    Error ex = MockedError("antani");
     REQUIRE(!!ex);
-    REQUIRE(ex == 17);
-    REQUIRE(ex.reason == "example error: antani");
-    REQUIRE(strcmp(ex.what(), "example error: antani") == 0);
+    REQUIRE(ex.reason == "mocked_error: antani");
+    REQUIRE(strcmp(ex.what(), "mocked_error: antani") == 0);
 }
 
 TEST_CASE("The add_child_error() method works") {
     Error err;
-    ExampleError ex{"antani"};
-    MockedError merr;
-    err.add_child_error(ex);
-    err.add_child_error(merr);
+    err.add_child_error(MockedError("antani"));
+    err.add_child_error(MockedError());
     REQUIRE((err.child_errors.size() == 2));
-    REQUIRE((err.child_errors[0] == ExampleError()));
-    REQUIRE((err.child_errors[0].reason == "example error: antani"));
+    REQUIRE((err.child_errors[0] == MockedError()));
+    REQUIRE((err.child_errors[0].reason == "mocked_error: antani"));
     REQUIRE((err.child_errors[1] == MockedError()));
     REQUIRE((err.child_errors[1].reason == "mocked_error"));
 }

--- a/test/common/settings.cpp
+++ b/test/common/settings.cpp
@@ -20,14 +20,14 @@ TEST_CASE("The settings class throw an exception when the conversions fails, "
           "due to an empty string") {
     Settings settings;
     settings["key"] = "";
-    REQUIRE_THROWS_AS(settings["key"].as<int>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<int>(), Error);
 }
 
 TEST_CASE("The settings class throw an exception when the conversion is not "
           "complete") {
     Settings settings;
     settings["key"] = "4 5 6";
-    REQUIRE_THROWS_AS(settings["key"].as<int>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<int>(), Error);
 }
 
 TEST_CASE("The settings class convert bool to int") {
@@ -52,14 +52,14 @@ TEST_CASE(
     "The settings class throws an exception while converting double to int") {
     Settings settings;
     settings["key"] = 6.5;
-    REQUIRE_THROWS_AS(settings["key"].as<int>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<int>(), Error);
 }
 
 TEST_CASE(
     "The settings class throws an exception when converting double to bool") {
     Settings settings;
     settings["key"] = 6.5;
-    REQUIRE_THROWS_AS(settings["key"].as<bool>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<bool>(), Error);
 }
 
 TEST_CASE("The settings class converts double to string") {
@@ -84,7 +84,7 @@ TEST_CASE(
     "The settings class throws an exception when converting int (10) to bool") {
     Settings settings;
     settings["key"] = 10;
-    REQUIRE_THROWS_AS(settings["key"].as<bool>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<bool>(), Error);
 }
 
 TEST_CASE("The settings class converts string to int") {
@@ -109,7 +109,7 @@ TEST_CASE("The settings class throws an exception when converting from string"
           "to bool with an uncorrect value") {
     Settings settings;
     settings["key"] = "10";
-    REQUIRE_THROWS_AS(settings["key"].as<bool>(), ValueError);
+    REQUIRE_THROWS_AS(settings["key"].as<bool>(), Error);
 }
 
 TEST_CASE("The Settings::get() method works as expected "

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -14,7 +14,7 @@ TEST_CASE("We are NOT using the default random seed") {
 }
 
 TEST_CASE("random_within_charset() works with zero length string") {
-    REQUIRE_THROWS_AS(mk::random_within_charset("", 16), mk::ValueError);
+    REQUIRE_THROWS_AS(mk::random_within_charset("", 16), mk::Error);
 }
 
 TEST_CASE("random_within_charset() uses all the available charset") {

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -23,7 +23,7 @@ TEST_CASE("ResponseParserNg deals with an invalid message") {
     data += "\r\n";
     data += "1234567";
 
-    REQUIRE_THROWS_AS(parser.feed(data), ParserError);
+    REQUIRE_THROWS_AS(parser.feed(data), Error);
 }
 
 TEST_CASE("ResponseParserNg deals with an UPGRADE request") {
@@ -184,7 +184,7 @@ TEST_CASE("ResponseParserNg stops after first message") {
 
     REQUIRE(data.size() > 0);
     auto c = data.front();
-    REQUIRE_THROWS_AS(parser.feed(c), ParserError);
+    REQUIRE_THROWS_AS(parser.feed(c), Error);
 }
 
 TEST_CASE("ResponseParserNg eof() works as expected") {

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -49,7 +49,7 @@ TEST_CASE("connect_base deals with bufferevent_socket_new error") {
     try {
         connect_base<make_sockaddr, fail>("130.192.16.172", 80, 3.14,
                 Reactor::global(), Logger::global(), nullptr);
-    } catch (GenericError &) {
+    } catch (Error &) {
         ok = true;
     }
     REQUIRE(ok);
@@ -63,7 +63,7 @@ TEST_CASE("connect_base deals with bufferevent_set_timeouts error") {
         connect_base<make_sockaddr, ::bufferevent_socket_new,
                      fail>("130.192.16.172", 80, 3.14, Reactor::global(),
                            Logger::global(), nullptr);
-    } catch (GenericError &) {
+    } catch (Error &) {
         ok = true;
     }
     REQUIRE(ok);

--- a/test/nettests/utils.cpp
+++ b/test/nettests/utils.cpp
@@ -135,7 +135,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                 intercept_randomize>(inputs, true, {"./test/fixtures/urls.txt"}, "IT",
                                      {{"randomize_input", "1"}},
                                      mk::Logger::global(), nullptr, nullptr)),
-            mk::MockedError);
+            mk::Error);
     }
 
     SECTION("The randomize functionality is invoked by default") {
@@ -145,7 +145,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                               intercept_randomize>(inputs,
                               true, {"./test/fixtures/urls.txt"}, "IT", {},
                               mk::Logger::global(), nullptr, nullptr)),
-                          mk::MockedError);
+                          mk::Error);
     }
 
     SECTION("The randomize functionality is not invoked when not requested") {

--- a/test/report/entry.cpp
+++ b/test/report/entry.cpp
@@ -56,7 +56,7 @@ TEST_CASE("We raise mk::JsonDomainError when keys cannot be added to entry") {
     // more than one access cycle we're still using the Entry type, which raises
     // JsonDomainError, rather than the base type nlohmann/json.
     entry["list"].push_back(17.0);
-    REQUIRE_THROWS_AS((entry["list"]["foo"] = "foobar"), JsonDomainError);
+    REQUIRE_THROWS_AS((entry["list"]["foo"] = "foobar"), Error);
 }
 
 TEST_CASE("We raise mk::JsonDomainError when we cannot append added to entry") {
@@ -65,7 +65,7 @@ TEST_CASE("We raise mk::JsonDomainError when we cannot append added to entry") {
     // more than one access cycle we're still using the Entry type, which raises
     // JsonDomainError, rather than the base type nlohmann/json.
     entry["dict"]["foo"] = "foobar";
-    REQUIRE_THROWS_AS((entry["dict"].push_back(17.0)), JsonDomainError);
+    REQUIRE_THROWS_AS((entry["dict"].push_back(17.0)), Error);
 }
 
 TEST_CASE("We can create an Array") {


### PR DESCRIPTION
Depends on #1530. See 64ca9588c7ee7f9e9a76424f42f85db02596f38c for the individual commit.

- - -

The bug we're trying to fix here is that, since Error derives from
std::exception, its destructor should be virtual.

The proper way of doing that would probably be that of defining a
virtual destructor for every error class that we have.

Adding an out-of-line destructor for each error class would take
time and/or being hackish (by augmenting the existing macro?).

Adding an in-line virtual destructor is bad practice (and indeed
clang warns about that; see `-Wweak-vtables`).

However, it seems we really don't need all these classes.

They were introduced when we were thinking about throwing errors
and then catching them using different catch clauses.

But, during #1235, #1262, and #1447, it occurred to me repeatedly
that we should only use exceptions as fatal errors because to have
exceptions and async code in the same plate is too tricky.

So, if that is the intent, we can get away with a single Error
class -- with proper virtual destructor, of course.

At least in the library.

Then, in the regress tests, we have a few instances where we do
actually check that an exception is of the specified type.

But, it also turn out that doing that is not exactly needed for
our code testing goal. Which is that of making sure that the code
throws `$whatever` in case something unexpected happens.

If that is the end, we can safely just check if the code throws
something and then rely on code coverage to make sure that all
the possible fatal error paths throw.

After all, we already have cases where different error paths lead
to the same exception being thrown, so we already cannot use the
exception type alone to tell whether we cover all paths.

While there, force the single-argument constructor to be called
explicitly, as that is considered good practice.

While there, force moving in the child error.