### PR TITLE
Fix tests assuming an invalid DNS server would never reply

### DIFF
--- a/test/mlabns/mlabns.cpp
+++ b/test/mlabns/mlabns.cpp
@@ -29,12 +29,17 @@ TEST_CASE("Query works as expected") {
     });
 }
 
+// Honestly: not sure whether we really need this test. Anyway, since it was
+// failing for me on Vodafone (where the Vodafone station always replies to
+// DNS queries regardless of the hostname provided), fixed the test. For the
+// rationale of the low timeout see `test/ooni/templates.cpp`.
 TEST_CASE("Query can pass the settings to the dns level") {
     Settings settings;
     settings["mlabns/address_family"] = "ipv4";
     settings["mlabns/metro"] = "trn";
     settings["mlabns/policy"] = "random";
-    settings["dns/nameserver"] = "8.8.8.1";
+    settings["dns/nameserver"] = "8.8.8.8";
+    settings["dns/timeout"] = 0.0001;
     settings["dns/engine"] = "libevent";
     std::string tool = "neubot";
 

--- a/test/ooni/templates.cpp
+++ b/test/ooni/templates.cpp
@@ -64,7 +64,13 @@ TEST_CASE("dns query template works as expected") {
                         REQUIRE(answers.is_array());
                         reactor->stop();
                     },
-                    {{"dns/timeout", 0.3}, {"dns/attempts", 1},
+                    // Rationale: originally I assumed having an invalid DNS
+                    // would have been enough for this test to fail. But it
+                    // is a fact that many ISPs reply nonetheless. Among them
+                    // Vodafone, which is now my ISP. Hence I become much
+                    // more annoyed by this test being broken. Fix by using
+                    // an insanely low timeout so it should always fail.
+                    {{"dns/timeout", 0.0001}, {"dns/attempts", 1},
                      {"dns/engine", "libevent"}}, reactor);
             }, {{"dns/engine", "libevent"}}, reactor);
     });
@@ -222,7 +228,7 @@ TEST_CASE("Http template scrubs IP addresses") {
         SharedPtr<Reactor> reactor = Reactor::make();
         SharedPtr<Logger> logger = Logger::make();
         http_request_impl<mocked_request>(entry, settings, headers,
-                body, [entry, ip, cb](Error error, SharedPtr<http::Response>) {
+                body, [entry, cb](Error error, SharedPtr<http::Response>) {
                     REQUIRE(error == NoError());
                     cb(entry);
                 }, reactor, logger);


### PR DESCRIPTION
Two tests had this assumption. It's bogus. Especially from my house
where I have Vodafone that always replies to DNS.

Having some tests failing when I run tests locally is so bad.

Fix these instances by setting an unreasonable timeout so that we
basically verify that we deal with the failure.

(Rather than failing because we receive no reply with an invalid
DNS server, now we fail for the super-low timeout.)