### PR TITLE
fix(nettests.hpp): repair JNI bindings

### DIFF
--- a/include/measurement_kit/nettests/nettests.hpp
+++ b/include/measurement_kit/nettests/nettests.hpp
@@ -25,6 +25,8 @@ class BaseTest {
 
     BaseTest &add_input(std::string);
 
+    BaseTest &set_input_filepath(std::string);
+
     BaseTest &add_input_filepath(std::string);
 
     BaseTest &set_output_filepath(std::string);

--- a/src/libmeasurement_kit/nettests/base_test.cpp
+++ b/src/libmeasurement_kit/nettests/base_test.cpp
@@ -54,6 +54,11 @@ BaseTest &BaseTest::add_input(std::string s) {
     return *this;
 }
 
+BaseTest &BaseTest::set_input_filepath(std::string s) {
+    runnable->input_filepaths.clear();
+    return add_input_filepath(s);
+}
+
 BaseTest &BaseTest::add_input_filepath(std::string s) {
     runnable->input_filepaths.push_back(s);
     return *this;


### PR DESCRIPTION
1. I deprecated and then removed this API to clean up

2. but actually this was used by JNI bindings

3. so, readd it

4. do not bother with deprecation because it only creates
   more annoyances when compiling Java bindings