### PR TITLE
Revert "runnable: make sure we always have a failure key"

### DIFF
--- a/src/libmeasurement_kit/nettests/runnable.cpp
+++ b/src/libmeasurement_kit/nettests/runnable.cpp
@@ -96,11 +96,6 @@ void Runnable::run_next_measurement(size_t thread_id, Callback<Error> cb,
         if (entry["input"] == "") {
             entry["input"] = nullptr;
         }
-        // Make sure we have a failure key. OONI relies on it.
-        if (test_keys->count("failure") <= 0) {
-            logger->warn("BUG: the test returned no failure key.");
-            (*test_keys)["failure"] = "generic_error";
-        }
         entry["test_keys"] = *test_keys;
         entry["test_keys"]["client_resolver"] = resolver_ip;
         entry["measurement_start_time"] =


### PR DESCRIPTION
This reverts commit 982a9c9a89bda813e1e6e1f1a2488b84c1b270e7.

See #1761