### PR TITLE
engine, ffi: emit UTF-7 without U+0000

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,6 +4,6 @@ INPUT = include/measurement_kit/ffi.h
 JAVADOC_AUTOBRIEF = YES
 PROJECT_BRIEF = "Portable C++14 network measurement library"
 PROJECT_NAME = measurement-kit
-PROJECT_NUMBER = v0.10.5
+PROJECT_NUMBER = v0.10.6
 RECURSIVE = NO
 STRIP_FROM_INC_PATH = include

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(measurement_kit, 0.10.5, bassosimone@gmail.com)
+AC_INIT(measurement_kit, 0.10.6, bassosimone@gmail.com)
 
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_MACRO_DIR([m4])

--- a/include/measurement_kit/common/version.h
+++ b/include/measurement_kit/common/version.h
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.10.5"
+#define MK_VERSION "0.10.6"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION
@@ -23,7 +23,7 @@
 // as part of the `./autogen.sh` script that prepares a source tarball. If we
 // cannot run `git` because we're not in a git repository, then we set this
 // variable equal to MK_VERSION.
-#define MK_VERSION_FULL "v0.10.5"
+#define MK_VERSION_FULL "v0.10.6"
 
 // MK_VERSION_MAJOR is the major version number extracted from MK_VERSION_FULL.
 #define MK_VERSION_MAJOR 0
@@ -32,7 +32,7 @@
 #define MK_VERSION_MINOR 10
 
 // MK_VERSION_PATCH is the patch version number extracted from MK_VERSION_FULL.
-#define MK_VERSION_PATCH 5
+#define MK_VERSION_PATCH 6
 
 // MK_VERSION_STABLE is 1 if this is a stable release, 0 otherwise.
 #define MK_VERSION_STABLE 1
@@ -47,7 +47,7 @@
 //       ^^^     ^^^     ^^^     ^^^
 //      major   minor   patch   stable
 // ```
-#define MK_VERSION_NUMERIC 0x00000000010000051LL
+#define MK_VERSION_NUMERIC 0x00000000010000061LL
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/measurement_kit/common/version.h.in
+++ b/include/measurement_kit/common/version.h.in
@@ -14,7 +14,7 @@
 // MK_VERSION is measurement-kit version according to manual tagging. This is
 // updated when we bless a new release. It does not accurately describe a
 // development build, for which MK_VERSION_FULL may be better.
-#define MK_VERSION "0.10.5"
+#define MK_VERSION "0.10.6"
 
 // MEASUREMENT_KIT_VERSION is a backward compatibility alias for MK_VERSION.
 #define MEASUREMENT_KIT_VERSION MK_VERSION

--- a/include/measurement_kit/internal/engine/task.hpp
+++ b/include/measurement_kit/internal/engine/task.hpp
@@ -1,0 +1,74 @@
+// Part of Measurement Kit <https://measurement-kit.github.io/>.
+// Measurement Kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+#ifndef INCLUDE_MEASUREMENT_KIT_INTERNAL_ENGINE_TASK_HPP
+#define INCLUDE_MEASUREMENT_KIT_INTERNAL_ENGINE_TASK_HPP
+
+#include <memory>
+
+#include <measurement_kit/common/nlohmann/json.hpp>
+
+namespace mk {
+namespace engine {
+
+/// TaskImpl is the opaque implementation of Task.
+class TaskImpl;
+
+/// Task is a task that Measurement Kit can run. You create a task with Task()
+/// by passing it the desired settings as a nlohmann::json. The minimal settings
+/// JSON must include the "name" key indicating the task name.
+///
+/// Creating a Task also creates the thread that will run it. Altough you can
+/// construct more than one Task at a time, Measurement Kit will make sure that
+/// tasks do not run concurrently, even though there is no guarantee that they
+/// will actually run sequentially.
+///
+/// A Task will emit events while running, which you can retrieve using the
+/// wait_for_next_event() call, which blocks until next event occurs. You can
+/// configure a Task to disable some or all events.
+///
+/// To know whether a task has finished running, use is_done(). The method will
+/// return true when the task thread has exited and there are no unread events
+/// in the queue drained by wait_for_next_event().
+///
+/// You can also interrupt a running task using interrupt().
+///
+/// The destructor, ~Task(), will join on the Task thread. That is, it will
+/// wait for the Task to complete before destroying all the resources.
+class Task {
+  public:
+    /// Task creates and starts a Task configured according to settings.
+    explicit Task(nlohmann::json &&settings);
+
+    /// wait_for_next_event blocks until the next event occurs. When the
+    /// task is terminated, it returns the "task_terminated" dummy event.
+    nlohmann::json wait_for_next_event();
+
+    /// emit emits a specific event by appending it to the queue that
+    /// is drained by user code via wait_for_next_event.
+    void emit(nlohmann::json event);
+
+    /// is_done returns true when the task has finished running and there
+    /// are no unread events in wait_for_next_event's queue.
+    bool is_done() const;
+
+    /// interrupt forces the Task to stop running ASAP.
+    void interrupt();
+
+    /// ~Task waits for the task to finish and deallocates resources.
+    ~Task();
+
+    // Implementation note: this class is _explicitly_ non copyable and non
+    // movable so we don't have to worry about pimpl's validity.
+    Task(const Task &) noexcept = delete;
+    Task &operator=(const Task &) noexcept = delete;
+    Task(Task &&) noexcept = delete;
+    Task &operator=(Task &&) noexcept = delete;
+
+  private:
+    std::unique_ptr<TaskImpl> pimpl_;
+};
+
+} // namespace engine
+} // namespace mk
+#endif

--- a/script/update-includes
+++ b/script/update-includes
@@ -4,7 +4,7 @@ set -e
 
 gen_automatic_includes() {
 
-    vfull=`git describe --tags 2>/dev/null |echo v0.10.5`
+    vfull=`git describe --tags 2>/dev/null |echo v0.10.6`
     vmajor=`echo $vfull|sed 's/^v//g'|awk -F. '{print $1}'`
     vminor=`echo $vfull|awk -F. '{print $2}'`
     vpatch=`echo $vfull|sed 's/-.*//g'|awk -F. '{print $3}'`

--- a/src/libmeasurement_kit/engine/task.hpp
+++ b/src/libmeasurement_kit/engine/task.hpp
@@ -4,80 +4,20 @@
 #ifndef SRC_LIBMEASUREMENT_KIT_ENGINE_TASK_HPP
 #define SRC_LIBMEASUREMENT_KIT_ENGINE_TASK_HPP
 
+#include <measurement_kit/internal/engine/task.hpp>
+
 #include <atomic>
 #include <condition_variable>
 #include <deque>
-#include <memory>
-#include <mutex>
 #include <thread>
-
-#include <measurement_kit/common/nlohmann/json.hpp>
-#include <measurement_kit/common/shared_ptr.hpp>
+#include <mutex>
 
 #include "src/libmeasurement_kit/common/reactor.hpp"
 
+#include <measurement_kit/common/shared_ptr.hpp>
+
 namespace mk {
 namespace engine {
-
-/// TaskImpl is the opaque implementation of Task.
-class TaskImpl;
-
-/// Task is a task that Measurement Kit can run. You create a task with Task()
-/// by passing it the desired settings as a nlohmann::json. The minimal settings
-/// JSON must include the "name" key indicating the task name.
-///
-/// Creating a Task also creates the thread that will run it. Altough you can
-/// construct more than one Task at a time, Measurement Kit will make sure that
-/// tasks do not run concurrently, even though there is no guarantee that they
-/// will actually run sequentially.
-///
-/// A Task will emit events while running, which you can retrieve using the
-/// wait_for_next_event() call, which blocks until next event occurs. You can
-/// configure a Task to disable some or all events.
-///
-/// To know whether a task has finished running, use is_done(). The method will
-/// return true when the task thread has exited and there are no unread events
-/// in the queue drained by wait_for_next_event().
-///
-/// You can also interrupt a running task using interrupt().
-///
-/// The destructor, ~Task(), will join on the Task thread. That is, it will
-/// wait for the Task to complete before destroying all the resources.
-class Task {
-  public:
-    /// Task creates and starts a Task configured according to settings.
-    explicit Task(nlohmann::json &&settings);
-
-    /// wait_for_next_event blocks until the next event occurs. When the
-    /// task is terminated, it returns the "task_terminated" dummy event.
-    nlohmann::json wait_for_next_event();
-
-    /// emit emits a specific event by appending it to the queue that
-    /// is drained by user code via wait_for_next_event.
-    void emit(nlohmann::json event);
-
-    /// is_done returns true when the task has finished running and there
-    /// are no unread events in wait_for_next_event's queue.
-    bool is_done() const;
-
-    /// interrupt forces the Task to stop running ASAP.
-    void interrupt();
-
-    /// ~Task waits for the task to finish and deallocates resources.
-    ~Task();
-
-    // Implementation note: this class is _explicitly_ non copyable and non
-    // movable so we don't have to worry about pimpl's validity.
-    Task(const Task &) noexcept = delete;
-    Task &operator=(const Task &) noexcept = delete;
-    Task(Task &&) noexcept = delete;
-    Task &operator=(Task &&) noexcept = delete;
-
-  private:
-    std::unique_ptr<TaskImpl> pimpl_;
-};
-
-// TODO(bassosimone): we can probably remove the pimpl pattern
 
 class TaskImpl {
   public:

--- a/src/libmeasurement_kit/ffi.cpp
+++ b/src/libmeasurement_kit/ffi.cpp
@@ -21,7 +21,16 @@
 mk_event_t *mk_event_create_(const nlohmann::json &json) noexcept {
     std::string ev;
     try {
-        ev = json.dump();
+        // The following encodes the JSON in the most compact representation
+        // (i.e. indent=-1, indent_char=' '), and make sure that we emit in
+        // ouput only ASCII characters (i.e. UTF-7 rather than UTF-8). We're
+        // doing this to increase the likelihood that the code that will be
+        // parsing this JSON will accept it. For example, Java's modified
+        // UTF-8 SHOULD be able to deal with UTF-7 where `U+0000` is properly
+        // encoded but MAY NOT deal correctly with an UTF-8 stream.
+        //
+        // See https://developer.android.com/training/articles/perf-jni#utf-8-and-utf-16-strings
+        ev = json.dump(-1, ' ', true);
     } catch (const std::exception &exc) {
         nlohmann::json failure;
         failure["key"] = "bug.json_dump";

--- a/test/dns/query.cpp
+++ b/test/dns/query.cpp
@@ -389,12 +389,12 @@ TEST_CASE("The libevent resolver works as expected") {
     });
 
     reactor->run_with_initial_event([=]() {
-        query("IN", "REVERSE_AAAA", "2001:858:2:2:aabb::563b:1e28",
+        query("IN", "REVERSE_AAAA", "2a01:4f8:172:1b46::abba:5:1",
               [=](Error e, SharedPtr<Message> message) {
                   REQUIRE(!e);
                   REQUIRE(message->error_code == DNS_ERR_NONE);
                   REQUIRE(message->answers.size() == 1);
-                  REQUIRE(message->answers[0].hostname == "nova.torproject.org");
+                  REQUIRE(message->answers[0].hostname == "saxatile.torproject.org");
                   REQUIRE(message->rtt > 0.0);
                   REQUIRE(message->answers[0].ttl > 0);
                   reactor->stop();
@@ -402,13 +402,13 @@ TEST_CASE("The libevent resolver works as expected") {
     });
 
     reactor->run_with_initial_event([=]() {
-        query("IN", "PTR", "8.2.e.1.b.3.6.5.0.0.0.0.b.b.a.a.2.0.0.0.2.0.0.0.8."
-                           "5.8.0.1.0.0.2.ip6.arpa",
+        query("IN", "PTR",
+              "1.0.0.0.5.0.0.0.a.b.b.a.0.0.0.0.6.4.b.1.2.7.1.0.8.f.4.0.1.0.a.2.ip6.arpa",
               [=](Error e, SharedPtr<Message> message) {
                   REQUIRE(!e);
                   REQUIRE(message->error_code == DNS_ERR_NONE);
                   REQUIRE(message->answers.size() == 1);
-                  REQUIRE(message->answers[0].hostname == "nova.torproject.org");
+                  REQUIRE(message->answers[0].hostname == "saxatile.torproject.org");
                   REQUIRE(message->rtt > 0.0);
                   REQUIRE(message->answers[0].ttl > 0);
                   reactor->stop();

--- a/test/ffi/mk_event_create.cpp
+++ b/test/ffi/mk_event_create.cpp
@@ -42,3 +42,32 @@ TEST_CASE("mk_event_create_() deals with invalid JSON event key") {
   REQUIRE(ev != nullptr);
   REQUIRE(mk_event_serialization(ev.get()) != nullptr);
 }
+
+TEST_CASE("mk_event_create_() correctly encodes NULL bytes") {
+  const uint8_t zeroterm[] = {115, 98, 115, 0, 115, 98, 115};
+  const std::string zerostring{(const char *)zeroterm, sizeof(zeroterm)};
+  nlohmann::json json;
+  json[zerostring] = zerostring;
+  mk_unique_event ev{mk_event_create_(json)};
+  REQUIRE(ev != nullptr);
+  auto seriop = mk_event_serialization(ev.get());
+  REQUIRE(seriop != nullptr);
+  auto serios = std::string{seriop};
+  REQUIRE(serios == R"({"sbs\u0000sbs":"sbs\u0000sbs"})");
+}
+
+TEST_CASE("mk_event_create_() correctly guarantees UTF-7 output") {
+  // (Cultural note: despite being born in Sanremo I'm actually opposed to
+  // the festival, which I consider low quality music, and I fancy much more
+  // Rock in the Casbah, a summer festival in Sanremo's casbah.)
+  const std::string sanremo{"Perché Sanremo è Sanremo"};
+  nlohmann::json json;
+  json[sanremo] = sanremo;
+  mk_unique_event ev{mk_event_create_(json)};
+  REQUIRE(ev != nullptr);
+  auto seriop = mk_event_serialization(ev.get());
+  REQUIRE(seriop != nullptr);
+  auto serios = std::string{seriop};
+  auto ex = R"({"Perch\u00e9 Sanremo \u00e8 Sanremo":"Perch\u00e9 Sanremo \u00e8 Sanremo"})";
+  REQUIRE(serios == ex);
+}

--- a/test/ffi/mk_event_create.cpp
+++ b/test/ffi/mk_event_create.cpp
@@ -60,7 +60,7 @@ TEST_CASE("mk_event_create_() correctly guarantees UTF-7 output") {
   // (Cultural note: despite being born in Sanremo I'm actually opposed to
   // the festival, which I consider low quality music, and I fancy much more
   // Rock in the Casbah, a summer festival in Sanremo's casbah.)
-  const std::string sanremo{"Perché Sanremo è Sanremo"};
+  const std::string sanremo{"Perché Sanremo è Sanremo 😇"};
   nlohmann::json json;
   json[sanremo] = sanremo;
   mk_unique_event ev{mk_event_create_(json)};
@@ -68,6 +68,6 @@ TEST_CASE("mk_event_create_() correctly guarantees UTF-7 output") {
   auto seriop = mk_event_serialization(ev.get());
   REQUIRE(seriop != nullptr);
   auto serios = std::string{seriop};
-  auto ex = R"({"Perch\u00e9 Sanremo \u00e8 Sanremo":"Perch\u00e9 Sanremo \u00e8 Sanremo"})";
+  auto ex = R"({"Perch\u00e9 Sanremo \u00e8 Sanremo \ud83d\ude07":"Perch\u00e9 Sanremo \u00e8 Sanremo \ud83d\ude07"})";
   REQUIRE(serios == ex);
 }


### PR DESCRIPTION
JNI's `NewStringUTF` requires modified UTF-8. That is, actually, incompatible UTF-8. In most cases UTF-8 streams are accepted by JNI. See #1877 for exceptions to this rule.

Address this issues with two changes:

1. export `engine::Task` as a public, internal API, such that we can, as a last resort mechanism, modify OONI code interfacing with MK to completely by pass C strings and C code. From C++ it seems easier to get an array of bytes and a size, and to convert that to a Java `byteArray` that then can be converted to a string using native Java code and an encoding. This approach has been documented, e.g., by [Scott Banachowski](http://banachowski.com/deprogramming/2012/02/working-around-jni-utf-8-strings/).

2. modify the way in which we returns serialised JSONs such that we only use UTF-7 bytes and make sure that `U+0000` is properly encoded with unit tests. This approach should be [compliant with what JNI code is documented to always be able to accept](https://developer.android.com/training/articles/perf-jni#utf-8-and-utf-16-strings).

The engine and ffi modules are the two only places where we need (1) to exercise care in the way in which we encode strings and (2) to have more flexibility. The rest of the API is now internal, C++ header only bits that we can easily convert to follow a `byteArray` compatible approach.

This set of changes will land as MK v0.10.6. I will use this release, as opposed to v0.10.5, for Android because I'd like to have this annoying JNI issue fixed as soon as possible.