### PR TITLE
test/nettests: use new collector implementation

### DIFF
--- a/.ci/docker/cmake
+++ b/.ci/docker/cmake
@@ -32,4 +32,4 @@ tc qdisc add dev eth0 root netem delay 200ms 10ms  # Slow down
 ./autogen.sh --cmake
 ./script/cmake/run -GNinja $CMAKE_OPTIONS
 ninja -v
-ctest -j6 --output-on-failure
+ctest -j6 --output-on-failure --timeout 300

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -34,7 +34,7 @@ template <typename T> void with_test(with_test_cb &&lambda) {
                 // TODO(bassosimone): switch to production collector when
                 // the new implementation is confirmed to be okay.
                 .set_option("collector_base_url",
-                            "https://collector-sandbox.ooni.io/")
+                            "https://collector-sandbox.ooni.io")
                 .set_option("bouncer_base_url",
                              mk::ooni::bouncer::production_bouncer_url()));
     /*
@@ -59,7 +59,7 @@ with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
     test.annotations["continuous_integration"] = "true";
     // TODO(bassosimone): see above comment regarding collector and bouncer
-    test.options["collector_base_url"] = "https://collector-sandbox.ooni.io/";
+    test.options["collector_base_url"] = "https://collector-sandbox.ooni.io";
     test.options["bouncer_base_url"] =
           mk::ooni::bouncer::production_bouncer_url();
     /*

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -57,7 +57,7 @@ template <typename T> void with_test(std::string s, with_test_cb &&lambda) {
 static inline void
 with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
-    test.add_annotation("continuous_integration", "true");
+    test.annotations["continuous_integration"] = "true";
     // TODO(bassosimone): see above comment regarding collector and bouncer
     test.options["collector_base_url"] = "https://collector-sandbox.ooni.io/";
     test.options["bouncer_base_url"] =

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -27,14 +27,14 @@ static inline void run_test(mk::nettests::BaseTest &test) {
 template <typename T> void with_test(with_test_cb &&lambda) {
     lambda(
           T{}.set_option("geoip_country_path", "GeoIP.dat")
+                .add_annotation("continuous_integration", "true")
                 .set_option("geoip_asn_path", "GeoIPASNum.dat")
                 .set_verbosity(MK_LOG_INFO)
-                /*
-                 * FIXME: the testing bouncer is not working. So use the testing
-                 * collector with the production bouncer.
-                 */
+                // Using the new collector for testing purposes.
+                // TODO(bassosimone): switch to production collector when
+                // the new implementation is confirmed to be okay.
                 .set_option("collector_base_url",
-                             mk::ooni::collector::testing_collector_url())
+                            "https://collector-sandbox.ooni.io/")
                 .set_option("bouncer_base_url",
                              mk::ooni::bouncer::production_bouncer_url()));
     /*
@@ -57,9 +57,9 @@ template <typename T> void with_test(std::string s, with_test_cb &&lambda) {
 static inline void
 with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
-    // FIXME: see above comment regarding collector and bouncer
-    test.options["collector_base_url"] =
-          mk::ooni::collector::testing_collector_url();
+    test.add_annotation("continuous_integration", "true");
+    // TODO(bassosimone): see above comment regarding collector and bouncer
+    test.options["collector_base_url"] = "https://collector-sandbox.ooni.io/";
     test.options["bouncer_base_url"] =
           mk::ooni::bouncer::production_bouncer_url();
     /*


### PR DESCRIPTION
While there, be prepared for using the production infrastructure for CI, by adding specific annotations to CI-run tests. (See below.)

cc: @hellais 

Closes #1307. Specifically, rather than using the testing infrastructure, this PR adds an annotation to tests run using the production infrastructure. This, as mentioned above, is in preparation of using the whole production infrastructure, but currently this PR also points to the collector to the new collector implementation, which is currently not production.