### PR TITLE
treewide: Change legacy C headers to C++ ones

### DIFF
--- a/src/libmeasurement_kit/dns/libevent_query.hpp
+++ b/src/libmeasurement_kit/dns/libevent_query.hpp
@@ -16,7 +16,7 @@
 #include <cassert>
 #include <new>
 #include <memory>
-#include <limits.h>
+#include <climits>
 #include <type_traits>
 
 extern "C" {

--- a/src/libmeasurement_kit/ffi.cpp
+++ b/src/libmeasurement_kit/ffi.cpp
@@ -6,8 +6,8 @@
 
 #include <measurement_kit/ffi.h>
 
-#include <limits.h>
-#include <string.h>
+#include <climits>
+#include <cstring>
 
 #include <exception>
 #include <string>

--- a/src/libmeasurement_kit/http/response_parser.cpp
+++ b/src/libmeasurement_kit/http/response_parser.cpp
@@ -5,8 +5,8 @@
 #include "src/libmeasurement_kit/http/response_parser.hpp"
 #include <measurement_kit/internal/vendor/http_parser.h>
 
-#include <stddef.h>
-#include <string.h>
+#include <cstddef>
+#include <cstring>
 
 extern "C" {
 

--- a/src/libmeasurement_kit/traceroute/android.cpp
+++ b/src/libmeasurement_kit/traceroute/android.cpp
@@ -49,7 +49,7 @@ void mk_traceroute_android_unused() {}
 #include <linux/errqueue.h>
 #include <sys/uio.h>
 
-#include <string.h>
+#include <cstring>
 #include <unistd.h>
 
 namespace mk {


### PR DESCRIPTION
These were deprecated in C++14.

Signed-off-by: Rosen Penev <rosenp@gmail.com>