### PR TITLE
Remove easy-to-remove singletons and default arguments

### DIFF
--- a/include/measurement_kit/common/logger.hpp
+++ b/include/measurement_kit/common/logger.hpp
@@ -78,9 +78,6 @@ class Logger {
     /// `make()` creates an instance of the default logger.
     static SharedPtr<Logger> make();
 
-    /// `global()` returns the global instance of the default logger.
-    static SharedPtr<Logger> global();
-
     /// \brief `logv()` writes a log message. \param mask is a mask of the
     /// verbosity level (e.g. MK_LOG_DEBUG) and possibly other
     /// specifiers (e.g. MK_LOG_EVENT). \param fmt is the format
@@ -222,44 +219,6 @@ class Logger {
     /// `~Logger()` destroys allocated resources.
     virtual ~Logger();
 };
-
-/// `log()` call the Logger::log() method of the global logger.
-void log(uint32_t, const char *, ...) __attribute__((format(printf, 2, 3)));
-
-/// `err()` call the Logger::err() method of the global logger.
-void err(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-/// `warn()` call the Logger::warn() method of the global logger.
-void warn(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-/// `info()` call the Logger::info() method of the global logger.
-void info(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-/// `debug()` call the Logger::debug() method of the global logger.
-void debug(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-/// `debug2()` call the Logger::debug2() method of the global logger.
-void debug2(const char *, ...) __attribute__((format(printf, 1, 2)));
-
-/// \brief `set_verbosity()` call the Logger::set_verbosity() method of the
-/// global logger.
-void set_verbosity(uint32_t v);
-
-/// \brief `increase_verbosity()` call the Logger::increase_verbosity()
-/// method of the global logger.
-void increase_verbosity();
-
-/// \brief `get_verbosity()` call the Logger::get_verbosity()
-/// method of the global logger.
-uint32_t get_verbosity();
-
-/// \brief `on_log()` call the Logger::on_log()
-/// method of the global logger.
-void on_log(Callback<uint32_t, const char *> &&fn);
-
-/// \brief `set_logfile()` call the Logger::set_logfile()
-/// method of the global logger.
-void set_logfile(std::string path);
 
 } // namespace mk
 

--- a/src/libmeasurement_kit/common/libevent_reactor.hpp
+++ b/src/libmeasurement_kit/common/libevent_reactor.hpp
@@ -72,7 +72,6 @@ class LibeventReactor : public Reactor, public NonCopyable, public NonMovable {
             if (initialized) {
                 return;
             }
-            mk::debug("initializing libevent once");
             if (evthread_init() != 0) {
                 throw std::runtime_error("evthread_init");
             }

--- a/src/libmeasurement_kit/common/logger.cpp
+++ b/src/libmeasurement_kit/common/logger.cpp
@@ -290,38 +290,7 @@ class DefaultLogger : public Logger, public NonCopyable, public NonMovable {
     return SharedPtr<Logger>{std::make_shared<DefaultLogger>()};
 }
 
-/*static*/ SharedPtr<Logger> Logger::global() {
-    return locked_global([]() {
-        static SharedPtr<Logger> singleton = Logger::make();
-        return singleton;
-    });
-}
-
 Logger::~Logger() {}
-
-void log(uint32_t level, const char *fmt, ...) { XX(Logger::global(), level); }
-
-void err(const char *fmt, ...) { XX(Logger::global(), MK_LOG_ERR); }
-
-void warn(const char *fmt, ...) { XX(Logger::global(), MK_LOG_WARNING); }
-
-void info(const char *fmt, ...) { XX(Logger::global(), MK_LOG_INFO); }
-
-void debug(const char *fmt, ...) { XX(Logger::global(), MK_LOG_DEBUG); }
-
-void debug2(const char *fmt, ...) { XX(Logger::global(), MK_LOG_DEBUG2); }
-
-void set_verbosity(uint32_t v) { Logger::global()->set_verbosity(v); }
-
-void increase_verbosity() { Logger::global()->increase_verbosity(); }
-
-uint32_t get_verbosity() { return Logger::global()->get_verbosity(); }
-
-void on_log(Callback<uint32_t, const char *> &&fn) {
-    Logger::global()->on_log(std::move(fn));
-}
-
-void set_logfile(std::string path) { Logger::global()->set_logfile(path); }
 
 #undef XX
 

--- a/src/libmeasurement_kit/common/reactor.cpp
+++ b/src/libmeasurement_kit/common/reactor.cpp
@@ -18,11 +18,4 @@ void Reactor::run_with_initial_event(Callback<> &&cb) {
     run();
 }
 
-/*static*/ SharedPtr<Reactor> Reactor::global() {
-    return locked_global([]() {
-        static SharedPtr<Reactor> singleton = make();
-        return singleton;
-    });
-}
-
 } // namespace mk

--- a/src/libmeasurement_kit/common/reactor.hpp
+++ b/src/libmeasurement_kit/common/reactor.hpp
@@ -44,9 +44,6 @@ class Reactor {
     /// to be thread safe _and_, on Unix, we ignore SIGPIPE.
     static SharedPtr<Reactor> make();
 
-    /// `global()` returns the global instance of the default Reactor.
-    static SharedPtr<Reactor> global();
-
     /// `~Reactor()` destroys any allocated resources.
     virtual ~Reactor();
 

--- a/src/libmeasurement_kit/dns/libevent_query.hpp
+++ b/src/libmeasurement_kit/dns/libevent_query.hpp
@@ -120,12 +120,12 @@ class QueryContext : public NonMovable, public NonCopyable {
     SharedPtr<Message> message;
     Callback<Error, SharedPtr<Message>> callback;
 
-    SharedPtr<Logger> logger = Logger::global();
-    SharedPtr<Reactor> reactor = Reactor::global();
+    SharedPtr<Logger> logger;
+    SharedPtr<Reactor> reactor;
 
     QueryContext(evdns_base *b, Callback<Error, SharedPtr<Message>> c,
-            SharedPtr<Message> m, SharedPtr<Logger> l = Logger::global(),
-            SharedPtr<Reactor> r = Reactor::global()) {
+            SharedPtr<Message> m, SharedPtr<Logger> l,
+            SharedPtr<Reactor> r) {
         base = b;
         callback = c;
         message = m;
@@ -153,7 +153,7 @@ template <MK_MOCK(evdns_base_new), MK_MOCK(evdns_base_nameserver_sockaddr_add),
           typename evdns_base_uptr = evdns_base_uptr,
           MK_MOCK(evdns_base_set_option)>
 static inline evdns_base *
-create_evdns_base(Settings settings, SharedPtr<Reactor> reactor = Reactor::global()) {
+create_evdns_base(Settings settings, SharedPtr<Reactor> reactor) {
 
     event_base *evb = reactor->get_event_base();
     const int initialize_nameservers = settings.count("dns/nameserver") ? 0 : 1;
@@ -220,7 +220,7 @@ create_evdns_base(Settings settings, SharedPtr<Reactor> reactor = Reactor::globa
 template <MK_MOCK(inet_ntop)>
 static inline std::vector<Answer>
 build_answers_evdns(int code, char type, int count, int ttl, void *addresses,
-                    SharedPtr<Logger> logger = Logger::global()) {
+                    SharedPtr<Logger> logger) {
 
     std::vector<Answer> answers;
 

--- a/src/libmeasurement_kit/dns/query.hpp
+++ b/src/libmeasurement_kit/dns/query.hpp
@@ -55,9 +55,9 @@ void query(
         QueryType dns_type,
         std::string name,
         Callback<Error, SharedPtr<Message>> func,
-        Settings settings = {},
-        SharedPtr<Reactor> reactor = Reactor::global(),
-        SharedPtr<Logger> logger = Logger::global()
+        Settings settings,
+        SharedPtr<Reactor> reactor,
+        SharedPtr<Logger> logger
 );
 
 } // namespace dns

--- a/src/libmeasurement_kit/dns/resolve_hostname.hpp
+++ b/src/libmeasurement_kit/dns/resolve_hostname.hpp
@@ -25,9 +25,9 @@ class ResolveHostnameResult {
 
 void resolve_hostname(std::string hostname,
         Callback<ResolveHostnameResult> cb,
-        Settings settings = {},
-        SharedPtr<Reactor> reactor = Reactor::global(),
-        SharedPtr<Logger> logger = Logger::global());
+        Settings settings,
+        SharedPtr<Reactor> reactor,
+        SharedPtr<Logger> logger);
 
 } // namespace dns
 } // namespace mk

--- a/src/libmeasurement_kit/http/http.hpp
+++ b/src/libmeasurement_kit/http/http.hpp
@@ -133,7 +133,7 @@ class Request {
 
     Request() {}
     Error init(Settings, Headers, std::string);
-    void serialize(net::Buffer &, SharedPtr<Logger> logger = Logger::global());
+    void serialize(net::Buffer &, SharedPtr<Logger> logger);
 
     static ErrorOr<SharedPtr<Request>> make(Settings, Headers, std::string);
 };
@@ -153,8 +153,7 @@ struct Response {
 ErrorOr<Url> redirect(const Url &orig_url, const std::string &location);
 
 void request_connect(Settings, Callback<Error, SharedPtr<net::Transport>>,
-                     SharedPtr<Reactor> = Reactor::global(),
-                     SharedPtr<Logger> = Logger::global());
+                     SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void request_send(SharedPtr<net::Transport>, Settings, Headers, std::string,
                   SharedPtr<Logger>, Callback<Error, SharedPtr<Request>>);
@@ -164,20 +163,16 @@ void request_maybe_send(ErrorOr<SharedPtr<Request>>, SharedPtr<net::Transport>,
                         SharedPtr<Logger>, Callback<Error, SharedPtr<Request>>);
 
 void request_recv_response(SharedPtr<net::Transport>, Callback<Error, SharedPtr<Response>>,
-                           Settings = {}, SharedPtr<Reactor> = Reactor::global(),
-                           SharedPtr<Logger> = Logger::global());
+                           Settings, SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void request_sendrecv(SharedPtr<net::Transport>, Settings, Headers, std::string,
                       Callback<Error, SharedPtr<Response>>,
-                      SharedPtr<Reactor> = Reactor::global(),
-                      SharedPtr<Logger> = Logger::global());
+                      SharedPtr<Reactor>, SharedPtr<Logger>);
 
 // Same as above except that the optional Request is passed in explicitly
 void request_maybe_sendrecv(ErrorOr<SharedPtr<Request>>, SharedPtr<net::Transport>,
                             Callback<Error, SharedPtr<Response>>,
-                            Settings = {},
-                            SharedPtr<Reactor> = Reactor::global(),
-                            SharedPtr<Logger> = Logger::global());
+                            Settings, SharedPtr<Reactor>, SharedPtr<Logger>);
 
 /*
  * For settings the following options are defined:
@@ -193,13 +188,13 @@ void request_maybe_sendrecv(ErrorOr<SharedPtr<Request>>, SharedPtr<net::Transpor
  */
 
 void request(Settings, Headers, std::string, Callback<Error, SharedPtr<Response>>,
-             SharedPtr<Reactor> = Reactor::global(), SharedPtr<Logger> = Logger::global(),
+             SharedPtr<Reactor>, SharedPtr<Logger>,
              SharedPtr<Response> previous = {}, int nredirects = 0);
 
 inline void get(std::string url, Callback<Error, SharedPtr<Response>> cb,
-                Headers headers = {}, Settings settings = {},
-                SharedPtr<Reactor> reactor = Reactor::global(),
-                SharedPtr<Logger> lp = Logger::global(),
+                Headers headers, Settings settings,
+                SharedPtr<Reactor> reactor,
+                SharedPtr<Logger> lp,
                 SharedPtr<Response> previous = {},
                 int nredirects = 0) {
     settings["http/method"] = "GET";

--- a/src/libmeasurement_kit/http/request_impl.hpp
+++ b/src/libmeasurement_kit/http/request_impl.hpp
@@ -18,8 +18,8 @@ namespace http {
 
 template <MK_MOCK_AS(net::connect, net_connect)>
 void request_connect_impl(Settings settings, Callback<Error, SharedPtr<Transport>> cb,
-                          SharedPtr<Reactor> reactor = Reactor::global(),
-                          SharedPtr<Logger> logger = Logger::global()) {
+                          SharedPtr<Reactor> reactor,
+                          SharedPtr<Logger> logger) {
     if (settings.find("http/url") == settings.end()) {
         cb(MissingUrlError(), {});
         return;

--- a/src/libmeasurement_kit/http/response_parser.hpp
+++ b/src/libmeasurement_kit/http/response_parser.hpp
@@ -25,7 +25,7 @@ enum class HeaderParserState {
 
 class ResponseParserNg : public NonCopyable, public NonMovable {
   public:
-    ResponseParserNg(SharedPtr<Logger> = Logger::global());
+    ResponseParserNg(SharedPtr<Logger>);
 
     void on_begin(std::function<void()> fn) { begin_fn_ = fn; }
 
@@ -135,7 +135,7 @@ class ResponseParserNg : public NonCopyable, public NonMovable {
     Delegate<std::string> body_fn_;
     Delegate<> end_fn_;
 
-    SharedPtr<Logger> logger_ = Logger::global();
+    SharedPtr<Logger> logger_;
     http_parser parser_;
     http_parser_settings settings_;
     Buffer buffer_;

--- a/src/libmeasurement_kit/mlabns/mlabns.hpp
+++ b/src/libmeasurement_kit/mlabns/mlabns.hpp
@@ -30,8 +30,8 @@ class Reply {
 
 /// Query mlab-ns and receive response.
 void query(std::string tool, Callback<Error, Reply> callback,
-           Settings settings = {}, SharedPtr<Reactor> reactor = Reactor::global(),
-           SharedPtr<Logger> logger = Logger::global());
+           Settings settings, SharedPtr<Reactor> reactor,
+           SharedPtr<Logger> logger);
 
 } // namespace mlabns
 } // namespace mk

--- a/src/libmeasurement_kit/ndt/internal.hpp
+++ b/src/libmeasurement_kit/ndt/internal.hpp
@@ -120,9 +120,9 @@ struct Context {
     std::list<std::string> granted_suite;
     size_t granted_suite_count = 0;
     size_t current_test_count = 0;
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Logger> logger;
     int port = NDT_PORT;
-    SharedPtr<Reactor> reactor = Reactor::global();
+    SharedPtr<Reactor> reactor;
     Settings settings;
     // We always set these two tests because they are the bare minimum
     // required to talk to a NDT server. Other sets could be added as flags
@@ -145,11 +145,11 @@ struct Context {
 namespace messages {
 
 void read_ll(SharedPtr<Context> ctx, Callback<Error, uint8_t, std::string> callback,
-             SharedPtr<Reactor> reactor = Reactor::global());
+             SharedPtr<Reactor> reactor);
 void read_json(SharedPtr<Context> ctx, Callback<Error, uint8_t, nlohmann::json> callback,
-               SharedPtr<Reactor> reactor = Reactor::global());
+               SharedPtr<Reactor> reactor);
 void read_msg(SharedPtr<Context> ctx, Callback<Error, uint8_t, std::string> callback,
-              SharedPtr<Reactor> reactor = Reactor::global());
+              SharedPtr<Reactor> reactor);
 
 ErrorOr<Buffer> format_msg_extended_login(unsigned char tests);
 ErrorOr<Buffer> format_test_msg(std::string s);
@@ -198,9 +198,9 @@ void disconnect_and_callback(SharedPtr<Context> ctx, Error err);
 namespace test_c2s {
 
 void coroutine(SharedPtr<nlohmann::json>, std::string address, int port, double runtime,
-               Callback<Error, Continuation<Error>> cb, double timeout = 10.0,
-               Settings settings = {}, SharedPtr<Reactor> reactor = Reactor::global(),
-               SharedPtr<Logger> logger = Logger::global());
+               Callback<Error, Continuation<Error>> cb, double timeout,
+               Settings settings, SharedPtr<Reactor> reactor,
+               SharedPtr<Logger> logger);
 
 void run(SharedPtr<Context> ctx, Callback<Error> callback);
 
@@ -250,9 +250,9 @@ struct Params {
 
 void coroutine(SharedPtr<nlohmann::json> report_entry, std::string address, Params params,
                Callback<Error, Continuation<Error, double>> cb,
-               double timeout = 10.0, Settings settings = {},
-               SharedPtr<Reactor> reactor = Reactor::global(),
-               SharedPtr<Logger> logger = Logger::global());
+               double timeout, Settings settings,
+               SharedPtr<Reactor> reactor,
+               SharedPtr<Logger> logger);
 
 void finalizing_test(SharedPtr<Context> ctx, SharedPtr<nlohmann::json> cur_entry,
                      Callback<Error> callback);

--- a/src/libmeasurement_kit/ndt/internal.hpp
+++ b/src/libmeasurement_kit/ndt/internal.hpp
@@ -120,9 +120,9 @@ struct Context {
     std::list<std::string> granted_suite;
     size_t granted_suite_count = 0;
     size_t current_test_count = 0;
-    SharedPtr<Logger> logger;
+    SharedPtr<Logger> logger = Logger::make();
     int port = NDT_PORT;
-    SharedPtr<Reactor> reactor;
+    SharedPtr<Reactor> reactor = Reactor::make();
     Settings settings;
     // We always set these two tests because they are the bare minimum
     // required to talk to a NDT server. Other sets could be added as flags

--- a/src/libmeasurement_kit/ndt/run.hpp
+++ b/src/libmeasurement_kit/ndt/run.hpp
@@ -10,13 +10,12 @@ namespace mk {
 namespace ndt {
 
 void run_with_specific_server(SharedPtr<nlohmann::json> entry, std::string address, int port,
-                              Callback<Error> callback, Settings settings = {},
-                              SharedPtr<Reactor> reactor = Reactor::global(),
-                              SharedPtr<Logger> logger = Logger::global());
+                              Callback<Error> callback, Settings settings,
+                              SharedPtr<Reactor> reactor,
+                              SharedPtr<Logger> logger);
 
-void run(SharedPtr<nlohmann::json> entry, Callback<Error> callback, Settings settings = {},
-         SharedPtr<Reactor> reactor = Reactor::global(),
-         SharedPtr<Logger> logger = Logger::global());
+void run(SharedPtr<nlohmann::json> entry, Callback<Error> callback, Settings settings,
+         SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 } // namespace ndt
 } // namespace mk

--- a/src/libmeasurement_kit/net/connect.hpp
+++ b/src/libmeasurement_kit/net/connect.hpp
@@ -33,21 +33,19 @@ class ConnectResult {
 typedef std::function<void(std::vector<Error>, bufferevent *)> ConnectFirstOfCb;
 
 void connect_first_of(SharedPtr<ConnectResult> result, int port,
-                      ConnectFirstOfCb cb, Settings settings = {},
-                      SharedPtr<Reactor> reactor = Reactor::global(),
-                      SharedPtr<Logger> logger = Logger::global(), size_t index = 0,
+                      ConnectFirstOfCb cb, Settings settings,
+                      SharedPtr<Reactor> reactor,
+                      SharedPtr<Logger> logger, size_t index = 0,
                       SharedPtr<std::vector<Error>> errors = nullptr);
 
 void connect_logic(std::string hostname, int port,
                    Callback<Error, SharedPtr<ConnectResult>> cb,
-                   Settings settings = {},
-                   SharedPtr<Reactor> reactor = Reactor::global(),
-                   SharedPtr<Logger> logger = Logger::global());
+                   Settings settings, SharedPtr<Reactor> reactor,
+                   SharedPtr<Logger> logger);
 
 void connect_ssl(bufferevent *orig_bev, ssl_st *ssl, std::string hostname,
                  Callback<Error, bufferevent *> cb,
-                 SharedPtr<Reactor> = Reactor::global(),
-                 SharedPtr<Logger> = Logger::global());
+                 SharedPtr<Reactor>, SharedPtr<Logger>);
 
 using ConnectManyCb = Callback<Error, std::vector<SharedPtr<Transport>>>;
 
@@ -59,20 +57,20 @@ class ConnectManyCtx {
     std::string address;
     int port = 0;
     Settings settings;
-    SharedPtr<Reactor> reactor = Reactor::global();
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Reactor> reactor;
+    SharedPtr<Logger> logger;
 };
 
 void connect(std::string address, int port,
              Callback<Error, SharedPtr<Transport>> callback,
-             Settings settings = {},
-             SharedPtr<Reactor> reactor = Reactor::global(),
-             SharedPtr<Logger> logger = Logger::global());
+             Settings settings,
+             SharedPtr<Reactor> reactor,
+             SharedPtr<Logger> logger);
 
 void connect_many(std::string address, int port, int num,
-        ConnectManyCb callback, Settings settings = {},
-        SharedPtr<Reactor> reactor = Reactor::global(),
-        SharedPtr<Logger> logger = Logger::global());
+        ConnectManyCb callback, Settings settings,
+        SharedPtr<Reactor> reactor,
+        SharedPtr<Logger> logger);
 
 } // namespace mk
 } // namespace net

--- a/src/libmeasurement_kit/net/emitter.hpp
+++ b/src/libmeasurement_kit/net/emitter.hpp
@@ -243,8 +243,8 @@ class EmitterBase : public Transport {
 
   protected:
     // TODO: it would probably better to have accessors
-    SharedPtr<Reactor> reactor = Reactor::global();
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Reactor> reactor;
+    SharedPtr<Logger> logger;
     Buffer output_buff;
 
   private:

--- a/src/libmeasurement_kit/net/socks5.hpp
+++ b/src/libmeasurement_kit/net/socks5.hpp
@@ -50,14 +50,14 @@ class Socks5 : public Emitter {
     std::string proxy_port;
 };
 
-Buffer socks5_format_auth_request(SharedPtr<Logger> = Logger::global());
-ErrorOr<bool> socks5_parse_auth_response(Buffer &, SharedPtr<Logger> = Logger::global());
-ErrorOr<Buffer> socks5_format_connect_request(Settings, SharedPtr<Logger> = Logger::global());
-ErrorOr<bool> socks5_parse_connect_response(Buffer &, SharedPtr<Logger> = Logger::global());
+Buffer socks5_format_auth_request(SharedPtr<Logger>);
+ErrorOr<bool> socks5_parse_auth_response(Buffer &, SharedPtr<Logger>);
+ErrorOr<Buffer> socks5_format_connect_request(Settings, SharedPtr<Logger>);
+ErrorOr<bool> socks5_parse_connect_response(Buffer &, SharedPtr<Logger>);
 
 void socks5_connect(std::string address, int port, Settings settings,
         std::function<void(Error, SharedPtr<Transport>)> callback,
-        SharedPtr<Reactor> reactor = Reactor::global(), SharedPtr<Logger> logger = Logger::global());
+        SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 } // namespace net
 } // namespace mk

--- a/src/libmeasurement_kit/net/transport.hpp
+++ b/src/libmeasurement_kit/net/transport.hpp
@@ -140,10 +140,10 @@ class Transport : public TransportEmitter,
 void write(SharedPtr<Transport> txp, Buffer buf, Callback<Error> cb);
 
 void readn(SharedPtr<Transport> txp, SharedPtr<Buffer> buff, size_t n, Callback<Error> cb,
-           SharedPtr<Reactor> reactor = Reactor::global());
+           SharedPtr<Reactor> reactor);
 
 void read(SharedPtr<Transport> t, SharedPtr<Buffer> buff, Callback<Error> callback,
-          SharedPtr<Reactor> reactor = Reactor::global());
+          SharedPtr<Reactor> reactor);
 
 } // namespace net
 } // namespace mk

--- a/src/libmeasurement_kit/net/utils.cpp
+++ b/src/libmeasurement_kit/net/utils.cpp
@@ -143,7 +143,6 @@ int storage_init(sockaddr_storage *storage, socklen_t *salen,
     } else if (strcmp(family, "PF_INET6") == 0) {
         _family = PF_INET6;
     } else {
-        warn("utils:storage_init: invalid family");
         return -1;
     }
     return storage_init(storage, salen, _family, address, port, logger);
@@ -154,7 +153,6 @@ int storage_init(sockaddr_storage *storage, socklen_t *salen, int _family,
     const char *errstr;
     int _port = (int)mkp_strtonum(port, 0, 65535, &errstr);
     if (errstr != nullptr) {
-        warn("utils:storage_init: invalid port");
         return -1;
     }
     return storage_init(storage, salen, _family, address, _port, logger);

--- a/src/libmeasurement_kit/ooni/collector_client.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client.hpp
@@ -22,15 +22,13 @@ std::string production_collector_url();
 std::string testing_collector_url();
 
 void submit_report(std::string filepath, std::string collector_base_url,
-                   Callback<Error> callback, Settings conf = {},
-                   SharedPtr<Reactor> = Reactor::global(),
-                   SharedPtr<Logger> = Logger::global());
+                   Callback<Error> callback, Settings conf,
+                   SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void submit_report(std::string filepath, std::string collector_base_url,
                    std::string collector_front_domain,
-                   Callback<Error> callback, Settings conf = {},
-                   SharedPtr<Reactor> = Reactor::global(),
-                   SharedPtr<Logger> = Logger::global());
+                   Callback<Error> callback, Settings conf,
+                   SharedPtr<Reactor>, SharedPtr<Logger>);
 
 /*
     The following APIs are used to implement `submit_report()` and could
@@ -39,34 +37,30 @@ void submit_report(std::string filepath, std::string collector_base_url,
 */
 
 void connect(Settings, Callback<Error, SharedPtr<net::Transport>>,
-             SharedPtr<Reactor> = Reactor::global(), SharedPtr<Logger> = Logger::global());
+             SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void create_report(SharedPtr<net::Transport>, nlohmann::json,
-                   Callback<Error, std::string>, Settings = {},
-                   SharedPtr<Reactor> = Reactor::global(),
-                   SharedPtr<Logger> = Logger::global());
+                   Callback<Error, std::string>, Settings,
+                   SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void connect_and_create_report(nlohmann::json, Callback<Error, std::string>,
-                               Settings = {}, SharedPtr<Reactor> = Reactor::global(),
-                               SharedPtr<Logger> = Logger::global());
+                               Settings, SharedPtr<Reactor>,
+                               SharedPtr<Logger>);
 
 void update_report(SharedPtr<net::Transport>, std::string report_id, nlohmann::json,
-                   Callback<Error>, Settings = {},
-                   SharedPtr<Reactor> = Reactor::global(),
-                   SharedPtr<Logger> = Logger::global());
+                   Callback<Error>, Settings,
+                   SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void connect_and_update_report(std::string report_id, nlohmann::json,
-                               Callback<Error>, Settings = {},
-                               SharedPtr<Reactor> = Reactor::global(),
-                               SharedPtr<Logger> = Logger::global());
+                               Callback<Error>, Settings,
+                               SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void close_report(SharedPtr<net::Transport>, std::string report_id, Callback<Error>,
-                  Settings = {}, SharedPtr<Reactor> = Reactor::global(),
-                  SharedPtr<Logger> = Logger::global());
+                  Settings, SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void connect_and_close_report(std::string report_id, Callback<Error>,
-                              Settings = {}, SharedPtr<Reactor> = Reactor::global(),
-                              SharedPtr<Logger> = Logger::global());
+                              Settings, SharedPtr<Reactor>,
+                              SharedPtr<Logger>);
 
 } // namespace collector
 } // namespace mk

--- a/src/libmeasurement_kit/ooni/collector_client_impl.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client_impl.hpp
@@ -34,8 +34,8 @@ using namespace mk::net;
 */
 
 void post(SharedPtr<Transport> transport, std::string url_extra, std::string body,
-          Callback<Error, nlohmann::json> callback, Settings conf = {},
-          SharedPtr<Reactor> = Reactor::global(), SharedPtr<Logger> = Logger::global());
+          Callback<Error, nlohmann::json> callback, Settings conf,
+          SharedPtr<Reactor>, SharedPtr<Logger>);
 
 template <MK_MOCK_AS(http::request_sendrecv, http_request_sendrecv)>
 void post_impl(SharedPtr<Transport> transport, std::string append_to_url,

--- a/src/libmeasurement_kit/ooni/nettests.hpp
+++ b/src/libmeasurement_kit/ooni/nettests.hpp
@@ -12,47 +12,37 @@ namespace mk {
 namespace ooni {
 
 void captiveportal(std::string, Settings, Callback<SharedPtr<nlohmann::json>>,
-                    SharedPtr<Reactor> = Reactor::global(),
-                    SharedPtr<Logger> = Logger::global());
+                    SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void dns_injection(std::string, Settings, Callback<SharedPtr<nlohmann::json>>,
-                   SharedPtr<Reactor> = Reactor::global(),
-                   SharedPtr<Logger> = Logger::global());
+                   SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void http_invalid_request_line(Settings, Callback<SharedPtr<nlohmann::json>>,
-                               SharedPtr<Reactor> = Reactor::global(),
-                               SharedPtr<Logger> = Logger::global());
+                               SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void tcp_connect(std::string, Settings, Callback<SharedPtr<nlohmann::json>>,
-                 SharedPtr<Reactor> = Reactor::global(),
-                 SharedPtr<Logger> = Logger::global());
+                 SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void web_connectivity(std::string input, Settings,
                       Callback<SharedPtr<nlohmann::json>>,
-                      SharedPtr<Reactor> = Reactor::global(),
-                      SharedPtr<Logger> = Logger::global());
+                      SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void meek_fronted_requests(std::string input, Settings,
                            Callback<SharedPtr<nlohmann::json>>,
-                           SharedPtr<Reactor> = Reactor::global(),
-                           SharedPtr<Logger> = Logger::global());
+                           SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void http_header_field_manipulation(std::string input, Settings,
                                     Callback<SharedPtr<nlohmann::json>>,
-                                    SharedPtr<Reactor> = Reactor::global(),
-                                    SharedPtr<Logger> = Logger::global());
+                                    SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void telegram(Settings, Callback<SharedPtr<nlohmann::json>>,
-              SharedPtr<Reactor> = Reactor::global(),
-              SharedPtr<Logger> = Logger::global());
+              SharedPtr<Reactor>, SharedPtr<Logger>);
   
 void facebook_messenger(Settings, Callback<SharedPtr<nlohmann::json>>,
-                        SharedPtr<Reactor> = Reactor::global(),
-                        SharedPtr<Logger> = Logger::global());
+                        SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void whatsapp(Settings, Callback<SharedPtr<nlohmann::json>>,
-              SharedPtr<Reactor> = Reactor::global(),
-              SharedPtr<Logger> = Logger::global());
+              SharedPtr<Reactor>, SharedPtr<Logger>);
 
 } // namespace ooni
 } // namespace mk

--- a/src/libmeasurement_kit/ooni/orchestrate.cpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.cpp
@@ -175,7 +175,7 @@ void Client::register_probe(std::string &&password,
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread(Logger::global(), [
+    Worker::default_tasks_queue()->call_in_thread(Logger::make(), [
         password = std::move(password), meta = *this, cb = std::move(cb)
     ]() mutable {
         SharedPtr<Reactor> reactor = Reactor::make();
@@ -196,7 +196,7 @@ void Client::find_location(
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread(Logger::global(),
+    Worker::default_tasks_queue()->call_in_thread(Logger::make(),
           [ meta = *this, cb = std::move(cb) ]() {
               SharedPtr<Reactor> reactor = Reactor::make();
               reactor->run_with_initial_event([&]() {
@@ -217,7 +217,7 @@ void Client::update(Auth &&auth, Callback<Error &&, Auth &&> &&cb) const {
     //
     // We must copy or move everything into the initial lambda and then from
     // there the task is synchronous because run_...() is blocking.
-    Worker::default_tasks_queue()->call_in_thread(Logger::global(), [
+    Worker::default_tasks_queue()->call_in_thread(Logger::make(), [
         meta = *this, cb = std::move(cb), auth = std::move(auth)
     ]() mutable {
         SharedPtr<Reactor> reactor = Reactor::make();

--- a/src/libmeasurement_kit/ooni/orchestrate.hpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.hpp
@@ -54,7 +54,7 @@ class Auth {
 
 class ClientMetadata {
   public:
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Logger> logger;
     Settings settings = {};
     std::string available_bandwidth;
     std::string device_token;

--- a/src/libmeasurement_kit/ooni/orchestrate.hpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.hpp
@@ -54,7 +54,7 @@ class Auth {
 
 class ClientMetadata {
   public:
-    SharedPtr<Logger> logger;
+    SharedPtr<Logger> logger = Logger::make();
     Settings settings = {};
     std::string available_bandwidth;
     std::string device_token;

--- a/src/libmeasurement_kit/ooni/templates.hpp
+++ b/src/libmeasurement_kit/ooni/templates.hpp
@@ -15,18 +15,15 @@ namespace templates {
 
 void dns_query(SharedPtr<nlohmann::json> entry, dns::QueryType, dns::QueryClass,
                std::string query_name, std::string nameserver,
-               Callback<Error, SharedPtr<dns::Message>>, Settings = {},
-               SharedPtr<Reactor> = Reactor::global(),
-               SharedPtr<Logger> = Logger::global());
+               Callback<Error, SharedPtr<dns::Message>>, Settings,
+               SharedPtr<Reactor>, SharedPtr<Logger>);
 
 void http_request(SharedPtr<nlohmann::json> entry, Settings settings, http::Headers headers,
                   std::string body, Callback<Error, SharedPtr<http::Response>> cb,
-                  SharedPtr<Reactor> reactor = Reactor::global(),
-                  SharedPtr<Logger> logger = Logger::global());
+                  SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 void tcp_connect(Settings options, Callback<Error, SharedPtr<net::Transport>> cb,
-                 SharedPtr<Reactor> reactor = Reactor::global(),
-                 SharedPtr<Logger> logger = Logger::global());
+                 SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 } // namespace templates
 } // namespace mk

--- a/src/libmeasurement_kit/ooni/utils.hpp
+++ b/src/libmeasurement_kit/ooni/utils.hpp
@@ -19,9 +19,8 @@ std::string scrub(
         std::string real_probe_ip
 );
 
-void resolver_lookup(Callback<Error, std::string> callback, Settings = {},
-                     SharedPtr<Reactor> reactor = Reactor::global(),
-                     SharedPtr<Logger> logger = Logger::global());
+void resolver_lookup(Callback<Error, std::string> callback, Settings,
+                     SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 nlohmann::json represent_string(const std::string &s);
 

--- a/src/libmeasurement_kit/ooni/utils_impl.hpp
+++ b/src/libmeasurement_kit/ooni/utils_impl.hpp
@@ -17,9 +17,9 @@ namespace ooni {
 
 template <MK_MOCK_AS(dns::query, dns_query)>
 void resolver_lookup_impl(Callback<Error, std::string> callback,
-                          Settings settings = {},
-                          SharedPtr<Reactor> reactor = Reactor::global(),
-                          SharedPtr<Logger> logger = Logger::global()) {
+                          Settings settings,
+                          SharedPtr<Reactor> reactor,
+                          SharedPtr<Logger> logger) {
   dns_query("IN", "A", "whoami.akamai.net",
       [=](Error error, SharedPtr<dns::Message> message) {
         if (!error) {

--- a/src/libmeasurement_kit/ooni/web_connectivity.cpp
+++ b/src/libmeasurement_kit/ooni/web_connectivity.cpp
@@ -143,7 +143,7 @@ static void compare_dns_queries(SharedPtr<nlohmann::json> entry,
                                 std::vector<std::string> experiment_addresses,
                                 nlohmann::json control, Settings options) {
 
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Logger> logger = Logger::make();
     // When the controls fails in the same way as the experiment we consider the
     // DNS queries to be consistent.
     // XXX ensure the failure messages are aligned between ooniprobe and MK

--- a/src/libmeasurement_kit/report/ooni_reporter.hpp
+++ b/src/libmeasurement_kit/report/ooni_reporter.hpp
@@ -25,8 +25,8 @@ class OoniReporter : public BaseReporter {
   private:
     OoniReporter(Settings, SharedPtr<Reactor>, SharedPtr<Logger>);
 
-    SharedPtr<Reactor> reactor = Reactor::global();
-    SharedPtr<Logger> logger = Logger::global();
+    SharedPtr<Reactor> reactor;
+    SharedPtr<Logger> logger;
     Settings settings; // Our private copy of the ooni_test settings
     std::string report_id;
 };

--- a/src/libmeasurement_kit/traceroute/android.cpp
+++ b/src/libmeasurement_kit/traceroute/android.cpp
@@ -170,7 +170,6 @@ void AndroidProber::send_probe(std::string addr, int port, int ttl,
 
     if (sendto(sockfd_, payload.data(), payload.length(), 0, (sockaddr *)&ss,
                sslen) != (ssize_t)payload.length()) {
-        mk::warn("sendto() failed: errno %d", errno);
         error_cb_(SendtoError());
         return;
     }
@@ -261,7 +260,6 @@ ProbeResult AndroidProber::on_socket_readable() {
         }
         if (cmsg->cmsg_type != expected_type_recverr &&
             cmsg->cmsg_type != expected_type_ttl) {
-            mk::warn("Received unexpected cmsg_type: %d", cmsg->cmsg_type);
             continue;
         }
         if (cmsg->cmsg_type == expected_type_ttl) {
@@ -276,7 +274,6 @@ ProbeResult AndroidProber::on_socket_readable() {
 
         socket_error = (sock_extended_err *)CMSG_DATA(cmsg);
         if (socket_error->ee_origin != expected_origin) {
-            mk::warn("Received unexpected ee_type: %d", cmsg->cmsg_type);
             continue;
         }
         r.icmp_type = socket_error->ee_type;

--- a/src/libmeasurement_kit/traceroute/android.hpp
+++ b/src/libmeasurement_kit/traceroute/android.hpp
@@ -67,8 +67,8 @@ class AndroidProber : public NonCopyable,
     /// \param evbase Event base to use (optional)
     AndroidProber(
         bool use_ipv4, int port,
-        SharedPtr<Reactor> reactor = Reactor::global(),
-        SharedPtr<Logger> logger = Logger::global());
+        SharedPtr<Reactor> reactor,
+        SharedPtr<Logger> logger);
 
     /// Destructor
     ~AndroidProber() { cleanup(); }
@@ -93,7 +93,7 @@ class AndroidProber : public NonCopyable,
     bool use_ipv4_ = true;         ///< using IPv4?
     SharedPtr<Reactor> reactor;          ///< The reactor
     int port_ = 0;                 ///< socket port
-    SharedPtr<Logger> logger = Logger::global();///< logger
+    SharedPtr<Logger> logger;      ///< logger
 
     Delegate<ProbeResult> result_cb_;  ///< on result callback
     Delegate<> timeout_cb_;            ///< on timeout callback

--- a/src/libmeasurement_kit/traceroute/interface.cpp
+++ b/src/libmeasurement_kit/traceroute/interface.cpp
@@ -77,20 +77,14 @@ static ProbeResultMapping MAPPINGv6[] = {
 
 ProbeResultMeaning ProbeResult::get_meaning() {
     if (valid_reply) {
-        mk::debug("type %d code %d meaning %lld (got reply packet)",
-                  icmp_type, icmp_code, (long long)PRM_::GOT_REPLY_PACKET);
         return PRM_::GOT_REPLY_PACKET;
     }
     for (auto m = is_ipv4 ? &MAPPINGv4[0] : &MAPPINGv6[0];
          m->meaning != PRM_::OTHER; ++m) {
         if (m->type == icmp_type && m->code == icmp_code) {
-            mk::debug("type %d code %d meaning %lld", icmp_type,
-                      icmp_code, (long long)m->meaning);
             return m->meaning;
         }
     }
-    mk::debug("type %d code %d meaning %lld (other)", icmp_type,
-              icmp_code, (long long)PRM_::OTHER);
     return PRM_::OTHER;
 }
 

--- a/src/libmeasurement_kit/traceroute/interface.hpp
+++ b/src/libmeasurement_kit/traceroute/interface.hpp
@@ -127,7 +127,7 @@ template <class Impl> class Prober : public ProberInterface {
     /// \param evbase Event base to use (optional)
     /// \throws Exception on error
     Prober(bool use_ipv4, int port, SharedPtr<Reactor> reactor) {
-        impl_.reset(new Impl(use_ipv4, port, reactor));
+        impl_.reset(new Impl(use_ipv4, port, reactor, Logger::make()));
     }
 
     void send_probe(std::string addr, int port, int ttl, std::string payload,

--- a/src/libmeasurement_kit/traceroute/interface.hpp
+++ b/src/libmeasurement_kit/traceroute/interface.hpp
@@ -126,7 +126,7 @@ template <class Impl> class Prober : public ProberInterface {
     /// \param port The port to bind
     /// \param evbase Event base to use (optional)
     /// \throws Exception on error
-    Prober(bool use_ipv4, int port, SharedPtr<Reactor> reactor = Reactor::global()) {
+    Prober(bool use_ipv4, int port, SharedPtr<Reactor> reactor) {
         impl_.reset(new Impl(use_ipv4, port, reactor));
     }
 

--- a/test/common/logger.cpp
+++ b/test/common/logger.cpp
@@ -15,46 +15,49 @@ using namespace mk;
 
 TEST_CASE("By default the logger is quiet") {
     std::string buffer;
+    auto logger = mk::Logger::make();
 
-    mk::on_log([&buffer](uint32_t, const char *s) {
+    logger->on_log([&buffer](uint32_t, const char *s) {
         buffer += s;
         buffer += "\n";
     });
 
-    mk::debug("Antani");
-    mk::info("Foo");
+    logger->debug("Antani");
+    logger->info("Foo");
 
     REQUIRE(buffer == "");
 }
 
 TEST_CASE("It is possible to make the logger verbose") {
     std::string buffer;
+    auto logger = mk::Logger::make();
 
-    mk::on_log([&buffer](uint32_t, const char *s) {
+    logger->on_log([&buffer](uint32_t, const char *s) {
         buffer += s;
         buffer += "\n";
     });
 
-    mk::set_verbosity(MK_LOG_INFO);
+    logger->set_verbosity(MK_LOG_INFO);
 
-    mk::debug("Antani");
-    mk::info("Foo");
+    logger->debug("Antani");
+    logger->info("Foo");
 
     REQUIRE(buffer == "Foo\n");
 }
 
 TEST_CASE("Verbosity can be further increased") {
     std::string buffer;
+    auto logger = mk::Logger::make();
 
-    mk::on_log([&buffer](uint32_t, const char *s) {
+    logger->on_log([&buffer](uint32_t, const char *s) {
         buffer += s;
         buffer += "\n";
     });
 
-    mk::set_verbosity(MK_LOG_DEBUG);
+    logger->set_verbosity(MK_LOG_DEBUG);
 
-    mk::debug("Antani");
-    mk::info("Foo");
+    logger->debug("Antani");
+    logger->info("Foo");
 
     REQUIRE(buffer == "Antani\nFoo\n");
 }

--- a/test/common/worker.cpp
+++ b/test/common/worker.cpp
@@ -18,7 +18,7 @@
 TEST_CASE("The worker is robust to submitting many tasks in a row") {
     auto worker = mk::SharedPtr<mk::Worker>::make();
     for (size_t i = 0; i < 128; ++i) {
-        worker->call_in_thread(mk::Logger::global(), []() {
+        worker->call_in_thread(mk::Logger::make(), []() {
             using namespace std::chrono_literals;
             std::this_thread::sleep_for(2s);
         });

--- a/test/dns/ping.cpp
+++ b/test/dns/ping.cpp
@@ -26,7 +26,7 @@ TEST_CASE("The dns::ping() template works") {
     reactor->run_with_initial_event([&]() {
         dns::ping_nameserver("IN", "A", "www.google.com", 1.0,
                              Maybe<double>{10.0}, settings, reactor,
-                             Logger::global(),
+                             Logger::make(),
                              [](Error err, SharedPtr<dns::Message> message) {
                                  std::cout << err;
                                  if (message) {

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -215,17 +215,21 @@ TEST_CASE("dns::query deals with inet_pton returning 0") {
 TEST_CASE("dns::query raises if the query is unsupported") {
     SharedPtr<Reactor> reactor = Reactor::make();
     SharedPtr<Logger> logger = Logger::make();
-    query("IN", "MX", "www.neubot.org",
-          [](Error e, SharedPtr<Message>) { REQUIRE(e == UnsupportedTypeError()); },
-          {{"dns/engine", "libevent"}}, reactor, logger);
+    reactor->run_with_initial_event([&]() {
+        query("IN", "MX", "www.neubot.org",
+              [](Error e, SharedPtr<Message>) { REQUIRE(e == UnsupportedTypeError()); },
+              {{"dns/engine", "libevent"}}, reactor, logger);
+    });
 }
 
 TEST_CASE("dns::query raises if the class is unsupported") {
     SharedPtr<Reactor> reactor = Reactor::make();
     SharedPtr<Logger> logger = Logger::make();
-    query("CS", "A", "www.neubot.org",
-          [](Error e, SharedPtr<Message>) { REQUIRE(e == UnsupportedClassError()); },
-          {{"dns/engine", "libevent"}}, reactor, logger);
+    reactor->run_with_initial_event([&]() {
+        query("CS", "A", "www.neubot.org",
+              [](Error e, SharedPtr<Message>) { REQUIRE(e == UnsupportedClassError()); },
+              {{"dns/engine", "libevent"}}, reactor, logger);
+    });
 }
 
 TEST_CASE("dns::query deals with invalid PTR name") {
@@ -233,9 +237,11 @@ TEST_CASE("dns::query deals with invalid PTR name") {
     SharedPtr<Logger> logger = Logger::make();
     // This should be enough to see the failure, more tests for the
     // parser for PTR addresses are in test/common/utils.cpp
-    query("IN", "PTR", "xx",
-          [](Error e, SharedPtr<Message>) { REQUIRE(e == InvalidNameForPTRError()); },
-          {{"dns/engine", "libevent"}}, reactor, logger);
+    reactor->run_with_initial_event([&]() {
+        query("IN", "PTR", "xx",
+              [](Error e, SharedPtr<Message>) { REQUIRE(e == InvalidNameForPTRError()); },
+              {{"dns/engine", "libevent"}}, reactor, logger);
+    });
 }
 
 // Test resolve_hostname

--- a/test/dns/system_resolver.cpp
+++ b/test/dns/system_resolver.cpp
@@ -108,7 +108,11 @@ TEST_CASE("the system resolver is able to resolve an ipv6 address") {
 TEST_CASE("the system resolver can handle errors with a CNAME query") {
     run_system_resolver(
         "IN", "CNAME", "invalid_site.local", [](Error e, SharedPtr<Message>) {
-            REQUIRE(e == HostOrServiceNotProvidedOrNotKnownError());
+            bool ok = (
+                e == HostOrServiceNotProvidedOrNotKnownError() ||
+                e == TemporaryFailureError()
+            );
+            REQUIRE(ok);
         });
 }
 

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -557,7 +557,7 @@ TEST_CASE("http::request() correctly follows redirects") {
     reactor->run_with_initial_event([=]() {
         request(
             {
-                {"http/url", "http://fsrn.org"},
+                {"http/url", "http://google.com"},
                 {"http/max_redirects", 32},
                 {"net/ca_bundle_path", "cacert.pem"},
             },
@@ -568,11 +568,11 @@ TEST_CASE("http::request() correctly follows redirects") {
             [=](Error error, SharedPtr<Response> response) {
                 REQUIRE(!error);
                 REQUIRE(response->status_code == 200);
-                REQUIRE(response->request->url.schema == "https");
-                REQUIRE(response->request->url.address == "fsrn.org");
-                REQUIRE(response->previous->status_code == 302);
+                REQUIRE(response->request->url.schema == "http");
+                REQUIRE(response->request->url.address == "www.google.com");
+                REQUIRE(response->previous->status_code == 301);
                 REQUIRE(response->previous->request->url.schema == "http");
-                REQUIRE(response->previous->request->url.address == "fsrn.org");
+                REQUIRE(response->previous->request->url.address == "google.com");
                 REQUIRE(!response->previous->previous);
                 reactor->stop();
             }, reactor, Logger::make());

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -64,7 +64,7 @@ TEST_CASE("HTTP Request class works as expected") {
         },
         "0123456789");
     Buffer buffer;
-    request.serialize(buffer);
+    request.serialize(buffer, Logger::make());
     auto serialized = buffer.read();
     std::string expect = "GET /antani?clacsonato=yes HTTP/1.0\r\n";
     expect += "User-Agent: Antani/1.0.0.0\r\n";
@@ -92,7 +92,7 @@ TEST_CASE("HTTP Request class works as expected with explicit path") {
         },
         "0123456789");
     Buffer buffer;
-    request.serialize(buffer);
+    request.serialize(buffer, Logger::make());
     auto serialized = buffer.read();
     std::string expect = "GET /antani?amicimiei HTTP/1.0\r\n";
     expect += "User-Agent: Antani/1.0.0.0\r\n";
@@ -131,7 +131,7 @@ TEST_CASE("http::request works as expected") {
                 REQUIRE(md5(response->body) ==
                         "5d2182cb241b5a9aefad8ce584831666");
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -153,7 +153,7 @@ TEST_CASE("http::request() works using HTTPS") {
                     REQUIRE(md5(response->body) ==
                             "1be9d96d157a3df328faa30e51faf63a");
                     reactor->stop();
-                }, reactor);
+                }, reactor, Logger::make());
     });
 }
 
@@ -180,7 +180,7 @@ TEST_CASE("http::request() works as expected over Tor") {
                         "5d2182cb241b5a9aefad8ce584831666");
                 }
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -202,7 +202,7 @@ TEST_CASE("http::request correctly receives errors") {
                 REQUIRE(error);
                 REQUIRE(response->response_line == "");
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -255,13 +255,14 @@ TEST_CASE("http::request_recv_response() deals with immediate EOF") {
                                               REQUIRE(!!r);
                                               reactor->stop();
                                           },
-                                          {}, reactor);
+                                          {}, reactor, Logger::make());
                     transport->emit_error(EofError());
                 },
                 {// With this connect() succeeds immediately and the
                  // callback receives a dumb Emitter transport that you
                  // can drive by calling its emit_FOO() methods
-                 {"net/dumb_transport", true}});
+                 {"net/dumb_transport", true}},
+                 Reactor::make(), Logger::make());
     });
 }
 
@@ -288,10 +289,12 @@ TEST_CASE("Behavior is correct when only tor_socks_port is specified") {
     };
 
     settings["http/url"] = "httpo://nkvphnp3p6agi5qq.onion/bouncer";
-    request_connect_impl<socks_port_is_9055>(settings, nullptr);
+    request_connect_impl<socks_port_is_9055>(settings, nullptr,
+        Reactor::make(), Logger::make());
 
     settings["http/url"] = "http://ooni.torproject.org/";
-    request_connect_impl<socks_port_is_empty>(settings, nullptr);
+    request_connect_impl<socks_port_is_empty>(settings, nullptr,
+        Reactor::make(), Logger::make());
 }
 
 SOCKS_PORT_IS(9999)
@@ -305,10 +308,12 @@ TEST_CASE("Behavior is correct with both tor_socks_port and socks5_proxy") {
     };
 
     settings["http/url"] = "httpo://nkvphnp3p6agi5qq.onion/bouncer";
-    request_connect_impl<socks_port_is_9999>(settings, nullptr);
+    request_connect_impl<socks_port_is_9999>(settings, nullptr,
+        Reactor::make(), Logger::make());
 
     settings["http/url"] = "http://ooni.torproject.org/";
-    request_connect_impl<socks_port_is_9055>(settings, nullptr);
+    request_connect_impl<socks_port_is_9055>(settings, nullptr,
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
@@ -319,10 +324,12 @@ TEST_CASE("Behavior is corrent when only socks5_proxy is specified") {
     };
 
     settings["http/url"] = "httpo://nkvphnp3p6agi5qq.onion/bouncer";
-    request_connect_impl<socks_port_is_9055>(settings, nullptr);
+    request_connect_impl<socks_port_is_9055>(settings, nullptr,
+        Reactor::make(), Logger::make());
 
     settings["http/url"] = "http://ooni.torproject.org/";
-    request_connect_impl<socks_port_is_9055>(settings, nullptr);
+    request_connect_impl<socks_port_is_9055>(settings, nullptr,
+        Reactor::make(), Logger::make());
 }
 
 SOCKS_PORT_IS(9050)
@@ -333,10 +340,12 @@ TEST_CASE("Behavior is OK w/o tor_socks_port and socks5_proxy") {
     };
 
     settings["http/url"] = "httpo://nkvphnp3p6agi5qq.onion/bouncer";
-    request_connect_impl<socks_port_is_9050>(settings, nullptr);
+    request_connect_impl<socks_port_is_9050>(settings, nullptr,
+        Reactor::make(), Logger::make());
 
     settings["http/url"] = "http://ooni.torproject.org/";
-    request_connect_impl<socks_port_is_empty>(settings, nullptr);
+    request_connect_impl<socks_port_is_empty>(settings, nullptr,
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("http::request() callback is called if input URL parsing fails") {
@@ -348,7 +357,7 @@ TEST_CASE("http::request() callback is called if input URL parsing fails") {
                 called = true;
                 REQUIRE(err == MissingUrlError());
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
     REQUIRE(called);
 }
@@ -361,7 +370,7 @@ TEST_CASE("http::request_connect_impl() works for normal connections") {
                                  REQUIRE(!error);
                                  REQUIRE(static_cast<bool>(transport));
                                  transport->close([=]() { reactor->stop(); });
-                             }, reactor);
+                             }, reactor, Logger::make());
     });
 }
 
@@ -389,7 +398,7 @@ TEST_CASE("http::request_send() works as expected") {
                                  REQUIRE(!error);
                                  transport->close([=]() { reactor->stop(); });
                              });
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -419,9 +428,9 @@ TEST_CASE("http::request_recv_response() works as expected") {
                                 REQUIRE(status_code_ok(r->status_code));
                                 REQUIRE(r->body.size() > 0);
                                 transport->close([=]() { reactor->stop(); });
-                            }, {}, reactor);
+                            }, {}, reactor, Logger::make());
                     });
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -443,8 +452,8 @@ TEST_CASE("http::request_sendrecv() works as expected") {
                                      REQUIRE(status_code_ok(r->status_code));
                                      REQUIRE(r->body.size() > 0);
                                      transport->close([=]() { reactor->stop(); });
-                                 }, reactor);
-            }, reactor);
+                                 }, reactor, Logger::make());
+            }, reactor, Logger::make());
     });
 }
 
@@ -479,9 +488,9 @@ TEST_CASE("http::request_sendrecv() works for multiple requests") {
                                 REQUIRE(r->status_code == 200);
                                 REQUIRE(r->body.size() > 0);
                                 transport->close([=]() { reactor->stop(); });
-                            }, reactor);
-                    }, reactor);
-            }, reactor);
+                            }, reactor, Logger::make());
+                    }, reactor, Logger::make());
+            }, reactor, Logger::make());
     });
 }
 
@@ -513,7 +522,7 @@ TEST_CASE("http::request() works as expected using httpo URLs") {
                     REQUIRE(body["dns"]["address"] == "37.218.247.110:57004");
                 }
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -539,7 +548,7 @@ TEST_CASE("http::request() works as expected using tor_socks_port") {
                             "c0eb138de5f70c3b37566ba88146465d");
                 }
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -566,7 +575,7 @@ TEST_CASE("http::request() correctly follows redirects") {
                 REQUIRE(response->previous->request->url.address == "fsrn.org");
                 REQUIRE(!response->previous->previous);
                 reactor->stop();
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -594,7 +603,7 @@ TEST_CASE("Headers are preserved across redirects") {
                 REQUIRE(body["headers"]["Spam"] == "Ham");
                 reactor->stop();
             },
-            reactor);
+            reactor, Logger::make());
     });
 }
 
@@ -628,7 +637,7 @@ TEST_CASE("We correctly deal with end-of-response signalled by EOF") {
                 REQUIRE(response->previous->request->url.schema == "http");
                 reactor->stop();
             },
-            reactor);
+            reactor, Logger::make());
     });
 }
 
@@ -661,7 +670,7 @@ TEST_CASE("We correctly deal with schema-less redirect") {
                         == "/redirect-to");
                 reactor->stop();
             },
-            reactor);
+            reactor, Logger::make());
     });
 }
 
@@ -672,7 +681,7 @@ TEST_CASE("http::request_connect_impl fails without an url") {
                              [=](Error error, SharedPtr<Transport>) {
                                  REQUIRE(error == MissingUrlError());
                                  reactor->stop();
-                             }, reactor);
+                             }, reactor, Logger::make());
     });
 }
 
@@ -683,7 +692,7 @@ TEST_CASE("http::request_connect_impl fails with an uncorrect url") {
                              [=](Error error, SharedPtr<Transport>) {
                                  REQUIRE(error == UrlParserError());
                                  reactor->stop();
-                             }, reactor);
+                             }, reactor, Logger::make());
     });
 }
 
@@ -701,7 +710,7 @@ TEST_CASE("http::request_send fails without url in settings") {
                                  REQUIRE(error == MissingUrlError());
                                  transport->close([=]() { reactor->stop(); });
                              });
-            }, reactor);
+            }, reactor, Logger::make());
     });
 }
 
@@ -712,7 +721,7 @@ TEST_CASE("http::request() fails if fails request_send()") {
                 [=](Error error, SharedPtr<Response>) {
                     REQUIRE(error);
                     reactor->stop();
-                }, reactor);
+                }, reactor, Logger::make());
     });
 }
 

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -386,7 +386,7 @@ TEST_CASE("http::request_send() works as expected") {
                                  {"http/method", "GET"},
                                  {"http/url", "http://www.google.com/"},
                              },
-                             {}, "", Logger::global(),
+                             {}, "", Logger::make(),
                              [=](Error error, SharedPtr<Request> request) {
                                  REQUIRE((request->method == "GET"));
                                  REQUIRE((request->url.schema == "http"));
@@ -419,7 +419,7 @@ TEST_CASE("http::request_recv_response() works as expected") {
                         {"http/method", "GET"},
                         {"http/url", "http://www.google.com/"},
                     },
-                    {}, "", Logger::global(),
+                    {}, "", Logger::make(),
                     [=](Error error, SharedPtr<Request>) {
                         REQUIRE(!error);
                         request_recv_response(
@@ -704,7 +704,7 @@ TEST_CASE("http::request_send fails without url in settings") {
             [=](Error error, SharedPtr<Transport> transport) {
                 REQUIRE(!error);
                 request_send(transport, {{"http/method", "GET"}}, {}, "",
-                             Logger::global(),
+                             Logger::make(),
                              [=](Error error, SharedPtr<Request> request) {
                                  REQUIRE(!request);
                                  REQUIRE(error == MissingUrlError());
@@ -788,16 +788,16 @@ TEST_CASE("http::redirect() works as expected") {
 
 static void fail_request(Settings, Headers, std::string,
                          Callback<Error, SharedPtr<Response>> cb,
-                         SharedPtr<Reactor> = Reactor::global(),
-                         SharedPtr<Logger> = Logger::global(),
+                         SharedPtr<Reactor> = Reactor::make(),
+                         SharedPtr<Logger> = Logger::make(),
                          SharedPtr<Response> = nullptr, int = 0) {
     cb(MockedError(), SharedPtr<Response>::make());
 }
 
 static void non_200_response(Settings, Headers, std::string,
                              Callback<Error, SharedPtr<Response>> cb,
-                             SharedPtr<Reactor> = Reactor::global(),
-                             SharedPtr<Logger> = Logger::global(),
+                             SharedPtr<Reactor> = Reactor::make(),
+                             SharedPtr<Logger> = Logger::make(),
                              SharedPtr<Response> = nullptr, int = 0) {
     SharedPtr<Response> response = SharedPtr<Response>::make();
     response->status_code = 500;
@@ -807,8 +807,8 @@ static void non_200_response(Settings, Headers, std::string,
 
 static void fail_parsing(Settings, Headers, std::string,
                          Callback<Error, SharedPtr<Response>> cb,
-                         SharedPtr<Reactor> = Reactor::global(),
-                         SharedPtr<Logger> = Logger::global(),
+                         SharedPtr<Reactor> = Reactor::make(),
+                         SharedPtr<Logger> = Logger::make(),
                          SharedPtr<Response> = nullptr, int = 0) {
     SharedPtr<Response> response = SharedPtr<Response>::make();
     response->status_code = 200;
@@ -827,7 +827,7 @@ TEST_CASE("request_json_string() works as expected") {
                   REQUIRE(error == MockedError());
                     reactor->stop();
               },
-              {}, reactor, Logger::global());
+              {}, reactor, Logger::make());
         });
     }
 
@@ -840,7 +840,7 @@ TEST_CASE("request_json_string() works as expected") {
                   REQUIRE(resp->status_code != 200);
                   reactor->stop();
               },
-              {}, reactor, Logger::global());
+              {}, reactor, Logger::make());
         });
     }
 
@@ -851,7 +851,7 @@ TEST_CASE("request_json_string() works as expected") {
               [=](Error error, SharedPtr<Response>, nlohmann::json) {
                   REQUIRE(error == JsonProcessingError());
               },
-              {}, reactor, Logger::global());
+              {}, reactor, Logger::make());
         });
     }
 }

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -13,7 +13,7 @@ using namespace mk::net;
 using namespace mk::http;
 
 TEST_CASE("ResponseParserNg deals with an invalid message") {
-    ResponseParserNg parser;
+    ResponseParserNg parser{Logger::make()};
     std::string data;
 
     data = "";
@@ -28,7 +28,7 @@ TEST_CASE("ResponseParserNg deals with an invalid message") {
 }
 
 TEST_CASE("ResponseParserNg deals with an UPGRADE request") {
-    ResponseParserNg parser;
+    ResponseParserNg parser{Logger::make()};
     std::string data;
 
     data = "";
@@ -49,7 +49,7 @@ TEST_CASE("ResponseParserNg deals with an UPGRADE request") {
 
 TEST_CASE("ResponseParserNg works as expected") {
     std::string data;
-    ResponseParserNg parser;
+    ResponseParserNg parser{Logger::make()};
     std::string body;
 
     SECTION("With content-length response") {
@@ -119,7 +119,7 @@ TEST_CASE("ResponseParserNg works as expected") {
 
 TEST_CASE("ResponseParserNg stops after first message") {
     std::string data;
-    ResponseParserNg parser;
+    ResponseParserNg parser{Logger::make()};
     std::string body;
 
     //
@@ -190,7 +190,7 @@ TEST_CASE("ResponseParserNg stops after first message") {
 
 TEST_CASE("ResponseParserNg eof() works as expected") {
     bool called = false;
-    ResponseParserNg parser;
+    ResponseParserNg parser{Logger::make()};
     std::string data;
 
     data = "";

--- a/test/http/response_parser.cpp
+++ b/test/http/response_parser.cpp
@@ -49,7 +49,8 @@ TEST_CASE("ResponseParserNg deals with an UPGRADE request") {
 
 TEST_CASE("ResponseParserNg works as expected") {
     std::string data;
-    ResponseParserNg parser{Logger::make()};
+    auto logger = Logger::make();
+    ResponseParserNg parser{logger};
     std::string body;
 
     SECTION("With content-length response") {
@@ -77,7 +78,7 @@ TEST_CASE("ResponseParserNg works as expected") {
         parser.on_end([&body]() { REQUIRE(body == "1234567"); });
 
         for (auto c : data) {
-            mk::debug("%c\n", c);
+            logger->debug("%c\n", c);
             parser.feed(c);
         }
     }
@@ -111,7 +112,7 @@ TEST_CASE("ResponseParserNg works as expected") {
         parser.on_end([&body]() { REQUIRE(body == "abcabcabc"); });
 
         for (auto c : data) {
-            mk::debug("%c\n", c);
+            logger->debug("%c\n", c);
             parser.feed(c);
         }
     }
@@ -119,7 +120,8 @@ TEST_CASE("ResponseParserNg works as expected") {
 
 TEST_CASE("ResponseParserNg stops after first message") {
     std::string data;
-    ResponseParserNg parser{Logger::make()};
+    auto logger = Logger::make();
+    ResponseParserNg parser{logger};
     std::string body;
 
     //
@@ -151,7 +153,7 @@ TEST_CASE("ResponseParserNg stops after first message") {
     parser.on_end([&body]() { REQUIRE(body == "1234567"); });
 
     for (auto c : data) {
-        mk::debug("%c\n", c);
+        logger->debug("%c\n", c);
         parser.feed(c);
     }
 

--- a/test/mlabns/mlabns.cpp
+++ b/test/mlabns/mlabns.cpp
@@ -160,7 +160,7 @@ TEST_CASE(
                                             },
                                             settings,
                                             reactor,
-                                            Logger::global());
+                                            Logger::make());
     });
 }
 
@@ -197,7 +197,7 @@ TEST_CASE("Make sure that an error is passed to callback if the response does "
                 REQUIRE(error == JsonProcessingError());
                 reactor->stop();
             },
-            settings, reactor, Logger::global());
+            settings, reactor, Logger::make());
     });
 }
 
@@ -234,6 +234,6 @@ TEST_CASE("Make sure that an error is passed to callback if the response "
                 REQUIRE(error == JsonProcessingError());
                 reactor->stop();
             },
-            settings, reactor, Logger::global());
+            settings, reactor, Logger::make());
     });
 }

--- a/test/mlabns/mlabns.cpp
+++ b/test/mlabns/mlabns.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Query works as expected") {
                           REQUIRE(!error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 
@@ -51,7 +51,7 @@ TEST_CASE("Query can pass the settings to the dns level") {
                           REQUIRE(error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 
@@ -71,7 +71,7 @@ TEST_CASE("Make sure that an error is passed to callback with invalid "
                           REQUIRE(error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 
@@ -91,7 +91,7 @@ TEST_CASE("Make sure that an error is passed to callback with invalid metro "
                           REQUIRE(error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 
@@ -111,7 +111,7 @@ TEST_CASE("Make sure that an error is passed to callback with invalid policy "
                           REQUIRE(error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 
@@ -131,7 +131,7 @@ TEST_CASE("Make sure that an error is passed to callback with invalid tool "
                           REQUIRE(error);
                           reactor->stop();
                       },
-                      settings, reactor);
+                      settings, reactor, Logger::make());
     });
 }
 

--- a/test/ndt/messages.cpp
+++ b/test/ndt/messages.cpp
@@ -13,12 +13,12 @@ using namespace mk::ndt;
 using namespace mk::net;
 
 static void fail(SharedPtr<Transport>, SharedPtr<Buffer>, size_t, Callback<Error> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError());
 }
 
 static void succeed(SharedPtr<Transport>, SharedPtr<Buffer>, size_t, Callback<Error> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError());
 }
 
@@ -26,7 +26,7 @@ TEST_CASE("read_ndt() deals with the first readn() error") {
     SharedPtr<Context> ctx(new Context);
     messages::read_ll_impl<fail>(ctx, [](Error err, uint8_t, std::string) {
         REQUIRE(err == ReadingMessageTypeLengthError());
-    }, Reactor::global());
+    }, Reactor::make());
 }
 
 TEST_CASE("read_ndt() deals with the second readn() error") {
@@ -38,16 +38,16 @@ TEST_CASE("read_ndt() deals with the second readn() error") {
     messages::read_ll_impl<succeed, fail>(
         ctx, [](Error err, uint8_t, std::string) {
             REQUIRE(err == ReadingMessagePayloadError());
-        }, Reactor::global());
+        }, Reactor::make());
 }
 
 static void fail(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, "");
 }
 
 static void succeed(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), 0, "");
 }
 
@@ -55,23 +55,23 @@ TEST_CASE("read_json() deals with read_ndt() error") {
     SharedPtr<Context> ctx(new Context);
     messages::read_json_impl<fail>(
         ctx, [](Error err, uint8_t, nlohmann::json) { REQUIRE(err == MockedError()); },
-        Reactor::global());
+        Reactor::make());
 }
 
 TEST_CASE("read_json() deals with invalid JSON") {
     SharedPtr<Context> ctx(new Context);
     messages::read_json_impl<succeed>(ctx, [](Error err, uint8_t, nlohmann::json) {
         REQUIRE(err == JsonProcessingError());
-    }, Reactor::global());
+    }, Reactor::make());
 }
 
 static void fail(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, {});
 }
 
 static void invalid(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), 0, {{"foo", "baz"}, {"baz", 1}});
 }
 
@@ -79,18 +79,18 @@ TEST_CASE("read() deals with read_json() error") {
     SharedPtr<Context> ctx(new Context);
     messages::read_msg_impl<fail>(ctx, [](Error err, uint8_t, std::string) {
         REQUIRE(err == MockedError());
-    }, Reactor::global());
+    }, Reactor::make());
 }
 
 TEST_CASE("read() deals with json without 'msg' field") {
     SharedPtr<Context> ctx(new Context);
     messages::read_msg_impl<invalid>(ctx, [](Error err, uint8_t, std::string) {
         REQUIRE(err == JsonProcessingError());
-    }, Reactor::global());
+    }, Reactor::make());
 }
 
 static void bad_type(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), 0, 3.14);
 }
 
@@ -98,7 +98,7 @@ TEST_CASE("read() deals with json with 'msg' field of the wrong type") {
     SharedPtr<Context> ctx(new Context);
     messages::read_msg_impl<bad_type>(ctx, [](Error err, uint8_t, std::string) {
         REQUIRE(err == JsonProcessingError());
-    }, Reactor::global());
+    }, Reactor::make());
 }
 
 TEST_CASE("format_any() deals with too large input") {

--- a/test/ndt/protocol.cpp
+++ b/test/ndt/protocol.cpp
@@ -48,7 +48,7 @@ TEST_CASE("send_extended_login() deals with write error") {
 }
 
 static void fail(SharedPtr<Transport>, SharedPtr<Buffer>, size_t, Callback<Error> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError());
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("recv_and_ignore_kickoff() deals with readn() error") {
 }
 
 static void invalid(SharedPtr<Transport>, SharedPtr<Buffer> buff, size_t n,
-                    Callback<Error> cb, SharedPtr<Reactor> = Reactor::global()) {
+                    Callback<Error> cb, SharedPtr<Reactor> = Reactor::make()) {
     std::string s(n, 'a');
     buff->write(s);
     cb(NoError());
@@ -72,7 +72,7 @@ TEST_CASE("recv_and_ignore_kickoff() deals with invalid kickoff message") {
 }
 
 static void fail(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, "");
 }
 
@@ -83,7 +83,7 @@ TEST_CASE("wait_in_queue() deals with read() error") {
 }
 
 static void unexpected(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                       SharedPtr<Reactor> = Reactor::global()) {
+                       SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -94,7 +94,7 @@ TEST_CASE("wait_in_queue() deals with unexpected message error") {
 }
 
 static void bad_time(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                     SharedPtr<Reactor> = Reactor::global()) {
+                     SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "xo");
 }
 
@@ -109,7 +109,7 @@ static void call_soon_not_called(Callback<> &&, SharedPtr<Reactor>) {
 }
 
 static void s_fault(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "9977" /* SRV_QUEUE_SERVER_FAULT */);
 }
 
@@ -123,7 +123,7 @@ TEST_CASE("wait_in_queue() deals with server-fault wait time") {
 }
 
 static void s_busy(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                   SharedPtr<Reactor> = Reactor::global()) {
+                   SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "9987" /* SRV_QUEUE_SERVER_BUSY */);
 }
 
@@ -137,7 +137,7 @@ TEST_CASE("wait_in_queue() deals with server-busy wait time") {
 }
 
 static void s_busy60s(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "9999" /* SRV_QUEUE_SERVER_BUSY_60s */);
 }
 
@@ -157,7 +157,7 @@ static void call_soon_called(Callback<> &&, SharedPtr<Reactor>) {
 }
 
 static void heartbeat(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "9990" /* SRV_QUEUE_HEARTBEAT */);
 }
 
@@ -198,7 +198,7 @@ TEST_CASE("wait_in_queue() deals with format_msg_waiting_error") {
 }
 
 static void nonzero(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), SRV_QUEUE, "1");
 }
 
@@ -215,7 +215,7 @@ TEST_CASE("wait_in_queue() deals with nonzero wait time") {
 
 static void queued_then_whitelisted(SharedPtr<Context>,
         Callback<Error, uint8_t, std::string> cb,
-        SharedPtr<Reactor> = Reactor::global()) {
+        SharedPtr<Reactor> = Reactor::make()) {
     static int state = 2;
     REQUIRE(state >= 0);
     cb(NoError(), SRV_QUEUE, std::to_string(state).c_str());
@@ -298,49 +298,49 @@ TEST_CASE("recv_results_and_logout() deals with unexpected message error") {
 }
 
 static void eof_error(SharedPtr<Transport>, SharedPtr<Buffer>, Callback<Error> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(EofError());
 }
 
 TEST_CASE("wait_close() deals with EofError") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     protocol::wait_close_impl<eof_error>(
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
 
 static void timeout_error(SharedPtr<Transport>, SharedPtr<Buffer>, Callback<Error> cb,
-                          SharedPtr<Reactor> = Reactor::global()) {
+                          SharedPtr<Reactor> = Reactor::make()) {
     cb(TimeoutError());
 }
 
 TEST_CASE("wait_close() deals with TimeoutError") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     protocol::wait_close_impl<timeout_error>(
         ctx, [](Error err) { REQUIRE(err == NoError()); });
 }
 
 static void mocked_error(SharedPtr<Transport>, SharedPtr<Buffer>, Callback<Error> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError());
 }
 
 TEST_CASE("wait_close() deals with an error") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     protocol::wait_close_impl<mocked_error>(
         ctx, [](Error err) { REQUIRE(err == WaitingCloseError()); });
 }
 
 static void no_error(SharedPtr<Transport>, SharedPtr<Buffer>, Callback<Error> cb,
-                     SharedPtr<Reactor> = Reactor::global()) {
+                     SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError());
 }
 
 TEST_CASE("wait_close() deals with a extra data") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     protocol::wait_close_impl<no_error>(
         ctx, [](Error err) { REQUIRE(err == DataAfterLogoutError()); });
 }
@@ -355,7 +355,7 @@ TEST_CASE("disconnect_and_callback_impl() without transport") {
 // To increase coverage
 TEST_CASE("disconnect_and_callback_impl() with transport") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     ctx->callback = [](Error e) { REQUIRE(e == MockedError()); };
     protocol::disconnect_and_callback_impl(ctx, MockedError());
 }

--- a/test/ndt/protocol.cpp
+++ b/test/ndt/protocol.cpp
@@ -224,11 +224,10 @@ static void queued_then_whitelisted(SharedPtr<Context>,
 
 TEST_CASE("wait_in_queue() reschedules itself until we are white listed") {
     SharedPtr<Context> ctx(new Context);
-    SharedPtr<Reactor> reactor = Reactor::make();
-    reactor->run_with_initial_event([=]() {
+    ctx->reactor->run_with_initial_event([=]() {
         protocol::wait_in_queue_impl<queued_then_whitelisted>(ctx, [=](Error e) {
             REQUIRE((e == NoError()));
-            reactor->stop();
+            ctx->reactor->stop();
         });
     });
 }

--- a/test/ndt/run.cpp
+++ b/test/ndt/run.cpp
@@ -90,7 +90,7 @@ TEST_CASE("We deal with recv-results-and-logout error") {
                                   success, success, failure, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("run() deals with invalid port error") {
@@ -98,7 +98,7 @@ TEST_CASE("run() deals with invalid port error") {
     run(entry, [](Error err) { REQUIRE(err == InvalidPortError()); },
         {
             {"port", "xo"},
-        });
+        }, Reactor::make(), Logger::make());
 }
 
 static void fail(std::string, Callback<Error, mlabns::Reply> cb, Settings,
@@ -110,7 +110,7 @@ TEST_CASE("run() deals with mlab-ns query error") {
     SharedPtr<nlohmann::json> entry{new nlohmann::json};
     run_impl<run_with_specific_server, fail>(
         entry, [](Error err) { REQUIRE(err == MlabnsQueryError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 /*
@@ -131,6 +131,6 @@ TEST_CASE("NDT test run() should work") {
         ndt::run(entry, [=](Error err) {
             REQUIRE(!err);
             reactor->stop();
-        }, settings, reactor);
+        }, settings, reactor, Logger::make());
     });
 }

--- a/test/ndt/run.cpp
+++ b/test/ndt/run.cpp
@@ -29,7 +29,7 @@ TEST_CASE("We deal with connect error") {
     run_with_specific_server_impl<failure, die, die, die, die, die, die, die,
                                   die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with send-login error") {
@@ -37,7 +37,7 @@ TEST_CASE("We deal with send-login error") {
     run_with_specific_server_impl<success, failure, die, die, die, die, die,
                                   die, die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with recv-and-ignore-kickoff error") {
@@ -45,7 +45,7 @@ TEST_CASE("We deal with recv-and-ignore-kickoff error") {
     run_with_specific_server_impl<success, success, failure, die, die, die, die,
                                   die, die, protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with wait-in-queue error") {
@@ -54,7 +54,7 @@ TEST_CASE("We deal with wait-in-queue error") {
                                   die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with recv-version error") {
@@ -63,7 +63,7 @@ TEST_CASE("We deal with recv-version error") {
                                   die, die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with recv-tests-id error") {
@@ -72,7 +72,7 @@ TEST_CASE("We deal with recv-tests-id error") {
                                   failure, die, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with run-tests error") {
@@ -81,7 +81,7 @@ TEST_CASE("We deal with run-tests error") {
                                   success, failure, die, die,
                                   protocol::disconnect_and_callback>(
         entry, "127.0.0.1", 3001, [](Error err) { REQUIRE(err == MockedError()); }, {},
-        Reactor::global(), Logger::global());
+        Reactor::make(), Logger::make());
 }
 
 TEST_CASE("We deal with recv-results-and-logout error") {

--- a/test/ndt/test_c2s.cpp
+++ b/test/ndt/test_c2s.cpp
@@ -21,16 +21,16 @@ TEST_CASE("coroutine() is robust to connect error") {
     test_c2s::coroutine_impl<fail>(
         entry, "www.google.com", 3301, 10.0,
         [](Error err, Continuation<Error>) { REQUIRE(err == MockedError()); },
-        2.0, {}, Reactor::global(), Logger::global());
+        2.0, {}, Reactor::make(), Logger::make());
 }
 
 static void fail(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, "");
 }
 
 static void invalid(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -48,7 +48,7 @@ TEST_CASE("run() deals with receiving message different from PREPARE") {
 
 static void invalid_port(SharedPtr<Context>,
                          Callback<Error, uint8_t, std::string> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "foobar");
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("run() deals with receiving invalid port") {
 }
 
 static void too_large(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "65536");
 }
 
@@ -70,7 +70,7 @@ TEST_CASE("run() deals with receiving too large port") {
 }
 
 static void too_small(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "-1");
 }
 
@@ -82,7 +82,7 @@ TEST_CASE("run() deals with receiving too small port") {
 
 static void test_prepare(SharedPtr<Context>,
                          Callback<Error, uint8_t, std::string> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -120,7 +120,7 @@ TEST_CASE("run() deals with unexpected message instead of TEST_START") {
 }
 
 static void test_start(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                       SharedPtr<Reactor> = Reactor::global()) {
+                       SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_START, "");
 }
 
@@ -149,7 +149,7 @@ TEST_CASE("run() deals with unexpected message instead of TEST_MSG") {
 }
 
 static void test_msg(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                     SharedPtr<Reactor> = Reactor::global()) {
+                     SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_MSG, "");
 }
 

--- a/test/ndt/test_meta.cpp
+++ b/test/ndt/test_meta.cpp
@@ -14,7 +14,7 @@ using namespace mk::ndt;
 using namespace mk::net;
 
 static void fail(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                 SharedPtr<Reactor> = Reactor::global()) {
+                 SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, "");
 }
 
@@ -25,7 +25,7 @@ TEST_CASE("run() deals with read() error") {
 }
 
 static void unexpected(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                       SharedPtr<Reactor> = Reactor::global()) {
+                       SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -37,7 +37,7 @@ TEST_CASE("run() deals with unexpected message type") {
 
 static void test_prepare(SharedPtr<Context>,
                          Callback<Error, uint8_t, std::string> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "");
 }
 
@@ -62,7 +62,7 @@ static ErrorOr<Buffer> success(std::string s) {
 }
 
 static void test_start(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                       SharedPtr<Reactor> = Reactor::global()) {
+                       SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_START, "");
 }
 
@@ -75,7 +75,7 @@ TEST_CASE("run() deals with first format_test_msg() error") {
 
 TEST_CASE("run() deals with second format_test_msg() error") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     test_meta::run_impl<test_prepare, test_start, success, fail>(
         ctx,
         [](Error err) { REQUIRE(err == SerializingClientApplicationError()); });
@@ -83,7 +83,7 @@ TEST_CASE("run() deals with second format_test_msg() error") {
 
 TEST_CASE("run() deals with third format_test_msg() error") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     test_meta::run_impl<test_prepare, test_start, success, success, fail>(
         ctx, [](Error err) { REQUIRE(err == SerializingFinalMetaError()); });
 }
@@ -94,7 +94,7 @@ static void fail(SharedPtr<Context>, Buffer, Callback<Error> cb) {
 
 TEST_CASE("run() deals with write error") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         fail>(
         ctx, [](Error err) { REQUIRE(err == WritingMetaError()); });
@@ -104,7 +104,7 @@ static void success(SharedPtr<Context>, Buffer, Callback<Error> cb) { cb(NoError
 
 TEST_CASE("run() deals with third read() error") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         success, fail>(
         ctx, [](Error err) { REQUIRE(err == ReadingTestFinalizeError()); });
@@ -112,7 +112,7 @@ TEST_CASE("run() deals with third read() error") {
 
 TEST_CASE("run() deals with unexpected message on third read") {
     SharedPtr<Context> ctx(new Context);
-    ctx->txp.reset(new Emitter(Reactor::global(), Logger::global()));
+    ctx->txp.reset(new Emitter(Reactor::make(), Logger::make()));
     test_meta::run_impl<test_prepare, test_start, success, success, success,
                         success, unexpected>(
         ctx, [](Error err) { REQUIRE(err == NotTestFinalizeError()); });

--- a/test/ndt/test_s2c.cpp
+++ b/test/ndt/test_s2c.cpp
@@ -23,11 +23,11 @@ TEST_CASE("coroutine() is robust to connect error") {
         [](Error err, Continuation<Error, double>) {
             REQUIRE(err == MockedError());
         },
-        2.0, {}, Reactor::global(), Logger::global());
+        2.0, {}, Reactor::make(), Logger::make());
 }
 
 static void failure(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, "");
 }
 
@@ -39,7 +39,7 @@ TEST_CASE("finalizing_test() deals with read_msg() error") {
 }
 
 static void invalid(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), MSG_ERROR, "");
 }
 
@@ -52,7 +52,7 @@ TEST_CASE("finalizing_test() deals with receiving invalid message") {
 
 // XXX: static test function with a state is not good
 static void empty(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                  SharedPtr<Reactor> = Reactor::global()) {
+                  SharedPtr<Reactor> = Reactor::make()) {
     static int count = 0;
     if (count++ == 0) {
         cb(NoError(), TEST_MSG, "");
@@ -83,7 +83,7 @@ TEST_CASE("run() deals with receiving message different from PREPARE") {
 
 static void invalid_port(SharedPtr<Context>,
                          Callback<Error, uint8_t, std::string> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "foobar");
 }
 
@@ -94,7 +94,7 @@ TEST_CASE("run() deals with receiving invalid port") {
 }
 
 static void too_large(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "65536");
 }
 
@@ -105,7 +105,7 @@ TEST_CASE("run() deals with receiving too large port") {
 }
 
 static void too_small(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                      SharedPtr<Reactor> = Reactor::global()) {
+                      SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "-1");
 }
 
@@ -116,7 +116,7 @@ TEST_CASE("run() deals with receiving too small port") {
 }
 
 static void success(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -136,7 +136,7 @@ TEST_CASE("run() deals with coroutine failure") {
 
 static void test_prepare(SharedPtr<Context>,
                          Callback<Error, uint8_t, std::string> cb,
-                         SharedPtr<Reactor> = Reactor::global()) {
+                         SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_PREPARE, "3010");
 }
 
@@ -160,7 +160,7 @@ TEST_CASE("run() deals with unexpected message instead of TEST_START") {
 }
 
 static void test_start(SharedPtr<Context>, Callback<Error, uint8_t, std::string> cb,
-                       SharedPtr<Reactor> = Reactor::global()) {
+                       SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_START, "");
 }
 
@@ -177,7 +177,7 @@ static void coro_ok(SharedPtr<nlohmann::json>, std::string, test_s2c::Params,
 }
 
 static void failure(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(MockedError(), 0, {});
 }
 
@@ -188,7 +188,7 @@ TEST_CASE("run() deals with error when reading TEST_MSG") {
 }
 
 static void invalid(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                    SharedPtr<Reactor> = Reactor::global()) {
+                    SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), MSG_ERROR, {});
 }
 
@@ -199,7 +199,7 @@ TEST_CASE("run() deals with unexpected message instead of TEST_MSG") {
 }
 
 static void msg_test(SharedPtr<Context>, Callback<Error, uint8_t, nlohmann::json> cb,
-                     SharedPtr<Reactor> = Reactor::global()) {
+                     SharedPtr<Reactor> = Reactor::make()) {
     cb(NoError(), TEST_MSG, {});
 }
 

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -35,7 +35,7 @@ static Error fail(std::string, uint16_t, sockaddr_storage *, socklen_t *) {
 TEST_CASE("connect_base deals with evutil_parse_sockaddr_port error") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
-        connect_base<fail>("130.192.16.172", 80, 3.14, reactor, Logger::global(),
+        connect_base<fail>("130.192.16.172", 80, 3.14, reactor, Logger::make(),
                            [=](Error e, bufferevent *b, double) {
                                REQUIRE(e);
                                REQUIRE(b == nullptr);
@@ -50,7 +50,7 @@ TEST_CASE("connect_base deals with bufferevent_socket_new error") {
     bool ok = false;
     try {
         connect_base<make_sockaddr, fail>("130.192.16.172", 80, 3.14,
-                Reactor::global(), Logger::global(), nullptr);
+                Reactor::make(), Logger::make(), nullptr);
     } catch (GenericError &) {
         ok = true;
     }
@@ -63,8 +63,8 @@ TEST_CASE("connect_base deals with bufferevent_set_timeouts error") {
     bool ok = false;
     try {
         connect_base<make_sockaddr, ::bufferevent_socket_new,
-                     fail>("130.192.16.172", 80, 3.14, Reactor::global(),
-                           Logger::global(), nullptr);
+                     fail>("130.192.16.172", 80, 3.14, Reactor::make(),
+                           Logger::make(), nullptr);
     } catch (GenericError &) {
         ok = true;
     }
@@ -88,7 +88,7 @@ TEST_CASE("connect_base deals with bufferevent_socket_connect error") {
     reactor->run_with_initial_event([=]() {
         connect_base<make_sockaddr, ::bufferevent_socket_new,
                      bufferevent_set_timeouts, Fail::fail>(
-            "130.192.16.172", 80, 3.14, reactor, Logger::global(),
+            "130.192.16.172", 80, 3.14, reactor, Logger::make(),
             [=](Error e, bufferevent *b, double) {
                 REQUIRE(e);
                 REQUIRE(b == nullptr);
@@ -110,7 +110,7 @@ TEST_CASE("net::connect_many() correctly handles net::connect() success") {
                               REQUIRE(!err);
                               REQUIRE(conns.size() == 3);
                           },
-                          {}, reactor, Logger::global());
+                          {}, reactor, Logger::make());
     connect_many_impl<success>(ctx);
 }
 
@@ -127,7 +127,7 @@ TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
                               REQUIRE(err);
                               REQUIRE(conns.size() == 1);
                           },
-                          {}, reactor, Logger::global());
+                          {}, reactor, Logger::make());
     connect_many_impl<fail>(ctx);
 }
 
@@ -143,7 +143,7 @@ TEST_CASE("net::connect_many() correctly handles net::connect() failure") {
 TEST_CASE("connect_base works with ipv4") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
-        connect_base("130.192.16.172", 80, 3.14, reactor, Logger::global(),
+        connect_base("130.192.16.172", 80, 3.14, reactor, Logger::make(),
                      [=](Error err, bufferevent *bev, double) {
                          REQUIRE(!err);
                          REQUIRE(bev);
@@ -161,7 +161,7 @@ static bool check_error(Error err) {
 TEST_CASE("connect_base works with ipv4 and closed port") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
-        connect_base("130.192.16.172", 81, 3.14, reactor, Logger::global(),
+        connect_base("130.192.16.172", 81, 3.14, reactor, Logger::make(),
                      [=](Error err, bufferevent *bev, double) {
                          REQUIRE(check_error(err));
                          REQUIRE(bev == nullptr);
@@ -173,7 +173,7 @@ TEST_CASE("connect_base works with ipv4 and closed port") {
 TEST_CASE("connect_base works with ipv4 and timeout") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
-        connect_base("130.192.16.172", 80, 0.00001, reactor, Logger::global(),
+        connect_base("130.192.16.172", 80, 0.00001, reactor, Logger::make(),
                      [=](Error err, bufferevent *bev, double) {
                          REQUIRE(err == TimeoutError());
                          REQUIRE(bev == nullptr);
@@ -185,7 +185,7 @@ TEST_CASE("connect_base works with ipv4 and timeout") {
 TEST_CASE("connect_base works with ipv6") {
     SharedPtr<Reactor> reactor = Reactor::make();
     reactor->run_with_initial_event([=]() {
-        connect_base("2a00:1450:4001:801::1004", 80, 3.14, reactor, Logger::global(),
+        connect_base("2a00:1450:4001:801::1004", 80, 3.14, reactor, Logger::make(),
                      [=](Error err, bufferevent *bev, double) {
                          /* Coverage note: depending on whether IPv6
                             works or not here we're going to see either

--- a/test/net/connect.cpp
+++ b/test/net/connect.cpp
@@ -213,7 +213,7 @@ TEST_CASE("connect_first_of works with empty vector") {
                              REQUIRE(bev == nullptr);
                              reactor->stop();
                          },
-                         {{"net/timeout", 3.14}}, reactor);
+                         {{"net/timeout", 3.14}}, reactor, Logger::make());
     });
 }
 
@@ -235,7 +235,7 @@ TEST_CASE("connect_first_of works when all connect fail") {
                 REQUIRE(bev == nullptr);
                 reactor->stop();
             },
-            {{"net/timeout", 0.00001}}, reactor);
+            {{"net/timeout", 0.00001}}, reactor, Logger::make());
     });
 }
 
@@ -258,7 +258,7 @@ TEST_CASE("connect_first_of works when a connect succeeds") {
                 ::bufferevent_free(bev);
                 reactor->stop();
             },
-            {{"net/timeout", 3.14}}, reactor);
+            {{"net/timeout", 3.14}}, reactor, Logger::make());
     });
 }
 
@@ -270,7 +270,7 @@ TEST_CASE("connect() works with valid IPv4") {
             REQUIRE(r->connected_bev != nullptr);
             ::bufferevent_free(r->connected_bev);
             reactor->stop();
-        }, {}, reactor);
+        }, {}, reactor, Logger::make());
     });
 }
 
@@ -281,7 +281,7 @@ TEST_CASE("connect() fails when port is closed or filtered") {
             REQUIRE(e);
             REQUIRE(r->connected_bev == nullptr);
             reactor->stop();
-        }, {{"net/timeout", 1.0}}, reactor);
+        }, {{"net/timeout", 1.0}}, reactor, Logger::make());
     });
 }
 
@@ -298,7 +298,7 @@ TEST_CASE("connect() fails when setting an invalid dns") {
                        {"dns/timeout", 0.001},
                        {"dns/engine", "libevent"},
                        {"dns/attempts", 1}},
-                      reactor);
+                      reactor, Logger::make());
     });
 }
 
@@ -318,7 +318,7 @@ TEST_CASE("net::connect_many() works as expected") {
                                  }
                              });
                          }
-                     }, {}, reactor);
+                     }, {}, reactor, Logger::make());
     });
 }
 
@@ -336,7 +336,7 @@ TEST_CASE("net::connect() works with a custom reactor") {
                     txp->close([&]() { reactor->stop(); });
                     ok = true;
                 },
-                {}, reactor, Logger::global());
+                {}, reactor, Logger::make());
     });
     REQUIRE(ok);
 }
@@ -351,7 +351,7 @@ TEST_CASE("net::connect() can connect to open port") {
             REQUIRE(!resolve_result.inet_pton_ipv6);
             REQUIRE(resolve_result.addresses.size() > 0);
             txp->close([=]() { reactor->stop(); });
-        }, {}, reactor);
+        }, {}, reactor, Logger::make());
     });
 }
 
@@ -369,7 +369,7 @@ TEST_CASE("net::connect() can connect to ssl port") {
                 },
                 {{"net/ssl", true},
                  {"net/ca_bundle_path", "test/fixtures/saved_ca_bundle.pem"}},
-                reactor);
+                reactor, Logger::make());
     });
 }
 
@@ -383,7 +383,7 @@ TEST_CASE("net::connect() ssl fails when presented an expired certificate") {
                 },
                 {{"net/ssl", true},
                  {"net/ca_bundle_path", "test/fixtures/saved_ca_bundle.pem"}},
-                reactor);
+                reactor, Logger::make());
     });
 }
 
@@ -398,7 +398,7 @@ TEST_CASE("net::connect() ssl fails when presented a certificate with the "
                 },
                 {{"net/ssl", true},
                  {"net/ca_bundle_path", "test/fixtures/saved_ca_bundle.pem"}},
-                reactor);
+                reactor, Logger::make());
     });
 }
 
@@ -412,7 +412,7 @@ TEST_CASE("net::connect() ssl works when using SNI") {
                 },
                 {{"net/ssl", true},
                  {"net/ca_bundle_path", "test/fixtures/saved_ca_bundle.pem"}},
-                reactor);
+                reactor, Logger::make());
     });
 }
 
@@ -429,6 +429,6 @@ TEST_CASE("net::connect() works in case of error") {
                     reactor->stop();
                 },
                 {{"net/timeout", 5.0}},
-                reactor);
+                reactor, Logger::make());
     });
 }

--- a/test/net/emitter.cpp
+++ b/test/net/emitter.cpp
@@ -13,14 +13,14 @@ using namespace mk::net;
 
 TEST_CASE("The record-received-data feature works") {
     SECTION("By default recording is disabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.emit_data(Buffer("foobar"));
         REQUIRE(transport.received_data().length() == 0);
     }
 
     SECTION("Recording works correctly when enabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.emit_data(Buffer("foobar"));
@@ -28,7 +28,7 @@ TEST_CASE("The record-received-data feature works") {
     }
 
     SECTION("Recording can also be disabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.emit_data(Buffer("foobar"));
@@ -38,7 +38,7 @@ TEST_CASE("The record-received-data feature works") {
     }
 
     SECTION("Recording input data does not modify input data") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_received_data();
         transport.on_data([](Buffer data) { REQUIRE(data.read() == "foo"); });
@@ -60,14 +60,14 @@ Helper::~Helper() {}
 
 TEST_CASE("The record-sent-data feature works") {
     SECTION("By default recording is disabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.write("foobar");
         REQUIRE(transport.sent_data().length() == 0);
     }
 
     SECTION("Recording works correctly when enabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foobar");
@@ -75,7 +75,7 @@ TEST_CASE("The record-sent-data feature works") {
     }
 
     SECTION("Recording can also be disabled") {
-        Emitter emitter(Reactor::global(), Logger::global());
+        Emitter emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foobar");
@@ -85,7 +85,7 @@ TEST_CASE("The record-sent-data feature works") {
     }
 
     SECTION("Recording output data does not modify output data") {
-        Helper emitter(Reactor::global(), Logger::global());
+        Helper emitter(Reactor::make(), Logger::make());
         Transport &transport = emitter;
         transport.record_sent_data();
         transport.write("foo");

--- a/test/net/libssl.cpp
+++ b/test/net/libssl.cpp
@@ -19,9 +19,9 @@ static SSL *ssl_new_fail(SSL_CTX *) { return nullptr; }
 
 TEST_CASE("Context::get_client_ssl() works") {
     SECTION("when SSL_new() fails") {
-        auto context = Context::make(default_cert, Logger::global());
+        auto context = Context::make(default_cert, Logger::make());
         auto maybe_ssl = (*context)->get_client_ssl<ssl_new_fail>(
-              "www.google.com", Logger::global());
+              "www.google.com", Logger::make());
         REQUIRE(!maybe_ssl);
         REQUIRE(maybe_ssl.as_error() == SslNewError());
     }
@@ -36,13 +36,13 @@ static int ssl_ctx_load_verify_locations_fail(SSL_CTX *, const char *,
 
 TEST_CASE("Context::make() works") {
     SECTION("when the ca_bundle_path is empty") {
-        auto maybe_ctx = Context::make("", Logger::global());
+        auto maybe_ctx = Context::make("", Logger::make());
         REQUIRE(!maybe_ctx);
         REQUIRE(maybe_ctx.as_error() == MissingCaBundlePathError());
     }
 
     SECTION("when SSL_CTX_new() fails") {
-        auto maybe_ctx = Context::make<ssl_ctx_new_fail>("/nonexistent", Logger::global());
+        auto maybe_ctx = Context::make<ssl_ctx_new_fail>("/nonexistent", Logger::make());
         REQUIRE(!maybe_ctx);
         REQUIRE(maybe_ctx.as_error() == SslCtxNewError());
     }
@@ -50,7 +50,7 @@ TEST_CASE("Context::make() works") {
     SECTION("when SSL_CTX_load_verify_locations() fails") {
         auto maybe_ctx =
               Context::make<SSL_CTX_new, ssl_ctx_load_verify_locations_fail>(
-                    default_cert, Logger::global());
+                    default_cert, Logger::make());
         REQUIRE(!maybe_ctx);
         REQUIRE(maybe_ctx.as_error() == SslCtxLoadVerifyLocationsError());
     }
@@ -64,7 +64,7 @@ TEST_CASE("Cache works as expected") {
     SECTION("different threads get different SSL_CTX") {
         auto make = []() {
             return Cache<>::thread_local_instance()->get_client_ssl(
-                  default_cert, "www.google.com", Logger::global());
+                  default_cert, "www.google.com", Logger::make());
         };
         auto first = std::async(std::launch::async, make).get();
         auto second = std::async(std::launch::async, make).get();
@@ -77,12 +77,12 @@ TEST_CASE("Cache works as expected") {
         auto cache = Cache<1>{};
         REQUIRE(cache.size() == 0);
         auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
-                                        Logger::global());
+                                        Logger::make());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
         ssl = cache.get_client_ssl("./test/fixtures/saved_ca_bundle.pem",
-                                   "www.google.com", Logger::global());
+                                   "www.google.com", Logger::make());
         REQUIRE(*ssl != nullptr);
         // Note: we expect this to be equal to one, meaning that the first
         // created SSL_CTX has been evicted, given cache size.
@@ -94,12 +94,12 @@ TEST_CASE("Cache works as expected") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
         auto ssl = cache.get_client_ssl(default_cert, "www.google.com",
-                                        Logger::global());
+                                        Logger::make());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 1);
         SSL_free(*ssl);
         ssl = cache.get_client_ssl("./test/fixtures/basic_ca.pem",
-                                   "www.google.com", Logger::global());
+                                   "www.google.com", Logger::make());
         REQUIRE(*ssl != nullptr);
         REQUIRE(cache.size() == 2);
         SSL_free(*ssl);
@@ -109,10 +109,10 @@ TEST_CASE("Cache works as expected") {
         auto cache = Cache<>{};
         REQUIRE(cache.size() == 0);
         auto first = cache.get_client_ssl(default_cert, "www.google.com",
-                                          Logger::global());
+                                          Logger::make());
         REQUIRE(!!first);
         auto second = cache.get_client_ssl(default_cert, "www.kernel.org",
-                                           Logger::global());
+                                           Logger::make());
         REQUIRE(!!second);
         REQUIRE(SSL_get_SSL_CTX(*first) == SSL_get_SSL_CTX(*second));
         SSL_free(*first);
@@ -122,7 +122,7 @@ TEST_CASE("Cache works as expected") {
     SECTION("cache behaves when Context::make fails") {
         auto cache = Cache<>{};
         auto r = cache.get_client_ssl<context_make_fail>(
-              default_cert, "www.google.com", Logger::global());
+              default_cert, "www.google.com", Logger::make());
         REQUIRE(!r);
         REQUIRE(r.as_error() == MockedError());
     }
@@ -157,35 +157,35 @@ TEST_CASE("verify_peer works as expected") {
     Cache<> c;
 
     SECTION("when SSL_get_verify_result fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::make());
         REQUIRE(verify_peer<ssl_get_verify_result_fail>(
-                      "", ssl, Logger::global()) != NoError());
+                      "", ssl, Logger::make()) != NoError());
         SSL_free(ssl);
     }
 
     SECTION("when SSL_get_peer_certificate fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::make());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_fail>(
-                      "", ssl, Logger::global())) != NoError());
+                      "", ssl, Logger::make())) != NoError());
         SSL_free(ssl);
     }
 
     SECTION("when tls_check_name fails") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::make());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
-                             tls_check_name_fail>("", ssl, Logger::global())) !=
+                             tls_check_name_fail>("", ssl, Logger::make())) !=
                 NoError());
         SSL_free(ssl);
     }
 
     SECTION("when tls_check_name does not match") {
-        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::global());
+        auto ssl = *c.get_client_ssl(default_cert, "x.org", Logger::make());
         REQUIRE((verify_peer<ssl_get_verify_result_success,
                              ssl_get_peer_certificate_success,
                              tls_check_name_nomatch>(
-                      "", ssl, Logger::global())) != NoError());
+                      "", ssl, Logger::make())) != NoError());
         SSL_free(ssl);
     }
 }

--- a/test/nettests/http_header_field_manipulation.cpp
+++ b/test/nettests/http_header_field_manipulation.cpp
@@ -29,7 +29,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                        Logger::global());
+                                        Logger::make());
         REQUIRE((*entry)["tampering"]["total"] == true);
         REQUIRE((*entry)["tampering"]["request_line_capitalization"] == true);
     }
@@ -38,7 +38,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["total"] == true);
         REQUIRE((*entry)["tampering"]["request_line_capitalization"] == true);
     }
@@ -47,7 +47,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["total"].get<bool>() == false);
         REQUIRE((*entry)["tampering"]["request_line_capitalization"] == true);
     }
@@ -56,7 +56,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["total"].get<bool>() == false);
         REQUIRE((*entry)["tampering"]["request_line_capitalization"] == true);
     }
@@ -65,7 +65,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["total"].get<bool>() == false);
         REQUIRE((*entry)["tampering"]["request_line_capitalization"].get<bool>() == false);
     }
@@ -75,7 +75,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["header_name_diff"] == std::set<std::string>{"foo2"});
         REQUIRE((*entry)["tampering"]["header_field_name"] == true);
     }
@@ -84,7 +84,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"}, {"foo2", "bar2"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["header_name_diff"] == std::set<std::string>{"foo"});
         REQUIRE((*entry)["tampering"]["header_field_name"] == true);
     }
@@ -93,7 +93,7 @@ TEST_CASE("compare_headers_response works") {
         ooni::compare_headers_response({ {"foo", "bar"} },
                                        response,
                                        entry,
-                                       Logger::global());
+                                       Logger::make());
         REQUIRE((*entry)["tampering"]["header_name_diff"] == std::set<std::string>{});
         REQUIRE((*entry)["tampering"]["header_field_name"].get<bool>() == false);
     }

--- a/test/nettests/utils.cpp
+++ b/test/nettests/utils.cpp
@@ -42,7 +42,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         std::deque<std::string> inputs;
         mk::Error error =
             mk::nettests::process_input_filepaths(inputs,
-                true, {}, "IT", {}, mk::Logger::global(), nullptr, nullptr);
+                true, {}, "IT", {}, mk::Logger::make(), nullptr, nullptr);
         REQUIRE(error);
         REQUIRE(error ==
                 mk::ooni::MissingRequiredInputFileError());
@@ -55,7 +55,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         std::deque<std::string> inputs{"antani"};
         mk::Error error =
             mk::nettests::process_input_filepaths(inputs,
-                true, {}, "IT", {}, mk::Logger::global(), nullptr, nullptr);
+                true, {}, "IT", {}, mk::Logger::make(), nullptr, nullptr);
         REQUIRE(!error);
         REQUIRE(error == mk::NoError());
     }
@@ -65,7 +65,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         mk::Error error =
             mk::nettests::process_input_filepaths_impl<check_variable_expanded>(
                 inputs,
-                true, {"${probe_cc}"}, "IT", {}, mk::Logger::global(), nullptr,
+                true, {"${probe_cc}"}, "IT", {}, mk::Logger::make(), nullptr,
                 nullptr);
         /*
          * We are going to fail because the mocked function returns a
@@ -83,7 +83,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                                                        cannot_read_line>(
                 inputs,
                 true, {"./test/fixtures/urls.txt"}, "IT", {},
-                mk::Logger::global(), nullptr, nullptr);
+                mk::Logger::make(), nullptr, nullptr);
         REQUIRE(error);
         REQUIRE(error ==
                 mk::ooni::CannotReadAnyInputFileError());
@@ -94,7 +94,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         std::string cannot_open;
         mk::Error error =
             mk::nettests::process_input_filepaths(inputs,
-                true, {"./nonexistent"}, "IT", {}, mk::Logger::global(),
+                true, {"./nonexistent"}, "IT", {}, mk::Logger::make(),
                 [&](const std::string &p) { cannot_open = p; }, nullptr);
         REQUIRE(error);
         REQUIRE(error ==
@@ -109,7 +109,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
             mk::nettests::process_input_filepaths_impl<mk::nettests::open_file_,
                                                        simulate_io_error>(
                 inputs, true, {"./test/fixtures/urls.txt"}, "IT", {},
-                mk::Logger::global(), nullptr,
+                mk::Logger::make(), nullptr,
                 [&](const std::string &p) { cannot_read = p; });
         REQUIRE(error);
         REQUIRE(error ==
@@ -122,7 +122,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         mk::Error error =
             mk::nettests::process_input_filepaths(
                 inputs, true, {"./test/fixtures/urls.txt"}, "IT",
-                {{"randomize_input", "antani"}}, mk::Logger::global(), nullptr,
+                {{"randomize_input", "antani"}}, mk::Logger::make(), nullptr,
                 nullptr);
         REQUIRE(error);
         REQUIRE(error == mk::ValueError());
@@ -135,7 +135,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                 mk::nettests::open_file_, mk::nettests::readline_,
                 intercept_randomize>(inputs, true, {"./test/fixtures/urls.txt"}, "IT",
                                      {{"randomize_input", "1"}},
-                                     mk::Logger::global(), nullptr, nullptr)),
+                                     mk::Logger::make(), nullptr, nullptr)),
             mk::MockedError);
     }
 
@@ -145,7 +145,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                               mk::nettests::open_file_, mk::nettests::readline_,
                               intercept_randomize>(inputs,
                               true, {"./test/fixtures/urls.txt"}, "IT", {},
-                              mk::Logger::global(), nullptr, nullptr)),
+                              mk::Logger::make(), nullptr, nullptr)),
                           mk::MockedError);
     }
 
@@ -156,7 +156,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
                                                    mk::nettests::readline_,
                                                    intercept_randomize>(
             inputs, true, {"./test/fixtures/urls.txt"}, "IT",
-            {{"randomize_input", "0"}}, mk::Logger::global(), nullptr, nullptr);
+            {{"randomize_input", "0"}}, mk::Logger::make(), nullptr, nullptr);
     }
 
     SECTION("The randomize primitive works as expected") {
@@ -194,7 +194,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         mk::Error error =
             mk::nettests::process_input_filepaths(
                 inputs, false, {"./test/fixtures/urls.txt"}, "IT",
-                {{"randomize_input", "antani"}}, mk::Logger::global(), nullptr,
+                {{"randomize_input", "antani"}}, mk::Logger::make(), nullptr,
                 nullptr);
         REQUIRE(!error);
         REQUIRE(inputs.size() == 1);
@@ -206,7 +206,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         mk::Error error =
             mk::nettests::process_input_filepaths(
                 inputs, false, {"./test/fixtures/urls.txt"}, "IT",
-                {{"randomize_input", "antani"}}, mk::Logger::global(), nullptr,
+                {{"randomize_input", "antani"}}, mk::Logger::make(), nullptr,
                 nullptr);
         REQUIRE(!error);
         REQUIRE(inputs.size() == 1);
@@ -229,7 +229,7 @@ TEST_CASE("process_input_filepaths() works as expected") {
         mk::Error error =
             mk::nettests::process_input_filepaths(inputs,
                 true, {"./test/fixtures/urls.txt"}, "IT", {},
-                mk::Logger::global(), nullptr, nullptr);
+                mk::Logger::make(), nullptr, nullptr);
         REQUIRE(!error);
         std::unordered_set<std::string> result(inputs.begin(),
                                                inputs.end());

--- a/test/ooni/bouncer.cpp
+++ b/test/ooni/bouncer.cpp
@@ -14,35 +14,35 @@ TEST_CASE("BouncerReply::create() works") {
 
     SECTION("When the collector is not found") {
         auto maybe_reply = ooni::BouncerReply::create(
-            R"({"error": "collector-not-found"})", Logger::global());
+            R"({"error": "collector-not-found"})", Logger::make());
         REQUIRE(!maybe_reply);
         REQUIRE(maybe_reply.as_error() == JsonProcessingError());
     }
 
     SECTION("When the response is invalid") {
         auto maybe_reply = ooni::BouncerReply::create(
-            R"({"error": "invalid-request"})", Logger::global());
+            R"({"error": "invalid-request"})", Logger::make());
         REQUIRE(!maybe_reply);
         REQUIRE(maybe_reply.as_error() == JsonProcessingError());
     }
 
     SECTION("When the error is something else") {
         auto maybe_reply = ooni::BouncerReply::create(
-            R"({"error": "xx"})", Logger::global());
+            R"({"error": "xx"})", Logger::make());
         REQUIRE(!maybe_reply);
         REQUIRE(maybe_reply.as_error() == JsonProcessingError());
     }
 
     SECTION("When the net-tests section is missing") {
         auto maybe_reply = ooni::BouncerReply::create(
-            R"({})", Logger::global());
+            R"({})", Logger::make());
         REQUIRE(!maybe_reply);
         REQUIRE(maybe_reply.as_error() == JsonProcessingError());
     }
 
     SECTION("When the parser throws invalid_argument") {
         auto maybe_reply = ooni::BouncerReply::create(
-            R"({)", Logger::global());
+            R"({)", Logger::make());
         REQUIRE(!maybe_reply);
         REQUIRE(maybe_reply.as_error() == JsonProcessingError());
     }
@@ -51,7 +51,7 @@ TEST_CASE("BouncerReply::create() works") {
 TEST_CASE("BouncerReply accessors are robust to missing fields") {
     auto maybe_reply = ooni::BouncerReply::create(
         R"({"net-tests": [{"test-helpers-alternate":[], "collector-alternate":1234}]})",
-        Logger::global());
+        Logger::make());
     REQUIRE(!!maybe_reply);
     auto reply = *maybe_reply;
 
@@ -94,8 +94,8 @@ TEST_CASE("BouncerReply accessors are robust to missing fields") {
 
 static void request_error(Settings, http::Headers, std::string,
                           Callback<Error, SharedPtr<http::Response>> cb,
-                          SharedPtr<Reactor> = Reactor::global(),
-                          SharedPtr<Logger> = Logger::global(),
+                          SharedPtr<Reactor> = Reactor::make(),
+                          SharedPtr<Logger> = Logger::make(),
                           SharedPtr<http::Response> = nullptr, int = 0) {
     cb(MockedError(), nullptr);
 }
@@ -115,7 +115,7 @@ TEST_CASE("post_net_tests() works") {
                     REQUIRE(e == MockedError());
                     reactor->stop();
                 },
-                settings, reactor, Logger::global());
+                settings, reactor, Logger::make());
         });
     }
 
@@ -131,7 +131,7 @@ TEST_CASE("post_net_tests() works") {
                     REQUIRE(e == JsonProcessingError());
                     reactor->stop();
                 },
-                settings, reactor, Logger::global());
+                settings, reactor, Logger::make());
         });
     }
 
@@ -170,7 +170,7 @@ TEST_CASE("post_net_tests() works") {
                                 "web-connectivity", "cloudfront"));
                     reactor->stop();
                 },
-                settings, reactor, Logger::global());
+                settings, reactor, Logger::make());
         });
     }
 }

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -52,7 +52,7 @@ class MockConnection : public Emitter, public NonCopyable, public NonMovable {
     Callback<> close_cb;
     SharedPtr<Transport> self;
 
-    MockConnection(SharedPtr<Reactor> reactor) : Emitter(reactor, Logger::global()) {}
+    MockConnection(SharedPtr<Reactor> reactor) : Emitter(reactor, Logger::make()) {}
 };
 
 void MockConnection::close(Callback<> cb) {
@@ -81,7 +81,7 @@ TEST_CASE("collector:post deals with missing URL") {
                              REQUIRE(err == MissingCollectorBaseUrlError());
                              reactor->stop();
                          },
-                         {}, reactor, Logger::global());
+                         {}, reactor, Logger::make());
     });
 }
 
@@ -103,7 +103,7 @@ TEST_CASE("collector::post deals with network error") {
                                    REQUIRE(r == nullptr);
                                    reactor->stop();
                                },
-                               SETTINGS, reactor, Logger::global());
+                               SETTINGS, reactor, Logger::make());
     });
 }
 
@@ -125,7 +125,7 @@ TEST_CASE("collector::post deals with unexpected response") {
             REQUIRE(r == nullptr);
             reactor->stop();
         },
-        SETTINGS, reactor, Logger::global());
+        SETTINGS, reactor, Logger::make());
     });
 }
 
@@ -146,7 +146,7 @@ TEST_CASE("collector::post deals with empty response") {
                                     REQUIRE(r == nullptr);
                                     reactor->stop();
                                 },
-                                SETTINGS, reactor, Logger::global());
+                                SETTINGS, reactor, Logger::make());
     });
 }
 
@@ -169,7 +169,7 @@ TEST_CASE("collector::post deals with invalid json") {
                                            reactor->stop();
                                        },
                                        SETTINGS, reactor,
-                                       Logger::global());
+                                       Logger::make());
     });
 }
 
@@ -181,7 +181,7 @@ TEST_CASE("collector::connect deals with missing URL") {
                                 REQUIRE(err == MissingCollectorBaseUrlError());
                                 reactor->stop();
                             },
-                            reactor, Logger::global());
+                            reactor, Logger::make());
     });
 }
 
@@ -250,7 +250,7 @@ TEST_CASE("collector::create_report deals with entry with missing key") {
             REQUIRE(s == "");
             reactor->stop();
         },
-        {}, reactor, Logger::global());
+        {}, reactor, Logger::make());
     });
 }
 
@@ -264,7 +264,7 @@ TEST_CASE("collector::create_report deals with entry with invalid value") {
             REQUIRE(s == "");
             reactor->stop();
         },
-        {}, reactor, Logger::global());
+        {}, reactor, Logger::make());
     });
 }
 
@@ -278,7 +278,7 @@ TEST_CASE("collector::create_report deals with POST error") {
                                             reactor->stop();
                                         },
                                         {}, reactor,
-                                        Logger::global());
+                                        Logger::make());
     });
 }
 
@@ -298,7 +298,7 @@ TEST_CASE("collector::create_report deals with wrong JSON type") {
             REQUIRE(s == "");
             reactor->stop();
         },
-        {}, reactor, Logger::global());
+        {}, reactor, Logger::make());
     });
 }
 
@@ -319,7 +319,7 @@ TEST_CASE("collector::create_report deals with missing report_id") {
             REQUIRE(s == "");
             reactor->stop();
         },
-        {}, reactor, Logger::global());
+        {}, reactor, Logger::make());
     });
 }
 
@@ -333,13 +333,13 @@ TEST_CASE("collector::update_report deals with entry with missing key") {
             REQUIRE(err == MissingMandatoryKeyError());
             reactor->stop();
         },
-        {}, reactor, Logger::global());
+        {}, reactor, Logger::make());
     });
 }
 
 TEST_CASE("collector::get_next_entry() works correctly at EOF") {
     SharedPtr<std::istream> input(new std::istringstream(""));
-    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::global());
+    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::make());
     REQUIRE(!entry);
     REQUIRE(entry.as_error() == FileEofError());
 }
@@ -347,21 +347,21 @@ TEST_CASE("collector::get_next_entry() works correctly at EOF") {
 TEST_CASE("collector::get_next_entry() works correctly on I/O error") {
     SharedPtr<std::istream> input(new std::istringstream(""));
     input->setstate(input->badbit);
-    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::global());
+    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::make());
     REQUIRE(!entry);
     REQUIRE(entry.as_error() == FileIoError());
 }
 
 TEST_CASE("collector::get_next_entry() works correctly on invalid JSON") {
     SharedPtr<std::istream> input(new std::istringstream("{\n"));
-    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::global());
+    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::make());
     REQUIRE(!entry);
     REQUIRE(entry.as_error() == JsonProcessingError());
 }
 
 TEST_CASE("collector::get_next_entry() works correctly on incomplete line") {
     SharedPtr<std::istream> input(new std::istringstream("{}"));
-    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::global());
+    ErrorOr<nlohmann::json> entry = collector::get_next_entry(input, Logger::make());
     REQUIRE(!entry);
     REQUIRE(entry.as_error() == FileEofError());
 }
@@ -380,7 +380,7 @@ TEST_CASE("update_and_fetch_next() deals with update_report error") {
                 REQUIRE(err == MockedError());
                 reactor->stop();
             },
-            {}, reactor, Logger::global());
+            {}, reactor, Logger::make());
     });
 }
 
@@ -402,7 +402,7 @@ TEST_CASE("update_and_fetch_next() deals with get_next_entry error") {
                 REQUIRE(err == MockedError());
                 reactor->stop();
             },
-            {}, reactor, Logger::global());
+            {}, reactor, Logger::make());
     });
 }
 
@@ -415,7 +415,7 @@ TEST_CASE("submit_report() deals with invalid file") {
                 REQUIRE(err == CannotOpenReportError());
                 reactor->stop();
             },
-            {}, reactor, Logger::global());
+            {}, reactor, Logger::make());
     });
 }
 
@@ -428,7 +428,7 @@ TEST_CASE("submit_report() deals with get_next_entry error") {
                                                 reactor->stop();
                                             },
                                             {}, reactor,
-                                            Logger::global());
+                                            Logger::make());
     });
 }
 
@@ -450,7 +450,7 @@ TEST_CASE("submit_report() deals with collector_connect error") {
                 REQUIRE(err == MockedError());
                 reactor->stop();
             },
-            {}, reactor, Logger::global());
+            {}, reactor, Logger::make());
     });
 }
 
@@ -473,7 +473,7 @@ TEST_CASE("submit_report() deals with collector_create_report error") {
                 REQUIRE(err == MockedError());
                 reactor->stop();
             },
-            {}, reactor, Logger::global());
+            {}, reactor, Logger::make());
     });
 }
 

--- a/test/ooni/collector_client.cpp
+++ b/test/ooni/collector_client.cpp
@@ -496,6 +496,6 @@ TEST_CASE("The collector client works as expected") {
                                  [=](Error err) {
                                      REQUIRE(err == NoError());
                                      reactor->stop();
-                                 }, settings, reactor);
+                                 }, settings, reactor, Logger::make());
     });
 }

--- a/test/ooni/orchestrate.cpp
+++ b/test/ooni/orchestrate.cpp
@@ -101,26 +101,26 @@ TEST_CASE("Auth::is_valid() works correctly") {
     Auth auth;
 
     SECTION("When we are not logged in") {
-        REQUIRE(auth.is_valid(Logger::global()) == false);
+        REQUIRE(auth.is_valid(Logger::make()) == false);
     }
 
     SECTION("When the token is empty") {
         auth.logged_in = true;
-        REQUIRE(auth.is_valid(Logger::global()) == false);
+        REQUIRE(auth.is_valid(Logger::make()) == false);
     }
 
     SECTION("When we are logged in and time is expired") {
         auth.expiry_time = make_time_([](time_t t) { return t - 60; });
         auth.logged_in = true;
         auth.auth_token = "{TOKEN}";
-        REQUIRE(auth.is_valid(Logger::global()) == false);
+        REQUIRE(auth.is_valid(Logger::make()) == false);
     }
 
     SECTION("When we are logged in and time is not expired") {
         auth.expiry_time = make_time_([](time_t t) { return t + 60; });
         auth.logged_in = true;
         auth.auth_token = "{TOKEN}";
-        REQUIRE(auth.is_valid(Logger::global()) == true);
+        REQUIRE(auth.is_valid(Logger::make()) == true);
     }
 }
 
@@ -132,7 +132,7 @@ TEST_CASE("orchestrate::login() works correctly") {
         Settings settings;
         settings["net/ca_bundle_path"] = "cacert.pem";
         reactor->run_with_initial_event([&]() {
-            login({}, testing_registry_url(), settings, reactor, Logger::global(),
+            login({}, testing_registry_url(), settings, reactor, Logger::make(),
                   [&](Error &&e, Auth &&) {
                       err = e;
                       reactor->stop();
@@ -149,7 +149,7 @@ TEST_CASE("orchestrate::login() works correctly") {
         settings["net/ca_bundle_path"] = "cacert.pem";
         reactor->run_with_initial_event([&]() {
             login(std::move(auth), testing_registry_url(), settings, reactor,
-                  Logger::global(), [&](Error &&e, Auth &&) {
+                  Logger::make(), [&](Error &&e, Auth &&) {
                       err = e;
                       reactor->stop();
                   });

--- a/test/ooni/templates.cpp
+++ b/test/ooni/templates.cpp
@@ -66,8 +66,8 @@ TEST_CASE("dns query template works as expected") {
                     // more annoyed by this test being broken. Fix by using
                     // an insanely low timeout so it should always fail.
                     {{"dns/timeout", 0.0001}, {"dns/attempts", 1},
-                     {"dns/engine", "libevent"}}, reactor);
-            }, {{"dns/engine", "libevent"}}, reactor);
+                     {"dns/engine", "libevent"}}, reactor, Logger::make());
+            }, {{"dns/engine", "libevent"}}, reactor, Logger::make());
     });
 }
 
@@ -104,7 +104,7 @@ TEST_CASE("dns query template works as expected with system engine") {
                     REQUIRE((answers[1]["answer_type"] == "A"));
                     reactor->stop();
                 },
-                {{"dns/engine", "system"}}, reactor);
+                {{"dns/engine", "system"}}, reactor, Logger::make());
     });
 }
 
@@ -115,7 +115,7 @@ TEST_CASE("tcp connect returns error if port is missing") {
             REQUIRE(err);
             REQUIRE(!!txp);
             reactor->stop();
-        }, reactor);
+        }, reactor, Logger::make());
     });
 }
 
@@ -129,7 +129,7 @@ TEST_CASE("tcp connect returns error if port is invalid") {
                                    REQUIRE(err);
                                    REQUIRE(!!txp);
                                    reactor->stop();
-                               }, reactor);
+                               }, reactor, Logger::make());
     });
 }
 
@@ -177,8 +177,8 @@ TEST_CASE("http requests template works as expected") {
                         REQUIRE((req["response"]["body"] == nullptr));
                         REQUIRE((req["response"]["headers"].is_object()));
                         reactor->stop();
-                    }, reactor);
-            }, reactor);
+                    }, reactor, Logger::make());
+            }, reactor, Logger::make());
     });
 }
 

--- a/test/report/file_reporter.cpp
+++ b/test/report/file_reporter.cpp
@@ -77,6 +77,6 @@ TEST_CASE(
                         REQUIRE(entry["antani"].get<std::string>() == "fuffa");
                     }
                 });
-            }, Logger::global());
+            }, Logger::make());
         });
     }

--- a/test/report/report.cpp
+++ b/test/report/report.cpp
@@ -179,13 +179,13 @@ TEST_CASE("The write_entry() method works correctly") {
                                 REQUIRE(err.child_errors.size() == 1);
                                 REQUIRE(err.child_errors[0] ==
                                         ReportAlreadyClosedError());
-                            }, Logger::global());
+                            }, Logger::make());
                         });
-                    }, Logger::global());
-                }, Logger::global());
-            }, Logger::global());
+                    }, Logger::make());
+                }, Logger::make());
+            }, Logger::make());
         });
-    }, Logger::global());
+    }, Logger::make());
 }
 
 TEST_CASE("We can retry a partially successful write_entry()") {
@@ -213,8 +213,8 @@ TEST_CASE("We can retry a partially successful write_entry()") {
                 REQUIRE(err.child_errors[0].child_errors[0] ==
                         DuplicateEntrySubmitError());
                 REQUIRE(err.child_errors[1] == NoError());
-            }, Logger::global());
-        }, Logger::global());
+            }, Logger::make());
+        }, Logger::make());
     });
     REQUIRE(counted_reporter->write_count == 1);
     REQUIRE(failing_reporter->write_count == 2);


### PR DESCRIPTION
Close #1739. The reason why this is the case is because it addresses all the follow up changes identified when analysing the crash on Android. However, when preparing this PR, I started having the suspect that there may be tests that pass because their callback is never called. I will open a new issue for that