### PR TITLE
fix(s/l/o/templates.cpp): pass proper logger to dns::query

### DIFF
--- a/src/libmeasurement_kit/ooni/templates.cpp
+++ b/src/libmeasurement_kit/ooni/templates.cpp
@@ -93,7 +93,7 @@ void dns_query(SharedPtr<nlohmann::json> entry, dns::QueryType query_type,
                    cb(error, message);
                    logger->debug("dns_test: callback called");
                },
-               options, reactor);
+               options, reactor, logger);
 }
 
 void http_request(SharedPtr<nlohmann::json> entry, Settings settings, http::Headers headers,


### PR DESCRIPTION
This appears to be the main culprit of #1739. However, TBH, this
is not a complete fix, because the proper fix would be to (1) make
sure we don't have default arguments anywhere and (2) make sure
we don't have singletons anywhere and (3) understand what was the
condition under which a singleton was moved and where.

However, this is a good first step. My plan, in going forward,
is to apply this diff also to stable, tag v0.9.3, and then
work on (1), (2), and (3) inside the master branch.