### PR TITLE
all: use ams-pg.ooni.org as testing probe service

### DIFF
--- a/include/measurement_kit/nettests.hpp
+++ b/include/measurement_kit/nettests.hpp
@@ -394,9 +394,9 @@ class MK_NETTESTS_DEPRECATED BaseTest {
             doc["speed"] = {speed_kbps, "kbit/s"};
             // Serializing may throw but we expect MK to pass us a good
             // JSON so don't consider this possible error condition.
-            const char *s = doc.dump().c_str();
+            auto s = doc.dump();
             for (auto &cb : tip->event_cbs) {
-                MK_NETTESTS_CALL_AND_SUPPRESS(cb, (s));
+                MK_NETTESTS_CALL_AND_SUPPRESS(cb, (s.c_str()));
             }
         } else if (key == "status.update.websites") {
             // NOTHING

--- a/script/autoapi/autoapi
+++ b/script/autoapi/autoapi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ Automatically generate API headers from a specification of the JSON
     messsages that are part of Measurement Kit's FFI API. """

--- a/script/autoapi/autoapi
+++ b/script/autoapi/autoapi
@@ -176,7 +176,7 @@ def main():
     options = [Attribute("std::string", "address"),
                Attribute("bool", "all_endpoints", "false"),
                Attribute("std::string", "backend"),
-               Attribute("std::string", "bouncer_base_url", json.dumps("https://bouncer.ooni.io")),
+               Attribute("std::string", "bouncer_base_url", json.dumps("https://ps1.ooni.io")),
                Attribute("std::string", "collector_base_url"),
                Attribute("int64_t", "constant_bitrate", "0"),
                Attribute("std::string", "dns/nameserver"),

--- a/script/autoapi/nettests.hpp.j2
+++ b/script/autoapi/nettests.hpp.j2
@@ -394,9 +394,9 @@ class MK_NETTESTS_DEPRECATED BaseTest {
             doc["speed"] = {speed_kbps, "kbit/s"};
             // Serializing may throw but we expect MK to pass us a good
             // JSON so don't consider this possible error condition.
-            const char *s = doc.dump().c_str();
+            auto s = doc.dump();
             for (auto &cb : tip->event_cbs) {
-                MK_NETTESTS_CALL_AND_SUPPRESS(cb, (s));
+                MK_NETTESTS_CALL_AND_SUPPRESS(cb, (s.c_str()));
             }
         } else if (key == "status.update.websites") {
             // NOTHING

--- a/src/libmeasurement_kit/ooni/bouncer.hpp
+++ b/src/libmeasurement_kit/ooni/bouncer.hpp
@@ -39,7 +39,7 @@ void post_net_tests(std::string base_bouncer_url, std::string test_name,
                     SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
 #define MK_OONI_PRODUCTION_BOUNCER_URL "https://ps1.ooni.io"
-#define MK_OONI_TESTING_BOUNCER_URL "https://ps-test.ooni.io"
+#define MK_OONI_TESTING_BOUNCER_URL "https://ams-pg.ooni.org"
 
 std::string production_bouncer_url();
 std::string testing_bouncer_url();

--- a/src/libmeasurement_kit/ooni/bouncer.hpp
+++ b/src/libmeasurement_kit/ooni/bouncer.hpp
@@ -38,7 +38,7 @@ void post_net_tests(std::string base_bouncer_url, std::string test_name,
                     Callback<Error, SharedPtr<BouncerReply>> cb, Settings settings,
                     SharedPtr<Reactor> reactor, SharedPtr<Logger> logger);
 
-#define MK_OONI_PRODUCTION_BOUNCER_URL "https://bouncer.ooni.io"
+#define MK_OONI_PRODUCTION_BOUNCER_URL "https://ps1.ooni.io"
 #define MK_OONI_TESTING_BOUNCER_URL "https://ps-test.ooni.io"
 
 std::string production_bouncer_url();

--- a/src/libmeasurement_kit/ooni/collector_client.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client.hpp
@@ -16,7 +16,7 @@ namespace collector {
 */
 
 #define MK_OONI_PRODUCTION_COLLECTOR_URL "https://ps1.ooni.io"
-#define MK_OONI_TESTING_COLLECTOR_URL "https://ps-test.ooni.io"
+#define MK_OONI_TESTING_COLLECTOR_URL "https://ams-pg.ooni.org"
 
 std::string production_collector_url();
 std::string testing_collector_url();

--- a/src/libmeasurement_kit/ooni/collector_client.hpp
+++ b/src/libmeasurement_kit/ooni/collector_client.hpp
@@ -15,7 +15,7 @@ namespace collector {
     the library uses the `production` collector.
 */
 
-#define MK_OONI_PRODUCTION_COLLECTOR_URL "https://b.collector.ooni.io"
+#define MK_OONI_PRODUCTION_COLLECTOR_URL "https://ps1.ooni.io"
 #define MK_OONI_TESTING_COLLECTOR_URL "https://ps-test.ooni.io"
 
 std::string production_collector_url();

--- a/src/libmeasurement_kit/ooni/facebook_messenger.cpp
+++ b/src/libmeasurement_kit/ooni/facebook_messenger.cpp
@@ -191,7 +191,7 @@ tcp_many(Error error, SharedPtr<nlohmann::json> entry,
         std::string service = service_and_ips.first;
         // if ANY ips for this service are in FB's ASN, switch to true
         (*entry)["facebook_" + service + "_dns_consistent"] = false;
-        for (auto const ip : service_and_ips.second) {
+        for (auto const &ip : service_and_ips.second) {
             bool this_ip_consistent = ip_in_fb_asn(options, ip);
             if (this_ip_consistent) {
                 logger->info("%s is in FB's ASN", ip.c_str());

--- a/src/libmeasurement_kit/ooni/orchestrate.hpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.hpp
@@ -21,10 +21,10 @@ namespace orchestrate {
  */
 
 #define MK_OONI_PRODUCTION_PROTEUS_REGISTRY_URL                                \
-    "https://registry.ooni.io"
+    "https://ps1.ooni.io"
 #define MK_OONI_TESTING_PROTEUS_REGISTRY_URL                                   \
     "https://ps-test.ooni.io"
-#define MK_OONI_PRODUCTION_PROTEUS_EVENTS_URL "https://orchestrate.ooni.io"
+#define MK_OONI_PRODUCTION_PROTEUS_EVENTS_URL "https://ps1.ooni.io"
 #define MK_OONI_TESTING_PROTEUS_EVENTS_URL "https://ps-test.ooni.io"
 
 std::string production_registry_url();

--- a/src/libmeasurement_kit/ooni/orchestrate.hpp
+++ b/src/libmeasurement_kit/ooni/orchestrate.hpp
@@ -23,9 +23,9 @@ namespace orchestrate {
 #define MK_OONI_PRODUCTION_PROTEUS_REGISTRY_URL                                \
     "https://ps1.ooni.io"
 #define MK_OONI_TESTING_PROTEUS_REGISTRY_URL                                   \
-    "https://ps-test.ooni.io"
+    "https://ams-pg.ooni.org"
 #define MK_OONI_PRODUCTION_PROTEUS_EVENTS_URL "https://ps1.ooni.io"
-#define MK_OONI_TESTING_PROTEUS_EVENTS_URL "https://ps-test.ooni.io"
+#define MK_OONI_TESTING_PROTEUS_EVENTS_URL "https://ams-pg.ooni.org"
 
 std::string production_registry_url();
 std::string testing_registry_url();

--- a/test/http/request.cpp
+++ b/test/http/request.cpp
@@ -162,7 +162,7 @@ TEST_CASE("http::request() works as expected over Tor") {
     reactor->run_with_initial_event([=]() {
         request(
             {
-                {"http/url", "http://ps-test.ooni.io/"},
+                {"http/url", "http://ams-pg.ooni.org/"},
                 {"http/method", "GET"},
                 {"http/http_version", "HTTP/1.1"},
                 {"Connection", "close"},

--- a/test/mkapi/orchestra.cpp
+++ b/test/mkapi/orchestra.cpp
@@ -25,7 +25,7 @@ TEST_CASE("mkapi_orchestra_client works") {
   mkapi_orchestra_client_set_probe_family(client.get(), "xxx-zzz");
   mkapi_orchestra_client_set_probe_timezone(client.get(), "Europe/Rome");
   mkapi_orchestra_client_set_registry_url(
-      client.get(), "https://ps-test.ooni.io");
+      client.get(), "https://ams-pg.ooni.org");
   mkapi_orchestra_client_set_secrets_file(client.get(), ".orchestra.json");
   mkapi_orchestra_client_set_software_name(client.get(), "dummy");
   mkapi_orchestra_client_set_software_version(client.get(), "0.1.0");

--- a/test/nettests/utils.hpp
+++ b/test/nettests/utils.hpp
@@ -32,7 +32,7 @@ template <typename T> void with_test(with_test_cb &&lambda) {
                 .set_option("net/ca_bundle_path", "cacert.pem")
                 .set_verbosity(MK_LOG_INFO)
                 .set_option("collector_base_url",
-                            "https://ps-test.ooni.io")
+                            "https://ams-pg.ooni.org")
                 .set_option("bouncer_base_url",
                              mk::ooni::bouncer::production_bouncer_url()));
     /*
@@ -57,7 +57,7 @@ with_runnable(std::function<void(mk::nettests::Runnable &)> lambda) {
     mk::nettests::Runnable test;
     test.annotations["continuous_integration"] = "true";
     test.options["net/ca_bundle_path"] = "cacert.pem";
-    test.options["collector_base_url"] = "https://ps-test.ooni.io";
+    test.options["collector_base_url"] = "https://ams-pg.ooni.org";
     test.options["bouncer_base_url"] =
           mk::ooni::bouncer::production_bouncer_url();
     /*


### PR DESCRIPTION
As indicated at https://github.com/ooni/sysadmin/pull/452, we wanna use ams-pg.ooni.org as our testing probe service for some time while ps-test.ooni.io is down and while we are working to refactor APIs at ams-pg.ooni.org.