### PR TITLE
Sketch out synchronous HTTP API

### DIFF
--- a/include/measurement_kit/http/http.hpp
+++ b/include/measurement_kit/http/http.hpp
@@ -173,6 +173,14 @@ void request(Settings, Headers, std::string, Callback<Error, SharedPtr<Response>
              SharedPtr<Reactor> = Reactor::global(), SharedPtr<Logger> = Logger::global(),
              SharedPtr<Response> previous = {}, int nredirects = 0);
 
+// TODO(bassosimone): I am wondering whether having an API where one creates
+// a request and receives back a response would be bad. The current API is
+// influenced by my state of mind when I thought that I could have C++11 work
+// like Node, but it seems it is not exactly the case :^).
+
+std::tuple<Error, Response> request_sync(Settings settings, Headers headers,
+        std::string body, SharedPtr<Logger> logger);
+
 inline void get(std::string url, Callback<Error, SharedPtr<Response>> cb,
                 Headers headers = {}, Settings settings = {},
                 SharedPtr<Reactor> reactor = Reactor::global(),

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -140,6 +140,27 @@ TEST_CASE("http::request works as expected") {
     });
 }
 
+TEST_CASE("http::request_sync works as expected") {
+    auto logger = Logger::make();
+    logger->set_verbosity(MK_LOG_DEBUG2);
+    auto tpl = request_sync(
+            {
+                    {"http/url", "http://a.http.th.ooni.io/"},
+                    {"http/method", "GET"},
+                    {"http/http_version", "HTTP/1.1"},
+            },
+            {
+                    {"Accept", "*/*"},
+            },
+            "", logger);
+    auto error = std::get<0>(tpl);
+    std::clog << error << std::endl;
+    auto response = std::get<1>(tpl);
+    REQUIRE(!error);
+    REQUIRE(response.status_code == 200);
+    REQUIRE(md5(response.body) == "5d2182cb241b5a9aefad8ce584831666");
+}
+
 TEST_CASE("http::request() works using HTTPS") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {


### PR DESCRIPTION
In recent discussions we realized that some parts of MK can be
synchronous, because they can also run in threads, since we are
not using thousands of connections, so threads will do.

This would easy contributing to MK and reviewing others' patches.

Since most of these parts deal with interactions with backend
servers, and since this interaction mostly involves HTTP, I
come to the conclusion that the lowest-effort path to improve
the situation is to allow for synchronous HTTP requests.

This diff adds a simple wrapper around the existing HTTP engine, so
we can use the current code also to make sync requests.