### PR TITLE
Release v0.10.5

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,6 +4,6 @@ INPUT = include/measurement_kit/ffi.h
 JAVADOC_AUTOBRIEF = YES
 PROJECT_BRIEF = "Portable C++14 network measurement library"
 PROJECT_NAME = measurement-kit
-PROJECT_NUMBER = v0.10.4
+PROJECT_NUMBER = v0.10.5
 RECURSIVE = NO
 STRIP_FROM_INC_PATH = include

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(measurement_kit, 0.10.4, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.10.5, bassosimone@gmail.com)
 
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.10.4"
+#define MK_VERSION "0.10.5"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION
@@ -23,7 +23,7 @@
 // as part of the `./autogen.sh` script that prepares a source tarball. If we
 // cannot run `git` because we're not in a git repository, then we set this
 // variable equal to MK_VERSION.
-#define MK_VERSION_FULL "v0.10.4"
+#define MK_VERSION_FULL "v0.10.5"
 
 // MK_VERSION_MAJOR is the major version number extracted from MK_VERSION_FULL.
 #define MK_VERSION_MAJOR 0
@@ -32,7 +32,7 @@
 #define MK_VERSION_MINOR 10
 
 // MK_VERSION_PATCH is the patch version number extracted from MK_VERSION_FULL.
-#define MK_VERSION_PATCH 4
+#define MK_VERSION_PATCH 5
 
 // MK_VERSION_STABLE is 1 if this is a stable release, 0 otherwise.
 #define MK_VERSION_STABLE 1
@@ -47,7 +47,7 @@
 //       ^^^     ^^^     ^^^     ^^^
 //      major   minor   patch   stable
 // ```
-#define MK_VERSION_NUMERIC 0x00000000010000041LL
+#define MK_VERSION_NUMERIC 0x00000000010000051LL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/measurement_kit/common/version.h.in
+++ b/include/measurement_kit/common/version.h.in
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.10.4"
+#define MK_VERSION "0.10.5"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION

--- a/script/update-includes
+++ b/script/update-includes
@@ -4,7 +4,7 @@ set -e
 
 gen_automatic_includes() {
 
-    vfull=`git describe --tags 2>/dev/null |echo v0.10.4`
+    vfull=`git describe --tags 2>/dev/null |echo v0.10.5`
     vmajor=`echo $vfull|sed 's/^v//g'|awk -F. '{print $1}'`
     vminor=`echo $vfull|awk -F. '{print $2}'`
     vpatch=`echo $vfull|sed 's/-.*//g'|awk -F. '{print $3}'`


### PR DESCRIPTION
This changes the version number to v0.10.5. After this is merged, we can tag.