### PR TITLE
configure.ac: link with iphlpapi required by libevent >= 2.1.12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,8 @@ AC_PROG_INSTALL
 
 case "$host" in
   *-w64-mingw32)
-    # Must link with ws2_32
-    LIBS="$LIBS -lws2_32"
+    # Must link with ws2_32 and iphlpapi for if_nametoindex (since libevent 2.1.12)
+    LIBS="$LIBS -lws2_32 -liphlpapi"
     # Required to expose inet_pton()
     CPPFLAGS="$CPPFLAGS -D_WIN32_WINNT=0x0600 -D_POSIX_C_SOURCE"
   ;;


### PR DESCRIPTION
Libevent >= 2.1.12 is using if_nametoindex. This function is part of
the iphlpapi library. So we need to link to it.

See also https://github.com/measurement-kit/homebrew-measurement-kit/commit/2d94c2eb4cc26deb46d0b6578efd737932422d70