### PR TITLE
include: reduce places where we throw Error

### DIFF
--- a/include/measurement_kit/dns/error.hpp
+++ b/include/measurement_kit/dns/error.hpp
@@ -46,7 +46,8 @@ MK_DEFINE_ERR(MK_ERR_DNS(27), NotSupportedServnameError,
               "dns_unsupported_servname")
 MK_DEFINE_ERR(MK_ERR_DNS(28), NotSupportedAISocktypeError,
               "dns_unsupported_socktype")
-MK_DEFINE_ERR(MK_ERR_DNS(29), InetNtopFailureError, "dns_inet_ntop_failure")
+//Was: MK_DEFINE_ERR(MK_ERR_DNS(29), InetNtopFailureError,
+//                   "dns_inet_ntop_failure")
 
 } // namespace dns
 } // namespace mk

--- a/include/measurement_kit/net/buffer.hpp
+++ b/include/measurement_kit/net/buffer.hpp
@@ -87,7 +87,7 @@ class Buffer {
     }
 
     void write(const char *in) {
-        if (in == nullptr) throw std::runtime_error("in is nullptr");
+        if (in == nullptr) throw std::runtime_error("null pointer");
         write(in, strlen(in));
     }
 

--- a/src/libmeasurement_kit/common/utils.cpp
+++ b/src/libmeasurement_kit/common/utils.cpp
@@ -54,7 +54,7 @@ timeval *timeval_init(timeval *tv, double delta) {
 std::string random_within_charset(const std::string charset, size_t length) {
     // See <http://stackoverflow.com/questions/440133/>
     if (charset.size() < 1) {
-        throw ValueError();
+        throw std::runtime_error("random_within_charset_with_empty_charset");
     }
     auto randchar = [&charset]() {
         int rand = 0;

--- a/src/libmeasurement_kit/dns/getaddrinfo_async.hpp
+++ b/src/libmeasurement_kit/dns/getaddrinfo_async.hpp
@@ -62,7 +62,7 @@ std::vector<Answer> getaddrinfo_async_parse_response(const std::string &name,
             answer.type = MK_DNS_TYPE_AAAA;
             aptr = &((sockaddr_in6 *)p->ai_addr)->sin6_addr;
         } else {
-            throw GenericError(); /* Avoid g++ warning */
+            throw std::runtime_error("unexpected_family"); // Avoid g++ warning
         }
         if (p->ai_canonname != nullptr) {
             Answer cname_ans = answer;
@@ -73,7 +73,7 @@ std::vector<Answer> getaddrinfo_async_parse_response(const std::string &name,
         }
         char abuf[128];
         if (inet_ntop(p->ai_family, aptr, abuf, sizeof(abuf)) == nullptr) {
-            throw InetNtopFailureError();
+            throw std::runtime_error("inet_ntop_failed"); // Should not occur
         }
         if (p->ai_family == AF_INET) {
             answer.ipv4 = abuf;
@@ -106,11 +106,7 @@ void getaddrinfo_async(std::string name, addrinfo hints, SharedPtr<Reactor> reac
                       name.c_str(), error.code, error.what());
         std::vector<Answer> answers;
         if (!error && rp != nullptr) {
-            try {
-                answers = getaddrinfo_async_parse_response<inet_ntop>(name, rp);
-            } catch (const Error &err) {
-                error = std::move(err);
-            }
+            answers = getaddrinfo_async_parse_response<inet_ntop>(name, rp);
         }
         if (rp != nullptr) {
             freeaddrinfo(rp);

--- a/src/libmeasurement_kit/dns/getaddrinfo_async.hpp
+++ b/src/libmeasurement_kit/dns/getaddrinfo_async.hpp
@@ -7,6 +7,8 @@
 #include "src/libmeasurement_kit/dns/utils.hpp"
 #include <measurement_kit/dns.hpp>
 
+#include <assert.h>
+
 namespace mk {
 namespace dns {
 
@@ -80,7 +82,7 @@ ErrorOr<std::vector<Answer>> getaddrinfo_async_parse_response(
         } else if (p->ai_family == AF_INET6) {
             answer.ipv6 = abuf;
         } else {
-            throw std::runtime_error("case_excluded_above");
+            assert(false); // case excluded above, cannot happen
         }
         answers.push_back(answer);
     }

--- a/test/common/utils.cpp
+++ b/test/common/utils.cpp
@@ -14,7 +14,8 @@ TEST_CASE("We are NOT using the default random seed") {
 }
 
 TEST_CASE("random_within_charset() works with zero length string") {
-    REQUIRE_THROWS_AS(mk::random_within_charset("", 16), mk::ValueError);
+    REQUIRE_THROWS_AS(mk::random_within_charset("", 16),
+                      const std::runtime_error &);
 }
 
 TEST_CASE("random_within_charset() uses all the available charset") {

--- a/test/dns/system_resolver.cpp
+++ b/test/dns/system_resolver.cpp
@@ -46,10 +46,11 @@ TEST_CASE("the system resolver can handle a getaddrinfo error") {
 #ifdef ENABLE_INTEGRATION_TESTS
 
 TEST_CASE("the system resolver can handle a inet_ntop error") {
-    REQUIRE_THROWS_AS(
-        (run_system_resolver<getaddrinfo, fail_inet_ntop>(
-            "IN", "A", "neubot.org", [](Error, SharedPtr<Message>) {})),
-        const std::runtime_error &);
+    run_system_resolver<getaddrinfo, fail_inet_ntop>(
+            "IN", "A", "neubot.org", [](Error e, SharedPtr<Message>) {
+                REQUIRE(e == GenericError());
+                REQUIRE(e.reason == "generic_error: inet_ntop_failed");
+            });
 }
 
 #endif

--- a/test/dns/system_resolver.cpp
+++ b/test/dns/system_resolver.cpp
@@ -46,9 +46,10 @@ TEST_CASE("the system resolver can handle a getaddrinfo error") {
 #ifdef ENABLE_INTEGRATION_TESTS
 
 TEST_CASE("the system resolver can handle a inet_ntop error") {
-    run_system_resolver<getaddrinfo, fail_inet_ntop>(
-        "IN", "A", "neubot.org",
-        [](Error e, SharedPtr<Message>) { REQUIRE(e == InetNtopFailureError()); });
+    REQUIRE_THROWS_AS(
+        (run_system_resolver<getaddrinfo, fail_inet_ntop>(
+            "IN", "A", "neubot.org", [](Error, SharedPtr<Message>) {})),
+        const std::runtime_error &);
 }
 
 #endif


### PR DESCRIPTION
This diff reduces the places where we throw `Error` below `include`. This is part of the work required to decouple `Error` and `std::exception`, as discussed with @pboothe in #1531.