### PR TITLE
acinclude.m4 configure.ac: fixes to compile with mingw-w64-cxx11

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -77,10 +77,14 @@ AC_DEFUN([MK_AM_LIBEVENT], [
   AC_CHECK_HEADERS(event2/event.h, [], [mk_not_found=1])
   AC_CHECK_LIB(event, event_new, [], [mk_not_found=1])
   AC_CHECK_HEADERS(event2/thread.h, [], [mk_not_found=1])
-  if test "`uname -s`" != "MINGW64_NT-10.0"; then
-    dnl Of course pthreads are not available under Windows.
-    AC_CHECK_LIB(event_pthreads, evthread_use_pthreads, [], [mk_not_found=1])
-  fi
+  case $host in
+    *-w64-mingw32)
+      # nothing
+    ;;
+    *)
+      AC_CHECK_LIB(event_pthreads, evthread_use_pthreads, [], [mk_not_found=1])
+    ;;
+  esac
   AC_CHECK_LIB(event_openssl, bufferevent_openssl_filter_new, [],
                [mk_not_found=1])
 
@@ -141,13 +145,7 @@ AC_DEFUN([MK_AM_OPENSSL], [
   mk_not_found=""
   AC_CHECK_HEADERS(openssl/ssl.h, [], [mk_not_found=1])
   AC_CHECK_LIB(crypto, RSA_new, [], [mk_not_found=1])
-  dnl TODO(bassosimone): understand why the following is required on
-  dnl the Msys system for the AC_CHECK_LIB check to actually work.
-  if test "`uname -s`" = "MINGW64_NT-10.0"; then
-    AC_CHECK_LIB(ssl, SSL_new, [], [mk_not_found=1], [-lcrypto])
-  else
-    AC_CHECK_LIB(ssl, SSL_new, [], [mk_not_found=1])
-  fi
+  AC_CHECK_LIB(ssl, SSL_new, [], [mk_not_found=1])
 
   dnl This test breaks the build with 12.04 on travis because the linker there
   dnl requires `LD_RUN_PATH` which sadly is not honoured by this test, still

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,28 @@ AM_CONDITIONAL([BUILD_TESTS], [test "yes" = "yes"])  # for now, build always
 AC_CANONICAL_HOST
 AC_PROG_INSTALL
 
+case "$host" in
+  *-apple-darwin*)
+    if test "$cross_compiling" != yes; then
+      # On my macOS, /usr/local is not added automatically
+      CPPFLAGS="$CPPFLAGS -I/usr/local/include"
+      LDFLAGS="$LDFLAGS -L/usr/local/lib"
+    fi
+  ;;
+  *-w64-mingw32)
+    # Must link with ws2_32
+    LIBS="$LIBS -lws2_32"
+    # Required to expose inet_pton()
+    CPPFLAGS="$CPPFLAGS -D_WIN32_WINNT=0x0600"
+  ;;
+  *)
+    # Must set -pthread before testing for -levent_pthreads
+    CFLAGS="$CFLAGS -pthread"
+    CXXFLAGS="$CXXFLAGS -pthread"
+    LDFLAGS="$LDFLAGS -pthread"
+  ;;
+esac
+
 # Must be before AC_PROG_CXX (see http://stackoverflow.com/questions/11703709)
 MK_AM_ENABLE_COVERAGE
 MK_AM_ADD_COVERAGE_FLAGS_IF_NEEDED
@@ -32,24 +54,6 @@ MK_AM_DISABLE_TRACEROUTE
 
 # See above comment
 AC_PROG_CXX
-
-if test "`uname`" != "Darwin"; then
-  # Must set -pthread before testing for -levent_pthreads
-  CFLAGS="$CFLAGS -pthread"
-  CXXFLAGS="$CXXFLAGS -pthread"
-  LDFLAGS="$LDFLAGS -pthread"
-elif test "$cross_compiling" != yes; then
-  # On my macOS, /usr/local is not added automatically
-  CPPFLAGS="$CPPFLAGS -I/usr/local/include"
-  LDFLAGS="$LDFLAGS -L/usr/local/lib"
-fi
-
-if test "`uname -s`" = "MINGW64_NT-10.0"; then
-  # Must link with ws2_32
-  LIBS="$LIBS -lws2_32"
-  # Required to expose inet_pton()
-  CPPFLAGS="$CPPFLAGS -D_WIN32_WINNT=0x0600"
-fi
 
 MK_AM_CHECK_LIBC_FUNCS
 MK_AM_OPENSSL


### PR DESCRIPTION
With these fixes committed, the code works with the cross toolchain
having C++11 support that I recently compiled for macOS.