### PR TITLE
Release v0.9.3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,6 +4,6 @@ INPUT = include/measurement_kit/ffi.h
 JAVADOC_AUTOBRIEF = YES
 PROJECT_BRIEF = "Portable C++14 network measurement library"
 PROJECT_NAME = measurement-kit
-PROJECT_NUMBER = v0.9.2
+PROJECT_NUMBER = v0.9.3
 RECURSIVE = NO
 STRIP_FROM_INC_PATH = include

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(measurement_kit, 0.9.2, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.9.3, bassosimone@gmail.com)
 
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.9.2"
+#define MK_VERSION "0.9.3"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION
@@ -23,7 +23,7 @@
 // as part of the `./autogen.sh` script that prepares a source tarball. If we
 // cannot run `git` because we're not in a git repository, then we set this
 // variable equal to MK_VERSION.
-#define MK_VERSION_FULL "v0.9.2"
+#define MK_VERSION_FULL "v0.9.3"
 
 // MK_VERSION_MAJOR is the major version number extracted from MK_VERSION_FULL.
 #define MK_VERSION_MAJOR 0
@@ -32,7 +32,7 @@
 #define MK_VERSION_MINOR 9
 
 // MK_VERSION_PATCH is the patch version number extracted from MK_VERSION_FULL.
-#define MK_VERSION_PATCH 2
+#define MK_VERSION_PATCH 3
 
 // MK_VERSION_STABLE is 1 if this is a stable release, 0 otherwise.
 #define MK_VERSION_STABLE 1
@@ -47,7 +47,7 @@
 //       ^^^     ^^^     ^^^     ^^^
 //      major   minor   patch   stable
 // ```
-#define MK_VERSION_NUMERIC 0x00000000009000021LL
+#define MK_VERSION_NUMERIC 0x00000000009000031LL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/measurement_kit/common/version.h.in
+++ b/include/measurement_kit/common/version.h.in
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.9.2"
+#define MK_VERSION "0.9.3"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION

--- a/script/update-includes
+++ b/script/update-includes
@@ -4,7 +4,7 @@ set -e
 
 gen_automatic_includes() {
 
-    vfull=`git describe --tags 2>/dev/null |echo v0.9.2`
+    vfull=`git describe --tags 2>/dev/null |echo v0.9.3`
     vmajor=`echo $vfull|sed 's/^v//g'|awk -F. '{print $1}'`
     vminor=`echo $vfull|awk -F. '{print $2}'`
     vpatch=`echo $vfull|sed 's/-.*//g'|awk -F. '{print $3}'`

--- a/src/libmeasurement_kit/ooni/templates.cpp
+++ b/src/libmeasurement_kit/ooni/templates.cpp
@@ -93,7 +93,7 @@ void dns_query(SharedPtr<nlohmann::json> entry, dns::QueryType query_type,
                    cb(error, message);
                    logger->debug("dns_test: callback called");
                },
-               options, reactor);
+               options, reactor, logger);
 }
 
 void http_request(SharedPtr<nlohmann::json> entry, Settings settings, http::Headers headers,

--- a/src/measurement_kit/main.cpp
+++ b/src/measurement_kit/main.cpp
@@ -23,6 +23,11 @@ static const struct {
 #undef XX
 };
 
+#define OPTID_HELP 256
+#define OPTID_VERSION 257
+#define OPTID_NO_BOUNCER 258
+#define OPTID_CA_BUNDLE_PATH 259
+
 static OptionSpec kv_specs[] = {
     {'A', "annotation", true, "key=value", "Add annotation"},
     {'b', "bouncer", true, "URL", "Set custom bouncer base URL"},
@@ -34,9 +39,10 @@ static OptionSpec kv_specs[] = {
     {'o', "reportfile", true, "PATH", "Set custom report file PATH"},
     {'s', "list", false, nullptr, "List available nettests"},
     {'v', "verbose", false, nullptr, "Increase verbosity"},
-    {256, "help", false, nullptr, "Display this help and exit"},
-    {257, "version", false, nullptr, "Display version number and exit"},
-    {258, "no-bouncer", false, nullptr, "Disable the bouncer"},
+    {OPTID_CA_BUNDLE_PATH, "ca-bundle-path", true, "PATH", "Set custom CA bundle"},
+    {OPTID_HELP, "help", false, nullptr, "Display this help and exit"},
+    {OPTID_NO_BOUNCER, "no-bouncer", false, nullptr, "Disable the bouncer"},
+    {OPTID_VERSION, "version", false, nullptr, "Display version number and exit"},
     {0, nullptr, 0, 0, nullptr}
 };
 
@@ -139,17 +145,25 @@ int main(int argc, char **argv) {
             initializers.push_back(
                 [](BaseTest &test) { test.increase_verbosity(); });
             break;
-        case 256:
+        case OPTID_HELP:
             return usage(0, stdout);
-        case 257:
+        case OPTID_VERSION:
             printf("measurement_kit version: %s (%s)\n", mk_version(),
                    mk_version_full());
             printf("libevent version: %s\n", mk_libevent_version());
             printf("OpenSSL version: %s\n", mk_openssl_version());
             return 0;
-        case 258:
+        case OPTID_NO_BOUNCER:
             initializers.push_back(
                 [](BaseTest &test) { test.set_option("no_bouncer", 1); });
+            break;
+        case OPTID_CA_BUNDLE_PATH:
+            {
+                std::string s = optarg;
+                initializers.push_back(
+                    [s](BaseTest &test) {
+                      test.set_option("net/ca_bundle_path", s.c_str()); });
+            }
             break;
         default:
             return usage(1, stderr);


### PR DESCRIPTION
[This backports f1ff62786f8e80b869ebad3fee5e1235b9654b7d from the master branch to stable. Original log follows:]

> This appears to be the main culprit of #1739. However, TBH, this
> is not a complete fix, because the proper fix would be to (1) make
> sure we don't have default arguments anywhere and (2) make sure
> we don't have singletons anywhere and (3) understand what was the
> condition under which a singleton was moved and where.
>
> However, this is a good first step. My plan, in going forward,
> is to apply this diff also to stable, tag v0.9.3, and then
> work on (1), (2), and (3) inside the master branch.

Also, this exposes the `--ca-bundle-path` flag (see #1737)