### PR TITLE
refactor(error): explicit ctor, move semantic

### DIFF
--- a/include/measurement_kit/common/error.hpp
+++ b/include/measurement_kit/common/error.hpp
@@ -45,13 +45,12 @@ namespace mk {
 /// as part of measurement-kit v0.8.0 as part of a refactoring of common.
 class Error : public std::exception {
   public:
-
     /// \brief The default constructor initializes the error code to zero.
     Error() : Error(0, "") {}
 
     /// \brief The constructor with error initializes the error code to the
     /// specified error code.
-    Error(int e) : Error(e, "") {}
+    explicit Error(int e) : Error(e, "") {}
 
     /// \brief The constructor with error and reason string initializes both.
     Error(int e, std::string r) : code{e}, reason{r} {
@@ -87,8 +86,8 @@ class Error : public std::exception {
     const char *what() const noexcept override { return reason.c_str(); }
 
     /// `add_child_error` allows you tou append additional child errors.
-    void add_child_error(const Error &err) {
-        child_errors.push_back(err);
+    void add_child_error(Error &&err) {
+        child_errors.push_back(std::move(err));
     }
 
     /// `child_errors` contains all the child errors.

--- a/src/libmeasurement_kit/ndt/messages_impl.hpp
+++ b/src/libmeasurement_kit/ndt/messages_impl.hpp
@@ -34,7 +34,7 @@ void read_ll_impl(SharedPtr<Context> ctx,
     // Receive message type (1 byte) and length (2 bytes)
     net_readn_first(ctx->txp, ctx->buff, 3, [=](Error err) {
         if (err) {
-            callback(ReadingMessageTypeLengthError(err), 0, "");
+            callback(ReadingMessageTypeLengthError(std::move(err)), 0, "");
             return;
         }
         ErrorOr<uint8_t> type = ctx->buff->read_uint8();
@@ -46,7 +46,7 @@ void read_ll_impl(SharedPtr<Context> ctx,
         // Now read the message payload (`*length` bytes in total)
         net_readn_second(ctx->txp, ctx->buff, *length, [=](Error err) {
             if (err) {
-                callback(ReadingMessagePayloadError(err), 0, "");
+                callback(ReadingMessagePayloadError(std::move(err)), 0, "");
                 return;
             }
             std::string s = ctx->buff->readn(*length);

--- a/src/libmeasurement_kit/ndt/protocol_impl.hpp
+++ b/src/libmeasurement_kit/ndt/protocol_impl.hpp
@@ -19,7 +19,7 @@ void connect_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                 [=](Error err, SharedPtr<Transport> txp) {
                     ctx->logger->debug("ndt: connect ... %d", (int)err);
                     if (err) {
-                        callback(ConnectControlConnectionError(err));
+                        callback(ConnectControlConnectionError(std::move(err)));
                         return;
                     }
                     txp->set_timeout(ctx->timeout);
@@ -45,7 +45,7 @@ void send_extended_login_impl(SharedPtr<Context> ctx, Callback<Error> callback) 
     messages_write(ctx, *out, [=](Error err) {
         ctx->logger->debug("ndt: send login ... %d", (int)err);
         if (err) {
-            callback(WriteExtendedLoginMessageError(err));
+            callback(WriteExtendedLoginMessageError(std::move(err)));
             return;
         }
         ctx->logger->debug("Sent LOGIN with test suite: %d", ctx->test_suite);
@@ -59,7 +59,7 @@ void recv_and_ignore_kickoff_impl(SharedPtr<Context> ctx, Callback<Error> callba
     net_readn(ctx->txp, ctx->buff, KICKOFF_MESSAGE_SIZE, [=](Error err) {
         ctx->logger->debug("ndt: recv and ignore kickoff ... %d", (int)err);
         if (err) {
-            callback(ReadingKickoffMessageError(err));
+            callback(ReadingKickoffMessageError(std::move(err)));
             return;
         }
         std::string s = ctx->buff->readn(KICKOFF_MESSAGE_SIZE);
@@ -86,7 +86,7 @@ void wait_in_queue_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: wait in queue ... %d", (int)err);
         if (err) {
-            callback(ReadingSrvQueueMessageError(err));
+            callback(ReadingSrvQueueMessageError(std::move(err)));
             return;
         }
         if (type != SRV_QUEUE) {
@@ -143,7 +143,7 @@ void recv_version_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv server version ... %d", (int)err);
         if (err) {
-            callback(ReadingServerVersionMessageError(err));
+            callback(ReadingServerVersionMessageError(std::move(err)));
             return;
         }
         if (type != MSG_LOGIN) {
@@ -163,7 +163,7 @@ void recv_tests_id_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv tests ID ... %d", (int)err);
         if (err) {
-            callback(ReadingTestsIdMessageError(err));
+            callback(ReadingTestsIdMessageError(std::move(err)));
             return;
         }
         if (type != MSG_LOGIN) {
@@ -232,7 +232,7 @@ void recv_results_and_logout_impl(SharedPtr<Context> ctx, Callback<Error> callba
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv RESULTS ... %d", (int)err);
         if (err) {
-            callback(ReadingResultsOrLogoutError(err));
+            callback(ReadingResultsOrLogoutError(std::move(err)));
             return;
         }
         if (type == MSG_RESULTS) {
@@ -276,7 +276,7 @@ void wait_close_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             return;
         }
         if (err) {
-            callback(WaitingCloseError(err));
+            callback(WaitingCloseError(std::move(err)));
             return;
         }
         ctx->logger->debug("ndt: got extra data: %s", buffer->read().c_str());

--- a/src/libmeasurement_kit/ndt/run_impl.hpp
+++ b/src/libmeasurement_kit/ndt/run_impl.hpp
@@ -136,7 +136,7 @@ void run_impl(SharedPtr<Entry> entry, Callback<Error> callback, Settings setting
     mlabns_query(settings.get<std::string>("mlabns_tool_name", "ndt"),
                  [=](Error err, mlabns::Reply reply) {
                      if (err) {
-                         callback(MlabnsQueryError(err));
+                         callback(MlabnsQueryError(std::move(err)));
                          return;
                      }
                      run_with_specific_server(entry, reply.fqdn, *port,

--- a/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_c2s_impl.hpp
@@ -92,7 +92,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", (int)err);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -118,7 +118,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             [=](Error err, Continuation<Error> cc) {
                 ctx->logger->debug("ndt: start c2s coroutine ... %d", (int)err);
                 if (err) {
-                    callback(ConnectTestConnectionError(err));
+                    callback(ConnectTestConnectionError(std::move(err)));
                     return;
                 }
 
@@ -128,7 +128,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                                   std::string) {
                     ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                     if (err) {
-                        callback(ReadingTestStartError(err));
+                        callback(ReadingTestStartError(std::move(err)));
                         return;
                     }
                     if (type != TEST_START) {
@@ -156,7 +156,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                             ctx->logger->debug("ndt: recv TEST_MSG ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestMsgError(err));
+                                callback(ReadingTestMsgError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_MSG) {
@@ -182,7 +182,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                         "ndt: recv TEST_FINALIZE ... %d",
                                         (int)err);
                                     if (err) {
-                                        callback(ReadingTestFinalizeError(err));
+                                        callback(ReadingTestFinalizeError(std::move(err)));
                                         return;
                                     }
                                     if (type != TEST_FINALIZE) {

--- a/src/libmeasurement_kit/ndt/test_meta_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_meta_impl.hpp
@@ -31,7 +31,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", (int)err);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -43,7 +43,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
             ctx, [=](Error err, uint8_t type, std::string) {
                 ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                 if (err) {
-                    callback(ReadingTestStartError(err));
+                    callback(ReadingTestStartError(std::move(err)));
                     return;
                 }
                 if (type != TEST_START) {
@@ -89,7 +89,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
                     ctx->logger->debug("ndt: send final empty message ... %d",
                                        (int)err);
                     if (err) {
-                        callback(WritingMetaError(err));
+                        callback(WritingMetaError(std::move(err)));
                         return;
                     }
 
@@ -102,7 +102,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> cb) {
                             ctx->logger->debug("ndt: recv TEST_FINALIZE ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestFinalizeError(err));
+                                callback(ReadingTestFinalizeError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_FINALIZE) {

--- a/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
+++ b/src/libmeasurement_kit/ndt/test_s2c_impl.hpp
@@ -112,7 +112,7 @@ void finalizing_test_impl(SharedPtr<Context> ctx, SharedPtr<Entry> cur_entry,
     messages_read_msg(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_MSG ... %d", (int)err);
         if (err) {
-            callback(ReadingTestMsgError(err));
+            callback(ReadingTestMsgError(std::move(err)));
             return;
         }
         if (type == TEST_FINALIZE) {
@@ -151,7 +151,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
     messages_read_msg_first(ctx, [=](Error err, uint8_t type, std::string s) {
         ctx->logger->debug("ndt: recv TEST_PREPARE ... %d", err.code);
         if (err) {
-            callback(ReadingTestPrepareError(err));
+            callback(ReadingTestPrepareError(std::move(err)));
             return;
         }
         if (type != TEST_PREPARE) {
@@ -217,7 +217,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
             [=](Error err, Continuation<Error, double> cc) {
                 ctx->logger->debug("ndt: start s2c coroutine ... %d", (int)err);
                 if (err) {
-                    callback(ConnectTestConnectionError(err));
+                    callback(ConnectTestConnectionError(std::move(err)));
                     return;
                 }
 
@@ -227,7 +227,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                                   std::string) {
                     ctx->logger->debug("ndt: recv TEST_START ... %d", (int)err);
                     if (err) {
-                        callback(ReadingTestStartError(err));
+                        callback(ReadingTestStartError(std::move(err)));
                         return;
                     }
                     if (type != TEST_START) {
@@ -251,7 +251,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                             ctx->logger->debug("ndt: recv TEST_MSG ... %d",
                                                (int)err);
                             if (err) {
-                                callback(ReadingTestMsgError(err));
+                                callback(ReadingTestMsgError(std::move(err)));
                                 return;
                             }
                             if (type != TEST_MSG) {
@@ -275,7 +275,7 @@ void run_impl(SharedPtr<Context> ctx, Callback<Error> callback) {
                                 ctx->logger->debug("ndt: send TEST_MSG ... %d",
                                                    (int)err);
                                 if (err) {
-                                    callback(WritingTestMsgError(err));
+                                    callback(WritingTestMsgError(std::move(err)));
                                     return;
                                 }
 

--- a/src/libmeasurement_kit/net/connect.cpp
+++ b/src/libmeasurement_kit/net/connect.cpp
@@ -118,7 +118,7 @@ void connect_logic(std::string hostname, int port,
                                      // Otherwise, report them all
                                      Error connect_error = ConnectFailedError();
                                      for (auto se: e) {
-                                         connect_error.add_child_error(se);
+                                         connect_error.add_child_error(std::move(se));
                                      }
                                      cb(connect_error, result);
                                      return;
@@ -127,7 +127,7 @@ void connect_logic(std::string hostname, int port,
                                     bufferevent_getfd(result->connected_bev)
                                  );
                                  for (auto se: e) {
-                                    nagle_error.add_child_error(se);
+                                    nagle_error.add_child_error(std::move(se));
                                  }
                                  cb(nagle_error, result);
                              },

--- a/src/libmeasurement_kit/nettests/multi_ndt.cpp
+++ b/src/libmeasurement_kit/nettests/multi_ndt.cpp
@@ -93,7 +93,7 @@ void MultiNdtRunnable::main(std::string, Settings ndt_settings,
         logger->set_progress_offset(0.55);
         logger->set_progress_scale(0.35);
         logger->progress(0.0, "Starting multi-stream test");
-        ndt::run(neubot_entry, [=](Error neubot_error) {
+        ndt::run(neubot_entry, [=](Error neubot_error) mutable {
             logger->progress(1.0, "Test completed");
             if (neubot_error) {
                 (*neubot_entry)["failure"] = neubot_error.reason;
@@ -106,8 +106,8 @@ void MultiNdtRunnable::main(std::string, Settings ndt_settings,
             (*overall_entry)["single_stream"] = *ndt_entry;
             if (ndt_error or neubot_error) {
                 Error overall_error = SequentialOperationError();
-                overall_error.add_child_error(ndt_error);
-                overall_error.add_child_error(neubot_error);
+                overall_error.add_child_error(std::move(ndt_error));
+                overall_error.add_child_error(std::move(neubot_error));
                 (*overall_entry)["failure"] = overall_error.reason;
                 // FALLTHROUGH
             }

--- a/test/common/error.cpp
+++ b/test/common/error.cpp
@@ -65,8 +65,8 @@ TEST_CASE("The add_child_error() method works") {
     Error err;
     ExampleError ex{"antani"};
     MockedError merr;
-    err.add_child_error(ex);
-    err.add_child_error(merr);
+    err.add_child_error(std::move(ex));
+    err.add_child_error(std::move(merr));
     REQUIRE((err.child_errors.size() == 2));
     REQUIRE((err.child_errors[0] == ExampleError()));
     REQUIRE((err.child_errors[0].reason == "example error: antani"));


### PR DESCRIPTION
This diff introduces a set of non-breaking correctness-related
changes to the Error class:

- explicit single-argument constructor

- enforce move semantic when adding child errors

Extracted from #1531. This should not be controversial and we can
perhaps see to merge it while deciding how to further refactor the
Error class according to the discussion in #1531.