### PR TITLE
fix logging: make sure we base64 non-UTF-8 bodies

### DIFF
--- a/src/libmeasurement_kit/common/encoding.cpp
+++ b/src/libmeasurement_kit/common/encoding.cpp
@@ -23,4 +23,11 @@ std::string base64_encode(std::string str) {
   return mkdata_moveout_base64(d);
 }
 
+std::string base64_encode_if_needed(std::string str) {
+  if (utf8_parse(str) != NoError()) {
+    return base64_encode(std::move(str));
+  }
+  return str;
+}
+
 } // namespace mk

--- a/src/libmeasurement_kit/common/encoding.hpp
+++ b/src/libmeasurement_kit/common/encoding.hpp
@@ -13,5 +13,7 @@ Error utf8_parse(const std::string &str);
 
 std::string base64_encode(std::string str);
 
+std::string base64_encode_if_needed(std::string str);
+
 } // namespace mk
 #endif

--- a/src/libmeasurement_kit/http/request.cpp
+++ b/src/libmeasurement_kit/http/request.cpp
@@ -3,6 +3,7 @@
 // and LICENSE for more information on the copying conditions.
 
 #include "src/libmeasurement_kit/http/request_impl.hpp"
+#include "src/libmeasurement_kit/common/encoding.hpp"
 #include "src/libmeasurement_kit/common/utils.hpp"
 #include "src/libmeasurement_kit/net/error.hpp"
 
@@ -89,7 +90,7 @@ void Request::serialize(net::Buffer &buff, SharedPtr<Logger> logger) {
     }
     logger->debug(">");
     if (body != "") {
-        logger->debug2("%s", body.c_str());
+        logger->debug2("%s", base64_encode_if_needed(body).c_str());
         buff << body;
     }
 }
@@ -190,7 +191,8 @@ static void request_recv_response_start(SharedPtr<RequestRecvResponse> ctx) {
     ctx->parser->on_end([ctx]() {
         ctx->reached_end = true;
         if (ctx->response->body.size() > 0) {
-            ctx->logger->debug2("%s", ctx->response->body.c_str());
+            ctx->logger->debug2("%s", base64_encode_if_needed(
+                  ctx->response->body).c_str());
         }
     });
 

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -373,6 +373,11 @@ static void control_request(http::Headers headers_to_pass_along,
     request["http_request"] = url;
     // XXX in OONI headers are like `key: [value,...]` whereas in MK
     // they are like `key: value`. Adapt to OONI format.
+    //
+    // BTW this is an interesting data point because it tells us that
+    // in some bits of the OONI data format we represented headers using
+    // correct format (i.e. a list) wheareas in other places we did it
+    // wrong (i.e. we used a map from string to string).
     nlohmann::json true_headers;
     for (auto h: headers_to_pass_along) {
         true_headers[h.key].push_back(h.value);
@@ -389,7 +394,7 @@ static void control_request(http::Headers headers_to_pass_along,
     }
 
     logger->info("Using backend %s", settings["backend"].c_str());
-    logger->debug2("Body %s", body.c_str());
+    logger->debug2("Body %s", body.c_str());  // safe because serialised JSON
 
     mk::dump_settings(settings, "web_connectivity", logger);
 


### PR DESCRIPTION
We recently enabled LOG_DEBUG2 when running OONI mobile in debug
mode. However, we also recently changed the code to emit logs using
the JSON format. As a consequence, we need to properly quote the
emitted body, when it is not UTF-8, otherwise the JSON library will
crash when trying to serialise the log event.

FWIW, the new HTTP code (https://github.com/measurement-kit/mkcurl)
has an API that explicitly forces you to reason about the body being
possibly binary. When we wrote the code that currently is inside of
MK, we did not consider this risk of logging a binary body because we
were just writing strings on a C++ stream. When we switched to a model
where log events were JSON, we did not consider this issue.

Closes #1699.