### PR TITLE
[ci skip] API documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Measurement Kit
 
-> Portable C++14 network measurement library
+> Network measurement engine
 
 [![GitHub license](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://raw.githubusercontent.com/measurement-kit/measurement-kit/master/LICENSE) [![Github Releases](https://img.shields.io/github/release/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/releases) [![Github Issues](https://img.shields.io/github/issues/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/issues)
 
@@ -20,6 +20,12 @@ novel tools.
 
 Please, refer to the [include/measurement_kit](include/measurement_kit)
 folder documentation for an up-to-date list of available tests.
+
+Note that this repository contains the C++ implementation of Measurement
+Kit, but we're also working on a Go implementation, available at
+[github.com/measurement-kit/engine](https://github.com/measurement-kit/engine).
+This implementation is currently experimental. The tentative plan is to use
+the Go implementation for nettests that are written in Go.
 
 ## API and examples
 

--- a/include/measurement_kit/README.md
+++ b/include/measurement_kit/README.md
@@ -8,11 +8,13 @@ this basic C-like FFI-friendly API:
 
 - [ObjectiveC API](https://github.com/measurement-kit/mkall-ios);
 
-- [Java API](https://github.com/measurement-kit/mkall-java);
+- [Android API](https://github.com/measurement-kit/android-libs);
 
 - [Golang API](https://github.com/measurement-kit/go-measurement-kit);
 
-We encourage you to avoid using it when a more user-friendly API is available.
+We encourage you to avoid using it when a more user-friendly API is available
+because, for each specific platform, we will strive to maintain backwards
+compatibility with the most high level API available on such platform.
 
 ## Synopsis
 


### PR DESCRIPTION
1. change the tagline to avoid referencing C++14

2. mention the Go engine

3. clarify that the Android API is android-libs (as it seems
   less surprising to continue improving that rather than
   restarting from scratch with mkall-java)

4. clarify that we will try to keep the highest level API
   backwards compatible (or trivially upgradable), because,
   if we ever switch to Go, that's what we'll aim for

Closes #1787

See https://github.com/measurement-kit/mkall-java/issues/8