### PR TITLE
HIRL, runnable now more robust to binary data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ for flag in -Wall -Wextra -pedantic -Wmissing-prototypes; do
   MK_MAYBE_APPEND_CFLAG([$flag])
   MK_MAYBE_APPEND_CXXFLAG([$flag])
 done
+MK_MAYBE_APPEND_CXXFLAG([-Wno-c++17-extensions]) # Silence clang on macOS
 
 AX_ADD_FORTIFY_SOURCE
 


### PR DESCRIPTION
It also includes an unrelated fix to an annoying issue, so I'll preserve history.

Closes #1823.

Depends on https://github.com/ooni/spec/pull/141.