### PR TITLE
web_connectivity: revert testing also http with https URL

### DIFF
--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -45,10 +45,6 @@ void Runnable::main(std::string, Settings, Callback<SharedPtr<nlohmann::json>> c
 }
 void Runnable::fixup_entry(nlohmann::json &) {}
 
-std::deque<std::string> Runnable::fixup_inputs(std::deque<std::string> &&il) {
-  return il;
-}
-
 void Runnable::run_next_measurement(size_t thread_id, Callback<Error> cb,
                                     size_t num_entries,
                                     SharedPtr<size_t> current_entry) {
@@ -470,7 +466,6 @@ void Runnable::begin(Callback<Error> cb) {
                             cb(error);
                             return;
                         }
-                        inputs = fixup_inputs(std::move(inputs));
                         size_t num_entries = inputs.size();
 
                         // Run `parallelism` measurements in parallel

--- a/src/libmeasurement_kit/nettests/runnable.hpp
+++ b/src/libmeasurement_kit/nettests/runnable.hpp
@@ -56,7 +56,6 @@ class Runnable : public NonCopyable, public NonMovable {
     virtual void teardown(std::string);
     virtual void main(std::string, Settings, Callback<SharedPtr<nlohmann::json>>);
     virtual void fixup_entry(nlohmann::json &);
-    virtual std::deque<std::string> fixup_inputs(std::deque<std::string> &&);
 
     // Functions that derived classes should access
     std::list<std::string> test_helpers_option_names();
@@ -103,7 +102,6 @@ class WebConnectivityRunnable : public Runnable {
     void main(
             std::string, Settings, Callback<SharedPtr<nlohmann::json>>) override;
     void fixup_entry(nlohmann::json &) override;
-    std::deque<std::string> fixup_inputs(std::deque<std::string> &&) override;
 };
 
 } // namespace nettests

--- a/src/libmeasurement_kit/nettests/web_connectivity.cpp
+++ b/src/libmeasurement_kit/nettests/web_connectivity.cpp
@@ -43,33 +43,5 @@ void WebConnectivityRunnable::fixup_entry(nlohmann::json &entry) {
     }
 }
 
-std::deque<std::string>
-WebConnectivityRunnable::fixup_inputs(std::deque<std::string> &&il) {
-    std::deque<std::string> rv;
-    while (!il.empty()) {
-        std::string original_url;
-        std::swap(original_url, il.front());
-        il.pop_front();
-        ErrorOr<http::Url> maybe_url = http::parse_url_noexcept(original_url);
-        if (maybe_url.as_error() != NoError()) {
-            // Incorrect URL. WebConnectivity will complain for us later.
-            rv.push_back(std::move(original_url));
-            continue;
-        }
-        if (maybe_url->schema == "https" && maybe_url->port == 443) {
-            // "Test both http and https versions of a website" #1560
-            http::Url httpURL = *maybe_url;
-            httpURL.schema = "http";
-            httpURL.port = 80;
-            rv.push_back(httpURL.str());
-            // FALLTHROUGH
-        }
-        // return to the app the original URL rather than a possibly
-        // canonicalised version of it; see #1685.
-        rv.push_back(original_url);
-    }
-    return rv;
-}
-
 } // namespace nettests
 } // namespace mk


### PR DESCRIPTION
Today, I discussed this issue further with @lorenzoPrimi and it
seems we're both not convinced that this is a desirable functionality
to have in OONI mobile v2.0, because, basically, the app is really
not designed to work like this.

The most compelling argument that @lorenzoPrimi brought, in my
opinion, is how to correctly estimate the elapsed time in light
of the fact that more URLs are tested.

While I can see many hackish ways to implement this, I also believe
it's not the job of MK to perform this sort of magic without the apps
knowing it. I'd rather implement in MK a function that takes a list
of URL in input and emits a normalised/expanded list in output.

This is the reason why I'm removing the existing code, rather than
just disabling it. We should discuss more and come out with a proper
solution, which is probably not changing the URLs like we do now.

Related to #1685.