### PR TITLE
dash: use HTTPS by default

### DIFF
--- a/src/libmeasurement_kit/neubot/dash_impl.hpp
+++ b/src/libmeasurement_kit/neubot/dash_impl.hpp
@@ -535,7 +535,7 @@ void negotiate_with_(std::string hostname, SharedPtr<nlohmann::json> entry,
                      SharedPtr<Logger> logger, Callback<Error> cb) {
     logger->info("Negotiating with: %s", hostname.c_str());
     std::stringstream ss;
-    ss << "http://" << hostname << "/";
+    ss << "https://" << hostname << "/";
     std::string url = ss.str();
     settings["http/url"] = url;
     http_request_connect(


### PR DESCRIPTION
The servers now support it, so why not?