### PR TITLE
Make cross building much simpler

### DIFF
--- a/script/build/c-ares
+++ b/script/build/c-ares
@@ -10,9 +10,8 @@ pkg_name=c-ares
 pkg_repository=https://github.com/c-ares/c-ares
 pkg_branch=cares-1_13_0
 
-pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}/${pkg_name}
-rm -rf ${pkg_dist_dir}
-mkdir -p ${pkg_dist_dir}
+pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}
+install -d ${pkg_dist_dir}
 
 pkg_build_dir=${pkg_topdir}/MK_BUILD/${pkg_os}/${pkg_arch}/${pkg_name}
 rm -rf ${pkg_build_dir}

--- a/script/build/geoip
+++ b/script/build/geoip
@@ -10,9 +10,8 @@ pkg_name=geoip
 pkg_repository=https://github.com/maxmind/geoip-api-c.git
 pkg_branch=v1.6.11
 
-pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}/${pkg_name}
-rm -rf ${pkg_dist_dir}
-mkdir -p ${pkg_dist_dir}
+pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}
+install -d ${pkg_dist_dir}
 
 pkg_build_dir=${pkg_topdir}/MK_BUILD/${pkg_os}/${pkg_arch}/${pkg_name}
 rm -rf ${pkg_build_dir}

--- a/script/build/libevent
+++ b/script/build/libevent
@@ -11,9 +11,8 @@ pkg_repository=https://github.com/libevent/libevent
 pkg_branch=patches-2.1
 pkg_expected_head=e7ff4ef2b4fc950a765008c18e74281cdb5e7668
 
-pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}/${pkg_name}
-rm -rf ${pkg_dist_dir}
-mkdir -p ${pkg_dist_dir}
+pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}
+install -d ${pkg_dist_dir}
 
 pkg_build_dir=${pkg_topdir}/MK_BUILD/${pkg_os}/${pkg_arch}/${pkg_name}
 rm -rf ${pkg_build_dir}
@@ -56,8 +55,8 @@ mkdir -p ${pkg_build_dir}
 
     ./autogen.sh
 
-    export CPPFLAGS="${CPPFLAGS} -I${pkg_dist_dir}/../libressl/include"
-    export LDFLAGS="${LDFLAGS} -L${pkg_dist_dir}/../libressl/lib"
+    export CPPFLAGS="${CPPFLAGS} -I${pkg_dist_dir}/include"
+    export LDFLAGS="${LDFLAGS} -L${pkg_dist_dir}/lib"
 
     ./configure --prefix=${pkg_dist_dir} --disable-shared  --disable-samples   \
             --disable-libevent-regress --disable-clock-gettime                 \

--- a/script/build/libressl
+++ b/script/build/libressl
@@ -27,7 +27,15 @@ mkdir -p ${pkg_build_dir}
     cd ${pkg_build_dir}
     wget ${pkg_tarball_url}
     tarball=$(basename ${pkg_tarball_url})
-    tarball_sha256sum=$(sha256sum ${tarball} | awk '{print $1}')
+    build_os=`uname`
+    if [ "${build_os}" = "Linux" ]; then
+        tarball_sha256sum=$(sha256sum ${tarball} | awk '{print $1}')
+    elif [ "${build_os}" = "Darwin" ]; then
+        tarball_sha256sum=$(shasum -a 256 ${tarball} | awk '{print $1}')
+    else
+        echo "FATAL: don't know how to compute sha256sum" 1>&2
+        exit 1
+    fi
     if [ "${tarball_sha256sum}" != "${pkg_sha256sum}" ]; then
         echo "FATAL: invalid SHA256 sum" 1>&2
         exit 1

--- a/script/build/libressl
+++ b/script/build/libressl
@@ -13,9 +13,8 @@ pkg_sha256sum="e57f5e3d5842a81fe9351b6e817fcaf0a749ca4ef35a91465edba9e071dce7c4"
 pkg_version=2.5.5
 pkg_tarball_url=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${pkg_version}.tar.gz
 
-pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}/${pkg_name}
-rm -rf ${pkg_dist_dir}
-mkdir -p ${pkg_dist_dir}
+pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}
+install -d ${pkg_dist_dir}
 
 pkg_build_dir=${pkg_topdir}/MK_BUILD/${pkg_os}/${pkg_arch}/${pkg_name}
 rm -rf ${pkg_build_dir}

--- a/script/build/mk
+++ b/script/build/mk
@@ -8,9 +8,8 @@ pkg_topdir=$(cd $(dirname $0)/../../ && pwd -P)
 
 pkg_name=measurement-kit
 
-pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}/${pkg_name}
-rm -rf ${pkg_dist_dir}
-mkdir -p ${pkg_dist_dir}
+pkg_dist_dir=${pkg_topdir}/MK_DIST/${pkg_os}/${pkg_arch}
+install -d ${pkg_dist_dir}
 
 pkg_build_dir=${pkg_topdir}/MK_BUILD/${pkg_os}/${pkg_arch}/${pkg_name}
 rm -rf ${pkg_build_dir}
@@ -33,9 +32,9 @@ mkdir -p ${pkg_build_dir}
     ../../../../configure --prefix=${pkg_dist_dir} --disable-shared           \
         --disable-examples                                                    \
         --disable-binaries                                                    \
-        --with-geoip=${pkg_dist_dir}/../geoip                                 \
-        --with-libevent=${pkg_dist_dir}/../libevent                           \
-        --with-openssl=${pkg_dist_dir}/../libressl                            \
+        --with-geoip=${pkg_dist_dir}                                          \
+        --with-libevent=${pkg_dist_dir}                                       \
+        --with-openssl=${pkg_dist_dir}                                        \
         ${pkg_configure_flags}
 
     make install


### PR DESCRIPTION
Put everything into the same directory. This is what existing script except. Rather than patching them to support a new style, better to use the previously existing convention.