### PR TITLE
Fix GeoIP crash with missing DB on Windows

### DIFF
--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -234,11 +234,17 @@ void Runnable::geoip_lookup(Callback<> cb) {
             auto country_path = options.get("geoip_country_path",
                                             std::string{});
             if (save_cc and country_path != "") {
-                try {
-                    probe_cc = *GeoipCache::thread_local_instance()
-                       ->resolve_country_code(country_path, ip, logger);
-                } catch (const Error &err) {
-                    logger->warn("cannot lookup country code: %s", err.what());
+                auto inst = GeoipCache::thread_local_instance();
+                if (!!inst) {
+                    auto rv = inst->resolve_country_code(
+                            country_path, ip, logger);
+                    if (!!rv) {
+                        probe_cc = rv.as_value();
+                    } else {
+                        // Error message already printed
+                    }
+                } else {
+                    logger->warn("cannot access GeoIP instance");
                 }
                 if (probe_cc != "ZZ") {
                     logger->info("Your country: %s", probe_cc.c_str());
@@ -249,11 +255,16 @@ void Runnable::geoip_lookup(Callback<> cb) {
 
             auto asn_path = options.get("geoip_asn_path", std::string{});
             if (save_asn and asn_path != "") {
-                try {
-                    probe_asn = *GeoipCache::thread_local_instance()
-                        ->resolve_asn(asn_path, ip, logger);
-                } catch (const Error &err) {
-                    logger->warn("cannot lookup asn: %s", err.what());
+                auto inst = GeoipCache::thread_local_instance();
+                if (!!inst) {
+                    auto rv = inst->resolve_asn(asn_path, ip, logger);
+                    if (!!rv) {
+                        probe_asn = rv.as_value();
+                    } else {
+                        // Error message already printed
+                    }
+                } else {
+                    logger->warn("cannot access GeoIP instance");
                 }
                 if (probe_asn != "AS0") {
                     logger->info("Your ISP identifier: %s", probe_asn.c_str());

--- a/src/libmeasurement_kit/ooni/utils.cpp
+++ b/src/libmeasurement_kit/ooni/utils.cpp
@@ -61,7 +61,7 @@ ErrorOr<std::string> GeoipDatabase::with_open_database_do(
         std::function<ErrorOr<std::string>()> action,
         SharedPtr<Logger> logger) {
     if (!db) {
-        db.reset(GeoIP_open(path.c_str(), GEOIP_MEMORY_CACHE),
+        db.reset(GeoIP_open(path.c_str(), GEOIP_MEMORY_CACHE|GEOIP_SILENCE),
                  [](GeoIP *pointer) {
                     if (pointer) {
                         GeoIP_delete(pointer);


### PR DESCRIPTION
Unclear what the real cause is. The failure seems to be related
with relying on exceptions to report the Error.

(I tried to define a virtual destructor for Error and all the
derived class, but that did not help.)

Cherry-picked from #1535 