### PR TITLE
build: sync built archs with master

### DIFF
--- a/build/android/dependency
+++ b/build/android/dependency
@@ -16,7 +16,7 @@ SPEC=$2
 echo ""
 echo "Cross-compiling $SPEC for all archs"
 
-ALL_ARCHS="armeabi armeabi-v7a arm64 mips mips64 x86 x86_64"
+ALL_ARCHS="armeabi-v7a arm64 x86 x86_64"
 
 for ARCH in $ALL_ARCHS; do
     echo ""

--- a/build/ios/dependency
+++ b/build/ios/dependency
@@ -16,7 +16,6 @@ echo "Cross-compiling $1 for all platforms and archs"
 $IOSDIR/cross iphonesimulator i386 $BUILDDIR/dependency $1
 $IOSDIR/cross iphonesimulator x86_64 $BUILDDIR/dependency $1
 
-$IOSDIR/cross iphoneos armv7 $BUILDDIR/dependency $1
 $IOSDIR/cross iphoneos armv7s $BUILDDIR/dependency $1
 $IOSDIR/cross iphoneos arm64 $BUILDDIR/dependency $1
 


### PR DESCRIPTION
In master we've agreed to reduce the number of architectures
for which we cross compile for Android and iOS.

Follow suit on stable. This can go in without explicit ACKs by
anyone since it's something we already agreed for.