### PR TITLE
Update the OONI servers we use

### DIFF
--- a/src/libmeasurement_kit/ooni/bouncer.hpp
+++ b/src/libmeasurement_kit/ooni/bouncer.hpp
@@ -39,7 +39,7 @@ void post_net_tests(std::string base_bouncer_url, std::string test_name,
                     SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 #define MK_OONI_PRODUCTION_BOUNCER_URL "https://bouncer.ooni.io"
-#define MK_OONI_TESTING_BOUNCER_URL "https://bouncer.test.ooni.io"
+#define MK_OONI_TESTING_BOUNCER_URL "https://ps-test.ooni.io"
 
 std::string production_bouncer_url();
 std::string testing_bouncer_url();

--- a/src/libmeasurement_kit/ooni/collector_client.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client.hpp
@@ -13,13 +13,10 @@ namespace collector {
 /*
     To submit a file report, use one of the following collectors. By default
     the library uses the `production` collector.
-
-    The testing collector has been discontinued as of 2019-04-30, hence we
-    are now using the production collector as agreed with @hellais.
 */
 
 #define MK_OONI_PRODUCTION_COLLECTOR_URL "https://b.collector.ooni.io"
-#define MK_OONI_TESTING_COLLECTOR_URL "https://b.collector.ooni.io"
+#define MK_OONI_TESTING_COLLECTOR_URL "https://ps-test.ooni.io"
 
 std::string production_collector_url();
 std::string testing_collector_url();

--- a/src/libmeasurement_kit/ooni/orchestrate.hpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.hpp
@@ -21,10 +21,10 @@ namespace orchestrate {
  */
 
 #define MK_OONI_PRODUCTION_PROTEUS_REGISTRY_URL                                \
-    "https://a.registry.proteus.ooni.io"
+    "https://registry.ooni.io"
 #define MK_OONI_TESTING_PROTEUS_REGISTRY_URL                                   \
     "https://ps-test.ooni.io"
-#define MK_OONI_PRODUCTION_PROTEUS_EVENTS_URL "https://a.events.proteus.ooni.io"
+#define MK_OONI_PRODUCTION_PROTEUS_EVENTS_URL "https://orchestrate.ooni.io"
 #define MK_OONI_TESTING_PROTEUS_EVENTS_URL "https://ps-test.ooni.io"
 
 std::string production_registry_url();

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -117,7 +117,7 @@ TEST_CASE("http::request works as expected") {
     reactor->run_with_initial_event([=]() {
         request(
             {
-                {"http/url", "http://a.http.th.ooni.io/"},
+                {"http/url", "http://www.google.com/humans.txt"},
                 {"http/method", "GET"},
                 {"http/http_version", "HTTP/1.1"},
             },
@@ -129,7 +129,7 @@ TEST_CASE("http::request works as expected") {
                 REQUIRE(!error);
                 REQUIRE(response->status_code == 200);
                 REQUIRE(md5(response->body) ==
-                        "5d2182cb241b5a9aefad8ce584831666");
+                        "58789d6fc04cbf43b2b4e7605044b1ed");
                 reactor->stop();
             }, reactor, Logger::make());
     });
@@ -162,7 +162,7 @@ TEST_CASE("http::request() works as expected over Tor") {
     reactor->run_with_initial_event([=]() {
         request(
             {
-                {"http/url", "http://a.http.th.ooni.io/"},
+                {"http/url", "http://ps-test.ooni.io/"},
                 {"http/method", "GET"},
                 {"http/http_version", "HTTP/1.1"},
                 {"Connection", "close"},
@@ -531,21 +531,21 @@ TEST_CASE("http::request() works as expected using tor_socks_port") {
     reactor->run_with_initial_event([=]() {
         request(
             {
-                {"http/url", "http://a.http.th.ooni.io/"},
-                {"http/method", "POST"},
+                {"http/url", "http://www.google.com/humans.txt"},
+                {"http/method", "GET"},
                 {"http/http_version", "HTTP/1.1"},
                 {"net/tor_socks_port", "9050"},
             },
             {
                 {"Accept", "*/*"},
             },
-            "{\"test-helpers\": [\"dns\"]}",
+            "",
             [=](Error error, SharedPtr<Response> response) {
                 REQUIRE(check_error_after_tor(error));
                 if (!error) {
                     REQUIRE(response->status_code == 200);
                     REQUIRE(md5(response->body) ==
-                            "c0eb138de5f70c3b37566ba88146465d");
+                            "58789d6fc04cbf43b2b4e7605044b1ed");
                 }
                 reactor->stop();
             }, reactor, Logger::make());

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -31,11 +31,8 @@ template <typename T> void with_test(with_test_cb &&lambda) {
                 .set_option("geoip_asn_path", "asn.mmdb")
                 .set_option("net/ca_bundle_path", "cacert.pem")
                 .set_verbosity(MK_LOG_INFO)
-                // Using the new collector for testing purposes.
-                // TODO(bassosimone): switch to production collector when
-                // the new implementation is confirmed to be okay.
                 .set_option("collector_base_url",
-                            "https://collector-sandbox.ooni.io")
+                            "https://ps-test.ooni.io")
                 .set_option("bouncer_base_url",
                              mk::ooni::bouncer::production_bouncer_url()));
     /*
@@ -60,8 +57,7 @@ with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
     test.annotations["continuous_integration"] = "true";
     test.options["net/ca_bundle_path"] = "cacert.pem";
-    // TODO(bassosimone): see above comment regarding collector and bouncer
-    test.options["collector_base_url"] = "https://collector-sandbox.ooni.io";
+    test.options["collector_base_url"] = "https://ps-test.ooni.io";
     test.options["bouncer_base_url"] =
           mk::ooni::bouncer::production_bouncer_url();
     /*

--- a/test/ooni/bouncer.cpp
+++ b/test/ooni/bouncer.cpp
@@ -152,7 +152,7 @@ TEST_CASE("post_net_tests() works") {
                     };
                     auto check_https = [](std::string s) {
                         REQUIRE(s.substr(0, 8) == "https://");
-                        // User to be `ooni.io` but now we also have cases
+                        // Used to be `ooni.io` but now we also have cases
                         // in which we're returned `ooni.nu`.
                         REQUIRE(s.find("ooni.") != std::string::npos);
                     };


### PR DESCRIPTION
Attempt to always use ps-test.ooni.io for testing. Make sure we use
the canonical hosts for orchestra, rather than deprecated ones.

Closes #1896 