### PR TITLE
runnable: make sure we always have a failure key

### DIFF
--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -96,6 +96,11 @@ void Runnable::run_next_measurement(size_t thread_id, Callback<Error> cb,
         if (entry["input"] == "") {
             entry["input"] = nullptr;
         }
+        // Make sure we have a failure key. OONI relies on it.
+        if (test_keys->count("failure") <= 0) {
+            logger->warn("BUG: the test returned no failure key.");
+            (*test_keys)["failure"] = "generic_error";
+        }
         entry["test_keys"] = *test_keys;
         entry["test_keys"]["client_resolver"] = resolver_ip;
         entry["measurement_start_time"] =


### PR DESCRIPTION
Closes #1758.

I played a bit with DASH settings without being able to cause
the test to produce a failure-less result.

It does not matter much. This diff makes the code more robust
anyway, because we'll make sure we have a failure.

Also, in the original bug report, that was the case. So, it
seems we should christen MK v0.9.5.