### PR TITLE
[ci skip] stop mentioning the stable branch everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Small pull requests should be tagged as `hotfix` and can be self
 merged. All other pull request should be reviewed by another core
 developer who will take responsibility of the merge. The repository
 should be configured such that it is not possible to merge into
-`master` (or `stable`) if unit tests are not passing.
+`master` if unit tests are not passing.
 
 If the diff is small, squash merge is preferred, otherwise preserve
 the history.  In general it is a good idea to keep your branches

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 | branch | Unix      | coverage  | Windows  |
 |--------|-----------|-----------|----------|
 | master | [![Build Status](https://img.shields.io/travis/measurement-kit/measurement-kit/master.svg?label=travis)](https://travis-ci.org/measurement-kit/measurement-kit) | [![codecov](https://codecov.io/gh/measurement-kit/measurement-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/measurement-kit/measurement-kit) | [![Build status](https://img.shields.io/appveyor/ci/bassosimone/measurement-kit/master.svg?label=appveyor)](https://ci.appveyor.com/project/bassosimone/measurement-kit/branch/master) |
-| stable | [![Build Status](https://img.shields.io/travis/measurement-kit/measurement-kit/stable.svg?label=travis)](https://travis-ci.org/measurement-kit/measurement-kit) | [![codecov](https://codecov.io/gh/measurement-kit/measurement-kit/branch/stable/graph/badge.svg)](https://codecov.io/gh/measurement-kit/measurement-kit) | [![Build status](https://img.shields.io/appveyor/ci/bassosimone/measurement-kit/stable.svg?label=appveyor)](https://ci.appveyor.com/project/bassosimone/measurement-kit/branch/stable) |
 
 Measurement Kit is a library that implements open network measurement
 methodologies (performance, censorship, etc.) for Android, iOS, Windows,


### PR DESCRIPTION
In the interest of making the build process easier, this commit
removes the stable branch and only keeps the master branch.

If there's need to make an emergency stable release, then I will
create temporary branches. The workflow in which I also need to
maintain a stable branch has too much toil and too little advantages
known to me. I can easily use tags instead.