### PR TITLE
Makefile.am: don't build libtest.la by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,6 @@ measurement_kit_SOURCES       = # Empty
 bin_PROGRAMS = measurement_kit
 measurement_kit_LDADD = libmeasurement_kit.la
 
-noinst_LTLIBRARIES       = libtest_main.la
 libtest_main_la_CPPFLAGS = -DCATCH_CONFIG_MAIN
 libtest_main_la_SOURCES  = test/main.cpp
 


### PR DESCRIPTION
We will pick it up automatically when we build tests. So, no need to
explicitly list it as something to build. Fixes cross compiling for
iOS, where catch.hpp is clearly not prepared for that:

```
==> ./autogen.sh -n
==> cross-ios i386 ../configure --prefix=/usr/local/Cellar/ios-measurement-kit/0.10.11/i386 --disable-shared --disable-depen
==> make V=0 install
==> cross-ios x86_64 ../configure --prefix=/usr/local/Cellar/ios-measurement-kit/0.10.11/x86_64 --disable-shared --disable-d
==> make V=0 install
==> cross-ios armv7s ../configure --prefix=/usr/local/Cellar/ios-measurement-kit/0.10.11/armv7s --disable-shared --disable-d
==> make V=0 install
Last 15 lines from /Users/sbs/Library/Logs/Homebrew/ios-measurement-kit/07.make:
In file included from ../test/main.cpp:1:
../include/private/catch.hpp:8182:13: error: cannot determine Thumb instruction size, use inst.n/inst.w instead
            CATCH_BREAK_INTO_DEBUGGER();
            ^
../include/private/catch.hpp:7894:79: note: expanded from macro 'CATCH_BREAK_INTO_DEBUGGER'
    #define CATCH_BREAK_INTO_DEBUGGER() []{ if( Catch::isDebuggerActive() ) { CATCH_TRAP(); } }()
                                                                              ^
../include/private/catch.hpp:7872:39: note: expanded from macro 'CATCH_TRAP'
        #define CATCH_TRAP()  __asm__(".inst 0xe7f001f0")
                                      ^
<inline asm>:1:2: note: instantiated into assembly here
        .inst 0xe7f001f0
        ^
1 error generated.
make: *** [test/libtest_main_la-main.lo] Error 1
```