### PR TITLE
Officially deprecate MK and describe upgrade path

### DIFF
--- a/OREADME.md
+++ b/OREADME.md
@@ -1,0 +1,101 @@
+# Measurement Kit
+
+> Network measurement engine
+
+[![GitHub license](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://raw.githubusercontent.com/measurement-kit/measurement-kit/master/LICENSE) [![Github Releases](https://img.shields.io/github/release/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/releases) [![Github Issues](https://img.shields.io/github/issues/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/issues)
+
+- - -
+
+| branch | Unix      | coverage  | Windows  |
+|--------|-----------|-----------|----------|
+| master | [![Build Status](https://img.shields.io/travis/measurement-kit/measurement-kit/master.svg?label=travis)](https://travis-ci.org/measurement-kit/measurement-kit) | [![codecov](https://codecov.io/gh/measurement-kit/measurement-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/measurement-kit/measurement-kit) | [![Build status](https://img.shields.io/appveyor/ci/bassosimone/measurement-kit/master.svg?label=appveyor)](https://ci.appveyor.com/project/bassosimone/measurement-kit/branch/master) |
+
+Measurement Kit is a library that implements open network measurement
+methodologies (performance, censorship, etc.) for Android, iOS, Windows,
+macOS, and Linux systems.
+
+It is meant to be embedded by third party applications with specific network
+measurement needs and/or to be used by researchers as a basis to implement
+novel tools.
+
+Please, refer to the [include/measurement_kit](include/measurement_kit)
+folder documentation for an up-to-date list of available tests.
+
+## API and examples
+
+Measurement Kit exposes a simple C-like API that is described in detail
+in the [include/measurement_kit](include/measurement_kit) folder
+documentation. You can find examples of usage of such API into the
+[example](example) folder.
+
+## Generic Unix instructions
+
+You need to have the autotools, a C++14 capable C++ compiler, a C++14
+capable C++ library, a C11 capable C compiler, and all the dependencies
+installed. For current information, we encourage you to read the very simple
+build script that we use on Travis CI to setup a Unix environment, from
+which you can gather up-to-date information regarding required packages on
+a Debian like system. To this end, please refer to the content of the
+[.ci/travis](.ci/travis) folder.
+
+With all the dependencies statisfied, build with:
+
+```
+./autogen.sh
+./configure
+make
+sudo make install    # optional, if you want to install to `/usr/local`
+sudo /sbin/ldconfig  # required only on Linux if you install
+```
+
+The configure script will also provide advice if a dependency is missing. Also,
+`./configure --help` can be useful.
+
+## Homebrew instructions
+
+Please check the [measurement-kit/homebrew-measurement-kit](
+https://github.com/measurement-kit/homebrew-measurement-kit) tap
+for Homebrew.
+
+## Mingw-w64 instructions
+
+We (cross) compile binaries for Windows using the [Mingw-w64](
+https://mingw-w64.org/doku.php) compiler distribution. The scripts
+we use to do that are also part of the [
+measurement-kit/homebrew-measurement-kit](
+https://github.com/measurement-kit/homebrew-measurement-kit) tap
+for Homebrew.
+
+We also build MK using Mingw-w64 on Windows when running AppVeyor
+integration tests. To see how we do that, please check the
+[.ci/appveyor](.ci/appveyor) folder.
+
+## Android instructions
+
+For cross-compiling Measurement Kit for Android, please refer to the
+[measurement-kit/homebrew-measurement-kit](
+https://github.com/measurement-kit/homebrew-measurement-kit) repository. For
+integrating Measurement Kit cross-compiled for Android with Java classes
+that you can use from Android, please see [measurement-kit/android-libs](
+https://github.com/measurement-kit/android-libs). For how to use Measurement
+Kit in an Android project, please see [measurement-kit/android-example](
+https://github.com/measurement-kit/android-example).
+
+## iOS instructions
+
+For cross-compiling Measurement Kit for iOS, please refer to the
+[measurement-kit/homebrew-measurement-kit](
+https://github.com/measurement-kit/homebrew-measurement-kit) repository. For
+integrating Measurement Kit cross-compiled for iOS into a framework
+that you can use from iOS, please see [measurement-kit/mkall-ios](
+https://github.com/measurement-kit/mkall-ios). For how to use Measurement
+Kit in an iOS project, please see [measurement-kit/ios-example](
+https://github.com/measurement-kit/ios-example).
+
+## How to develop for Measurement Kit
+
+To clone Measurement Kit repository, do:
+
+    git clone --recursive https://github.com/measurement-kit/measurement-kit
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The content of the old README.md is still available as [OREADME.md](OREADME.md).
 The ooni/probe-engine implementation exposes similar APIs to Measurement Kit
 and specifically honours the [data format of Measurement Kit v0.10.11](
 https://github.com/measurement-kit/measurement-kit/tree/v0.10.11/include/measurement_kit).
-
 There should be no differences in the emitted events. There are however some
 differences in the settings as discussed below.
 

--- a/README.md
+++ b/README.md
@@ -1,101 +1,221 @@
 # Measurement Kit
 
-> Network measurement engine
+> (deprecated) Network measurement engine
 
-[![GitHub license](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://raw.githubusercontent.com/measurement-kit/measurement-kit/master/LICENSE) [![Github Releases](https://img.shields.io/github/release/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/releases) [![Github Issues](https://img.shields.io/github/issues/measurement-kit/measurement-kit.svg)](https://github.com/measurement-kit/measurement-kit/issues)
+As of 2020-03-15, Measurement Kit is deprecated. This date has been chosen
+arbitrarily such that we could write:
 
-- - -
+> Friends, OONItarians, developers, lend me your ears;
+> I come to bury Measurement Kit, not to praise it.
+> The bugs that software have live after them;
+> The good is oft interred with their remote branches;
 
-| branch | Unix      | coverage  | Windows  |
-|--------|-----------|-----------|----------|
-| master | [![Build Status](https://img.shields.io/travis/measurement-kit/measurement-kit/master.svg?label=travis)](https://travis-ci.org/measurement-kit/measurement-kit) | [![codecov](https://codecov.io/gh/measurement-kit/measurement-kit/branch/master/graph/badge.svg)](https://codecov.io/gh/measurement-kit/measurement-kit) | [![Build status](https://img.shields.io/appveyor/ci/bassosimone/measurement-kit/master.svg?label=appveyor)](https://ci.appveyor.com/project/bassosimone/measurement-kit/branch/master) |
+The rewrite of Measurement Kit in Go has been going on for quite some time now
+as [ooni/probe-engine](https://github.com/ooni/probe-engine). As part of this
+rewrite, we considered all the use cases addressed by Measurement Kit, as documented
+by [issue #1913](https://github.com/measurement-kit/measurement-kit/issues/1913).
 
-Measurement Kit is a library that implements open network measurement
-methodologies (performance, censorship, etc.) for Android, iOS, Windows,
-macOS, and Linux systems.
+We will most likely never release v0.11.0 of Measurement Kit. We will keep
+maintaining the 0.10.x version until 2021-03-15. In the following, we'll discuss
+what options you have for replacing Measurement Kit in your use case. The
+current README reflects the situation "here and now". We are still working to
+provide a smooth upgrade path. Please, let us know if the upgrade path we have
+designed is troubling you by opening an issue in this repository.
 
-It is meant to be embedded by third party applications with specific network
-measurement needs and/or to be used by researchers as a basis to implement
-novel tools.
+The content of the old README.md is still available as [OREADME.md](OREADME.md).
 
-Please, refer to the [include/measurement_kit](include/measurement_kit)
-folder documentation for an up-to-date list of available tests.
+## Android
 
-## API and examples
+In your `app/build.gradle` file, replace
 
-Measurement Kit exposes a simple C-like API that is described in detail
-in the [include/measurement_kit](include/measurement_kit) folder
-documentation. You can find examples of usage of such API into the
-[example](example) folder.
-
-## Generic Unix instructions
-
-You need to have the autotools, a C++14 capable C++ compiler, a C++14
-capable C++ library, a C11 capable C compiler, and all the dependencies
-installed. For current information, we encourage you to read the very simple
-build script that we use on Travis CI to setup a Unix environment, from
-which you can gather up-to-date information regarding required packages on
-a Debian like system. To this end, please refer to the content of the
-[.ci/travis](.ci/travis) folder.
-
-With all the dependencies statisfied, build with:
-
-```
-./autogen.sh
-./configure
-make
-sudo make install    # optional, if you want to install to `/usr/local`
-sudo /sbin/ldconfig  # required only on Linux if you install
+```Groovy
+  implementation "org.openobservatory.measurement_kit:android-libs:$version"
 ```
 
-The configure script will also provide advice if a dependency is missing. Also,
-`./configure --help` can be useful.
+with
 
-## Homebrew instructions
+```Groovy
+  implementation "org.ooni:oonimkall:$version"
+```
 
-Please check the [measurement-kit/homebrew-measurement-kit](
-https://github.com/measurement-kit/homebrew-measurement-kit) tap
-for Homebrew.
+The `io.ooni.mk.MKAsyncTask` class has been replaced by `oonimkall.Task`. The
+following diff shows how you should be upgrading your code:
 
-## Mingw-w64 instructions
+```diff
+--- MK.java	2020-04-10 11:54:53.973521643 +0200
++++ PE.java	2020-04-10 11:55:50.915205613 +0200
+@@ -1,10 +1,8 @@
+ package com.example.something;
+ 
+-import io.ooni.mk.MKAsyncTask;
+-
+ public class Example {
+-    public static void run(settings String) {
+-        MKAsyncTask task = MKAsyncTask.start(settings);
++    public static void run(settings String) throws Exception {
++        oonimkall.Task task = oonimkall.Oonimkall.startTask(settings);
+         for (!task.isDone()) {
+             String event = task.waitForNextEvent();
+             System.out.println(event);
+```
 
-We (cross) compile binaries for Windows using the [Mingw-w64](
-https://mingw-w64.org/doku.php) compiler distribution. The scripts
-we use to do that are also part of the [
-measurement-kit/homebrew-measurement-kit](
-https://github.com/measurement-kit/homebrew-measurement-kit) tap
-for Homebrew.
+The most striking difference is that the function to start a task
+will explicitly throw `Exception` on failure, where the old code
+would instead throw `RuntimeException`. The definition of settings
+and events has only slightly changed from Measurement Kit. In
+particular, you should now add the following the settings JSON:
 
-We also build MK using Mingw-w64 on Windows when running AppVeyor
-integration tests. To see how we do that, please check the
-[.ci/appveyor](.ci/appveyor) folder.
+```JSON
+{
+  "assets_dir": "",
+  "state_dir": "",
+  "temp_dir": ""
+}
+```
 
-## Android instructions
+where `assets_dir` is the directory where to store assets, e.g.
+GeoIP databases; `state_dir` is the directory where to store the
+authentication information used with OONI orchestra; `temp_dir`
+is the directory where to store temporary files. If these three
+keys are not present, the test will fail during the startup
+phase (i.e. it will not throw, but rather you will see a very
+short test with explanatory errors in the logs). The new code does
+recognize all the settings recognized by the old code, but some
+unfrequently used settings are not implemented yet. If are by chance
+using settings that it does not implement, it will also fail during
+the startup phase and tell you with log messages. If a not implemented
+setting is causing you issues, let us know.
 
-For cross-compiling Measurement Kit for Android, please refer to the
-[measurement-kit/homebrew-measurement-kit](
-https://github.com/measurement-kit/homebrew-measurement-kit) repository. For
-integrating Measurement Kit cross-compiled for Android with Java classes
-that you can use from Android, please see [measurement-kit/android-libs](
-https://github.com/measurement-kit/android-libs). For how to use Measurement
-Kit in an Android project, please see [measurement-kit/android-example](
-https://github.com/measurement-kit/android-example).
+We currently do not provide drop-in replacements for other functionality
+implemented by measurement-kit/android-libs, e.g., accessing the GeoIP
+lookup functionality, submitting reports. We will most likely do that since
+we need that in OONI for Android. We should be able to provide drop-in
+replacements, except perhaps some minor details.
 
-## iOS instructions
+## iOS
 
-For cross-compiling Measurement Kit for iOS, please refer to the
-[measurement-kit/homebrew-measurement-kit](
-https://github.com/measurement-kit/homebrew-measurement-kit) repository. For
-integrating Measurement Kit cross-compiled for iOS into a framework
-that you can use from iOS, please see [measurement-kit/mkall-ios](
-https://github.com/measurement-kit/mkall-ios). For how to use Measurement
-Kit in an iOS project, please see [measurement-kit/ios-example](
-https://github.com/measurement-kit/ios-example).
+In your `Podfile` replace
 
-## How to develop for Measurement Kit
+```ruby
+    pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git',
+                 :tag => '$version'
+```
 
-To clone Measurement Kit repository, do:
+with
 
-    git clone --recursive https://github.com/measurement-kit/measurement-kit
+```ruby
+    pod 'oonimkall', :git => 'https://github.com/ooni/probe-engine',
+                     :tag => '$version'
+```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
+The `MKAsyncTask` class has been replaced by `OonimkallTask`. The
+following diff should how you should be upgrading your code:
+
+```diff
+--- MK.m	2020-04-10 12:06:14.252573662 +0200
++++ PE.m	2020-04-10 12:08:18.520924676 +0200
+@@ -1,11 +1,15 @@
+ #import <Foundation/Foundation.h>
+ 
+-#import <mkall/MKAsyncTask.h>
++#import <oonimkall/Oonimkall.h>
+ 
+-void run(NSDictionary *settings) {
+-    MKAsyncTask *task = [MKAsyncTask start:settings];
+-    while (![task done]) {
+-        NSDictionary *ev = [task waitForNextEvent];
++NSError *run(NSString *settings) {
++    NSError *error = nil;
++    OonimkallTask *task = OonimkallStartTask(settings, &error);
++    if (error != nil) {
++        return error;
++    }
++    while (![task isDone]) {
++        NSString *ev = [task waitForNextEvent];
+         if (ev == nil) {
+             continue;
+         }
+```
+
+The most striking differences are the following. First, the function
+that starts a measurement task now fails explicitly (e.g., if the settings
+are not valid JSON). Second, the new code takes in input and emits in
+output serialized JSONs rather than `NSDictionary *`. Also, the same
+caveats described in the Android section apply: you need to add three
+extra keys into the JSON and some unfrequently used settings may not work
+anymore. If that happens, the logs should help you understand the issue. If
+a not implemented setting is causing you issues, let us know.
+
+We currently do not provide drop-in replacements for other functionality
+implemented by measurement-kit/mkall-ios, e.g., accessing the GeoIP
+lookup functionality, submitting reports. We will most likely do that since
+we need that in OONI for iOS.
+
+## Command Line
+
+The [miniooni](https://github.com/ooni/probe-engine#building-miniooni) binary
+is a drop-in interface for the `measurement_kit` binary you could build from
+this repository. We automatically build `miniooni` for Windows/amd64, Linux/amd64,
+and macOS/amd64 at every commit. The Linux build is static and does not depend
+on any external shared library. You can find the builds by looking into the
+[GitHub actions of probe-engine](https://github.com/ooni/probe-engine/actions)
+and selecting for `cli-windows`, `cli-linux`, or `cli-darwin`. We are open to
+automatically publish such binaries also at every release of probe-engine at
+GitHub. Please, let us know if that is useful in your use case.
+
+## Shared Library
+
+The [libooniffi](https://github.com/ooni/probe-engine/tree/master/libooniffi)
+package of ooni/probe-engine is a drop-in replacement for the [Measurement
+Kit FFI API](include/measurement_kit). The following diff shows the changes you
+need to apply in order to run the tests using probe-engine:
+
+```diff
+--- MK.c	2020-04-10 12:32:13.582783743 +0200
++++ PE.c	2020-04-10 12:32:36.633038633 +0200
+@@ -1,19 +1,19 @@
+ #include <stdio.h>
+ 
+-#include <measurement_kit/ffi.h>
++#include <ooniffi.h>
+ 
+ void run(const char *settings) {
+-    mk_task_t *task = mk_task_start(settings);
++    ooniffi_task_t *task = ooniffi_task_start(settings);
+     if (task == NULL) {
+         return;
+     }
+-    while (!mk_task_is_done(task)) {
+-        mk_event_t *event = mk_task_wait_for_next_event(task);
++    while (!ooniffi_task_is_done(task)) {
++        ooniffi_event_t *event = ooniffi_task_wait_for_next_event(task);
+         if (event == NULL) {
+             continue;
+         }
+-        printf("%s\n", mk_event_serialization(event));
+-        mk_event_destroy(event);
++        printf("%s\n", ooniffi_event_serialization(event));
++        ooniffi_event_destroy(event);
+     }
+-    mk_task_destroy(task);
++    ooniffi_task_destroy(task);
+ }
+```
+
+We are not going to reimplement other APIs provided by Measurement Kit
+and most of them were private anyway. We are not going to automatically
+publish libooniffi builds. You can generate your own builds with:
+
+```bash
+# macOS from macOS or Linux from Linux
+go build -v -tags nomk -ldflags='-s -w' -buildmode c-shared -o libooniffi.so ./libooniffi
+# Windows from Linux or macOS with mingw-w64 installed
+export CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc
+go build -v -tags nomk -ldflags='-s -w' -buildmode c-shared -o libooniffi.dll ./libooniffi
+```
+
+Remember also to grab the corresponding header `./libooniffi/ooniffi.h`. Do
+not use the autogenerated `./libooniffi.h` since it's incomplete.
+
+Let us know if you want us to automatically publish `libooniffi` binaries
+at every commit and/or at every release.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 As of 2020-03-15, Measurement Kit is deprecated. This date has been chosen
 arbitrarily such that we could write:
 
-> Friends, OONItarians, developers, lend me your ears;
-> I come to bury Measurement Kit, not to praise it.
-> The bugs that software have live after them;
-> The good is oft interred with their remote branches;
+    Friends, OONItarians, developers, lend me your ears;
+    I come to bury Measurement Kit, not to praise it.
+    The bugs that software have live after them;
+    The good is oft interred with their remote branches;
 
 The rewrite of Measurement Kit in Go has been going on for quite some time now
 as [ooni/probe-engine](https://github.com/ooni/probe-engine). As part of this

--- a/README.md
+++ b/README.md
@@ -24,6 +24,40 @@ designed is troubling you by opening an issue in this repository.
 
 The content of the old README.md is still available as [OREADME.md](OREADME.md).
 
+## Changes in the settings JSON
+
+The ooni/probe-engine implementation exposes similar APIs to Measurement Kit
+and specifically honours the [data format of Measurement Kit v0.10.11](
+https://github.com/measurement-kit/measurement-kit/tree/v0.10.11/include/measurement_kit).
+
+There should be no differences in the emitted events. There are however some
+differences in the settings as discussed below.
+
+You should now add the following the settings JSON:
+
+```JSON
+{
+  "assets_dir": "",
+  "state_dir": "",
+  "temp_dir": ""
+}
+```
+
+where `assets_dir` is the directory where to store assets, e.g.
+GeoIP databases; `state_dir` is the directory where to store the
+authentication information used with OONI orchestra; `temp_dir`
+is the directory where to store temporary files. If these three
+keys are not present, the test will fail during the startup
+phase (i.e. it will not throw, but rather you will see a very
+short test with explanatory errors in the logs).
+
+Also, the Go code does recognize all the settings recognized by
+Measurement Kit, but some unfrequently used settings are not implemented
+yet. If are by chance using settings that it does not implement, it
+will also fail during the startup phase and tell you with log
+messages. If a not implemented setting is causing you issues, let us
+know by opening a bug in this repository.
+
 ## Android
 
 In your `app/build.gradle` file, replace
@@ -61,30 +95,8 @@ following diff shows how you should be upgrading your code:
 
 The most striking difference is that the function to start a task
 will explicitly throw `Exception` on failure, where the old code
-would instead throw `RuntimeException`. The definition of settings
-and events has only slightly changed from Measurement Kit. In
-particular, you should now add the following the settings JSON:
-
-```JSON
-{
-  "assets_dir": "",
-  "state_dir": "",
-  "temp_dir": ""
-}
-```
-
-where `assets_dir` is the directory where to store assets, e.g.
-GeoIP databases; `state_dir` is the directory where to store the
-authentication information used with OONI orchestra; `temp_dir`
-is the directory where to store temporary files. If these three
-keys are not present, the test will fail during the startup
-phase (i.e. it will not throw, but rather you will see a very
-short test with explanatory errors in the logs). The new code does
-recognize all the settings recognized by the old code, but some
-unfrequently used settings are not implemented yet. If are by chance
-using settings that it does not implement, it will also fail during
-the startup phase and tell you with log messages. If a not implemented
-setting is causing you issues, let us know.
+would instead throw `RuntimeException`. The definition of settings has
+only slightly changed from Measurement Kit, as discussed above.
 
 We currently do not provide drop-in replacements for other functionality
 implemented by measurement-kit/android-libs, e.g., accessing the GeoIP
@@ -140,11 +152,8 @@ following diff should how you should be upgrading your code:
 The most striking differences are the following. First, the function
 that starts a measurement task now fails explicitly (e.g., if the settings
 are not valid JSON). Second, the new code takes in input and emits in
-output serialized JSONs rather than `NSDictionary *`. Also, the same
-caveats described in the Android section apply: you need to add three
-extra keys into the JSON and some unfrequently used settings may not work
-anymore. If that happens, the logs should help you understand the issue. If
-a not implemented setting is causing you issues, let us know.
+output serialized JSONs rather than `NSDictionary *`. The definition of
+settings has only slighly changed from MK, as described above.
 
 We currently do not provide drop-in replacements for other functionality
 implemented by measurement-kit/mkall-ios, e.g., accessing the GeoIP


### PR DESCRIPTION
Part of https://github.com/measurement-kit/measurement-kit/issues/1921. Subject to changes as we further our understanding of how to smooth our transition. Main paint point seems to be iOS, for which we have not done basically any work yet (except we know we can build a framework).