### PR TITLE
Backport country flag into stable branch

### DIFF
--- a/include/measurement_kit/mlabns/mlabns.hpp
+++ b/include/measurement_kit/mlabns/mlabns.hpp
@@ -13,6 +13,7 @@ MK_DEFINE_ERR(MK_ERR_MLABNS(0), InvalidPolicyError, "mlabns_invalid_policy")
 MK_DEFINE_ERR(MK_ERR_MLABNS(1), InvalidAddressFamilyError, "mlabns_invalid_address_family")
 MK_DEFINE_ERR(MK_ERR_MLABNS(2), InvalidMetroError, "mlabns_invalid_metro")
 MK_DEFINE_ERR(MK_ERR_MLABNS(3), InvalidToolNameError, "mlabns_invalid_tool")
+MK_DEFINE_ERR(MK_ERR_MLABNS(4), InvalidCountryError, "mlabns_invalid_country")
 
 /// Reply to mlab-ns query.
 class Reply {

--- a/include/private/mlabns/mlabns_impl.hpp
+++ b/include/private/mlabns/mlabns_impl.hpp
@@ -18,6 +18,7 @@ namespace mlabns {
 static inline ErrorOr<std::string> as_query(Settings &settings) {
     std::string query;
     std::string policy = settings.get<std::string>("mlabns/policy", "");
+    std::string country = settings.get<std::string>("mlabns/country", "");
     std::string metro = settings.get<std::string>("mlabns/metro", "");
     std::string address_family =
         settings.get<std::string>("mlabns/address_family", "");
@@ -33,6 +34,16 @@ static inline ErrorOr<std::string> as_query(Settings &settings) {
             query += "&";
         }
         query += "policy=" + policy;
+    }
+    if (country != "") {
+        std::regex valid_country("^[A-Z]{2}$");
+        if (!std::regex_match(country, valid_country)) {
+            return InvalidCountryError();
+        }
+        if (query != "") {
+            query += "&";
+        }
+        query += "country=" + country;
     }
     if (metro != "") {
         std::regex valid_metro("^[a-z]{3}$");

--- a/src/measurement_kit/cmd/ndt.cpp
+++ b/src/measurement_kit/cmd/ndt.cpp
@@ -21,8 +21,12 @@ int main(std::list<Callback<BaseTest &>> &initializers, int argc, char **argv) {
     int test_suite = 0;
     int use_default_test_suite = true;
 
-    for (int ch; (ch = getopt(argc, argv, "m:N:p:T:")) != -1;) {
+    for (int ch; (ch = getopt(argc, argv, "C:m:N:p:T:")) != -1;) {
         switch (ch) {
+        case 'C':
+            test.set_option("mlabns/policy", "country");
+            test.set_option("mlabns/country", optarg);
+            break;
         case 'm':
             test.set_option("mlabns/policy", "metro");
             test.set_option("mlabns/metro", optarg);


### PR DESCRIPTION
This PR backports the changes to master that implement the `-C` flag to the ndt subcommand, which allows for querying the mlab_ns system by country.