### PR TITLE
Tag v0.9.6 to have a working stable release

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,6 +4,6 @@ INPUT = include/measurement_kit/ffi.h
 JAVADOC_AUTOBRIEF = YES
 PROJECT_BRIEF = "Portable C++14 network measurement library"
 PROJECT_NAME = measurement-kit
-PROJECT_NUMBER = v0.9.5
+PROJECT_NUMBER = v0.9.6
 RECURSIVE = NO
 STRIP_FROM_INC_PATH = include

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(measurement_kit, 0.9.5, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.9.6, bassosimone@gmail.com)
 
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.9.5"
+#define MK_VERSION "0.9.6"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION
@@ -23,7 +23,7 @@
 // as part of the `./autogen.sh` script that prepares a source tarball. If we
 // cannot run `git` because we're not in a git repository, then we set this
 // variable equal to MK_VERSION.
-#define MK_VERSION_FULL "v0.9.5"
+#define MK_VERSION_FULL "v0.9.6"
 
 // MK_VERSION_MAJOR is the major version number extracted from MK_VERSION_FULL.
 #define MK_VERSION_MAJOR 0
@@ -32,7 +32,7 @@
 #define MK_VERSION_MINOR 9
 
 // MK_VERSION_PATCH is the patch version number extracted from MK_VERSION_FULL.
-#define MK_VERSION_PATCH 5
+#define MK_VERSION_PATCH 6
 
 // MK_VERSION_STABLE is 1 if this is a stable release, 0 otherwise.
 #define MK_VERSION_STABLE 1
@@ -47,7 +47,7 @@
 //       ^^^     ^^^     ^^^     ^^^
 //      major   minor   patch   stable
 // ```
-#define MK_VERSION_NUMERIC 0x00000000009000051LL
+#define MK_VERSION_NUMERIC 0x00000000009000061LL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/measurement_kit/common/version.h.in
+++ b/include/measurement_kit/common/version.h.in
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.9.5"
+#define MK_VERSION "0.9.6"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION

--- a/script/update-includes
+++ b/script/update-includes
@@ -4,7 +4,7 @@ set -e
 
 gen_automatic_includes() {
 
-    vfull=`git describe --tags 2>/dev/null |echo v0.9.5`
+    vfull=`git describe --tags 2>/dev/null |echo v0.9.6`
     vmajor=`echo $vfull|sed 's/^v//g'|awk -F. '{print $1}'`
     vminor=`echo $vfull|awk -F. '{print $2}'`
     vpatch=`echo $vfull|sed 's/-.*//g'|awk -F. '{print $3}'`


### PR DESCRIPTION
It was pointed out that it's perhaps better that the latest
relase is stable. In all regards, this is v0.9.4 because
of the issue explained in #1761. So, people should actually
use v0.9.4, but this v0.9.6 tag exists such that we have a
stable release as the tip of the stable branch.

Suggested by @evfirerob.

Individual commits:

- release 0.9.6: step 1: update version number

- release 0.9.6: step 2: update headers

Using a PR with a merge commit to clearly mark this is as
a point in the stable history when something happens.